### PR TITLE
Rosewood town dungeon entrances are exit-only

### DIFF
--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -5470,7 +5470,10 @@
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town/clocktower)
 "cXA" = (
-/obj/structure/dungeon_entry/center,
+/obj/structure/dungeon_entry/center{
+	can_enter = 0;
+	icon_state = "portal_noenter"
+	},
 /turf/open/floor/snow,
 /area/rogue/outdoors/mountains)
 "cXO" = (
@@ -8006,7 +8009,10 @@
 /turf/open/floor/metal/barograte,
 /area/rogue/under/town/sewer)
 "evT" = (
-/obj/structure/dungeon_entry/center,
+/obj/structure/dungeon_entry/center{
+	can_enter = 0;
+	icon_state = "portal_noenter"
+	},
 /turf/open/floor/cobble,
 /area/rogue/under/cavewet)
 "evU" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Both of the dungeon entrances in Rosewood proper are now exit-only.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
No one escapes my wrath.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
