### PR TITLE
Adds progressive psydonite patron

### DIFF
--- a/code/datums/gods/patrons/forgotten.dm
+++ b/code/datums/gods/patrons/forgotten.dm
@@ -1,7 +1,7 @@
 /datum/patron/psydon
 	name = "Psydon"
 	domain = "God of Humenity, Dreams and Creation"
-	desc = "Deceased, slain by Necra in His final moments. She ripped His body apart to create The Ten... but He's still out there somewhere, right?"
+	desc = "Deceased, slain by Necra in His final moments. She ripped His body apart to create The Ten... but He'll return when the Ten are gone, right?"
 	flaws = "Grudge-Holding, Judgemental, Self-Sacrificing"
 	worshippers = "Grenzelhofters, Inquisitors, Heroes"
 	sins = "Apostasy, Demon Worship, Betraying thy Father"
@@ -20,3 +20,14 @@
 
 	to_chat(follower, span_danger("I can not talk to Him... I need His cross on my neck!"))
 	return FALSE
+
+/datum/patron/psydon/progressive
+	name = "Progressive Psydon"
+	desc = "Necra divided His body apart in an act of mercy to create The Ten, and as inheritors of His will it's only natural that they take over His position, right?"
+	flaws = "Fatalistic, Sentimental, Acquiescent"
+	worshippers = "Idealistic Dreamers, Optimists, Diplomats"
+	confess_lines = list(
+		"PSYDON AND THE TEN ARE THE RIGHTFUL GODS!",
+		"MAY THE SUCCESSORS CARRY ON HIS LEGACY!",
+		"PSYDON LIVES THROUGH THE TEN!",
+	)

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
@@ -20,6 +20,9 @@
 		if(/datum/patron/psydon)
 			head = /obj/item/clothing/head/helmet/heavy/bucket/gold
 			wrists = /obj/item/clothing/neck/psycross/g
+		if(/datum/patron/psydon/progressive)
+			head = /obj/item/clothing/head/helmet/heavy/bucket/gold
+			wrists = /obj/item/clothing/neck/psycross/g
 		if(/datum/patron/divine/astrata)
 			head = /obj/item/clothing/head/helmet/heavy/necked/astrata
 			wrists = /obj/item/clothing/neck/psycross/silver/astrata


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
- Adds a progressive patron for the Psydon patheon, which interprets the Ten as being Psydon rather than actively preventing his return. Functions identically except for role checks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
For all the fake psydonites out there.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
