### PR TITLE
Map votes now check to see if a given map is votable

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -223,7 +223,7 @@ SUBSYSTEM_DEF(vote)
 			if("map")
 				for(var/map in config.maplist)
 					var/datum/map_config/VM = config.maplist[map]
-					if(!VM.votable())
+					if(!VM.available_for_vote())
 						continue
 					choices.Add(VM.map_name)
 			if("custom")

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -152,7 +152,7 @@
 	return config_filename == "data/next_map.json" || fcopy(config_filename, "data/next_map.json")
 
 /// Checks config parameters to see if this map can be voted for. Returns TRUE or FALSE accordingly.
-/datum/map_config/proc/votable()
+/datum/map_config/proc/available_for_vote()
 	if(!votable)
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Map votes currently do not take any part of the configuration into account, aside from if the given map was disabled. This is bad because certain maps need certain conditions to run. This PR implements a `votable()` proc to remedy this issue.

## Why It's Good For The Game

Letting people vote for 80+ pop maps at 50 pop is not very good.