### PR TITLE
Fixes sleeping incapacitation runtime, minor code cleanup while I'm here

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -81,41 +81,36 @@
 	id = "sleeping"
 	alert_type = /atom/movable/screen/alert/status_effect/asleep
 	needs_update_stat = TRUE
-	var/mob/living/carbon/carbon_owner
-	var/mob/living/carbon/human/human_owner
 	var/sleptonground = FALSE
 
 /datum/status_effect/incapacitating/sleeping/on_creation(mob/living/new_owner, updating_canmove)
 	. = ..()
-	if(.)
-		if(owner.cmode)
-			owner.cmode = 0
-		SSdroning.kill_droning(owner.client)
-		SSdroning.kill_loop(owner.client)
-		SSdroning.kill_rain(owner.client)
-		owner.set_typing_indicator(FALSE)
-		if(iscarbon(owner)) //to avoid repeated istypes
-			carbon_owner = owner
-		if(ishuman(owner))
-			human_owner = owner
+	if(!.)
+		return
+
+	owner.cmode = FALSE
+	SSdroning.kill_droning(owner.client)
+	SSdroning.kill_loop(owner.client)
+	SSdroning.kill_rain(owner.client)
+	owner.set_typing_indicator(FALSE)
 
 /datum/status_effect/incapacitating/sleeping/on_remove()
-	if(human_owner && human_owner.client)
-		SSdroning.play_area_sound(get_area(src), human_owner.client)
-		SSdroning.play_loop(get_area(src), human_owner.client)
-	if(sleptonground)
+	var/area/this_area = get_area(owner)
+	SSdroning.play_area_sound(this_area, owner.client)
+	SSdroning.play_loop(this_area, owner.client)
+
+	if(ishuman(owner) && sleptonground)
+		var/mob/living/carbon/human/human_owner = owner
 		if(HAS_TRAIT(human_owner, TRAIT_NOBLE))
 			human_owner.add_stress(/datum/stressevent/sleepfloornoble)
 		else
 			human_owner.add_stress(/datum/stressevent/sleepfloor)
 	. = ..()
 
-/datum/status_effect/incapacitating/sleeping/Destroy()
-	carbon_owner = null
-	human_owner = null
-	return ..()
-
 /datum/status_effect/incapacitating/sleeping/tick()
+	var/mob/living/carbon/carbon_owner = iscarbon(owner) ? owner : null
+	var/mob/living/carbon/human/human_owner = ishuman(owner) ? owner : null
+
 	if(owner.maxHealth)
 		var/health_ratio = owner.health / owner.maxHealth
 		var/healing = -0.2
@@ -123,6 +118,8 @@
 			healing -= 0.3
 		else if((locate(/obj/structure/table) in owner.loc))
 			healing -= 0.1
+		else //we're sleeping on the damn floor!!
+			sleptonground = TRUE
 		if(locate(/obj/structure/bed/rogue/sleepingbag) in owner.loc)
 			sleptonground = TRUE
 		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
@@ -134,11 +131,10 @@
 			owner.adjustBruteLoss(healing)
 			owner.adjustFireLoss(healing)
 			owner.adjustToxLoss(healing * 0.5, FALSE, TRUE)
-	if(human_owner && human_owner.drunkenness)
-		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
+
+	human_owner?.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))
-		if(carbon_owner)
-			carbon_owner.handle_dreams()
+		carbon_owner?.handle_dreams()
 		if(prob(10) && owner.health > owner.crit_threshold)
 			owner.emote("snore")
 


### PR DESCRIPTION
## About The Pull Request

`/datum/status_effect/incapacitating/sleeping` had a logic error which made it clear owner variables before running `on_remove()`, causing a runtime. This fixes that runtime while also doing minor code cleanup while I was looking at it

## Why It's Good For The Game

![GgHGtn2bYAQ2On8](https://github.com/user-attachments/assets/8918b89b-2933-4dec-9ea4-094eec2a7991)