### PR TITLE
Fix Noc acolyte blindness miracle not working

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -48,7 +48,7 @@
 	added_traits = list(TRAIT_TUTELAGE)
 	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	t1 = /obj/effect/proc_holder/spell/invoked/invisibility
-	t2 = /obj/effect/proc_holder/spell/invoked/blindness
+	t2 = /obj/effect/proc_holder/spell/invoked/blindness/miracle
 	t3 = /obj/effect/proc_holder/spell/invoked/projectile/moondagger
 	confess_lines = list(
 		"NOC IS NIGHT!",

--- a/code/modules/spells/spell_types/blindness.dm
+++ b/code/modules/spells/spell_types/blindness.dm
@@ -22,7 +22,7 @@
 		var/mob/living/target = targets[1]
 		if(target.anti_magic_check(TRUE, TRUE))
 			return FALSE
-		target.visible_message("<span class='warning'>[user] points at [target]'s eyes!</span>","<span class='warning'>My eyes are covered in darkness!</span>")
+		user.visible_message(span_warning("[user] points at [target]'s eyes!"), span_warning("My eyes are covered in darkness!"))
 		target.blind_eyes(3)
 		return ..()
 	return FALSE

--- a/code/modules/spells/spell_types/blindness.dm
+++ b/code/modules/spells/spell_types/blindness.dm
@@ -12,6 +12,10 @@
 	invocation_type = "none"
 	antimagic_allowed = TRUE
 	recharge_time = 2 MINUTES
+	associated_skill = /datum/skill/magic/arcane
+	attunements = list(
+		/datum/attunement/arcyne = 0.1
+		)
 
 /obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/blindness.dm
+++ b/code/modules/spells/spell_types/blindness.dm
@@ -1,0 +1,13 @@
+/obj/effect/proc_holder/spell/invoked/blindness
+	name = "Blindness"
+	overlay_state = "blindness"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	range = 7
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
+	sound = 'sound/magic/churn.ogg'
+	invocation_type = "none"
+	antimagic_allowed = TRUE
+	recharge_time = 2 MINUTES

--- a/code/modules/spells/spell_types/blindness.dm
+++ b/code/modules/spells/spell_types/blindness.dm
@@ -1,5 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/blindness
 	name = "Blindness"
+	desc = "Point at a target to blind them for few seconds."
 	overlay_state = "blindness"
 	releasedrain = 30
 	chargedrain = 0
@@ -11,3 +12,13 @@
 	invocation_type = "none"
 	antimagic_allowed = TRUE
 	recharge_time = 2 MINUTES
+
+/obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		target.visible_message("<span class='warning'>[user] points at [target]'s eyes!</span>","<span class='warning'>My eyes are covered in darkness!</span>")
+		target.blind_eyes(3)
+		return ..()
+	return FALSE

--- a/code/modules/spells/spell_types/invoked/acolyte/noc.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/noc.dm
@@ -17,16 +17,6 @@
 	miracle = TRUE
 	devotion_cost = 30
 
-/obj/effect/proc_holder/spell/invoked/blindness/miracle/cast(list/targets, mob/user = usr)
-	if(isliving(targets[1]))
-		var/mob/living/target = targets[1]
-		if(target.anti_magic_check(TRUE, TRUE))
-			return FALSE
-		target.visible_message("<span class='warning'>[user] points at [target]'s eyes!</span>","<span class='warning'>My eyes are covered in darkness!</span>")
-		target.blind_eyes(3)
-		return ..()
-	return FALSE
-
 /obj/effect/proc_holder/spell/invoked/invisibility
 	name = "Invisibility"
 	overlay_state = "invisibility"

--- a/code/modules/spells/spell_types/invoked/acolyte/noc.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/noc.dm
@@ -1,19 +1,11 @@
-/obj/effect/proc_holder/spell/invoked/blindness
+/obj/effect/proc_holder/spell/invoked/blindness/miracle
 	name = "Blindness"
 	overlay_state = "blindness"
-	releasedrain = 30
-	chargedrain = 0
-	chargetime = 0
-	range = 7
-	warnie = "sydwarning"
-	movement_interrupt = FALSE
-	sound = 'sound/magic/churn.ogg'
 	req_items = list(/obj/item/clothing/neck/psycross/noc)
 	invocation = "Noc blinds thee of thy sins!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	associated_skill = /datum/skill/magic/holy
-	antimagic_allowed = TRUE
-	recharge_time = 2 MINUTES
+	miracle = TRUE
 	devotion_cost = 30
 
 /obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)

--- a/code/modules/spells/spell_types/invoked/acolyte/noc.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/noc.dm
@@ -1,9 +1,17 @@
 /obj/effect/proc_holder/spell/invoked/blindness/miracle
 	name = "Blindness"
 	overlay_state = "blindness"
+	releasedrain = 30
+	chargedrain = 0
+	chargetime = 0
+	range = 7
+	warnie = "sydwarning"
+	movement_interrupt = FALSE
 	req_items = list(/obj/item/clothing/neck/psycross/noc)
 	invocation = "Noc blinds thee of thy sins!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
+	antimagic_allowed = TRUE
+	recharge_time = 2 MINUTES
 	associated_skill = /datum/skill/magic/holy
 	miracle = TRUE
 	devotion_cost = 30

--- a/code/modules/spells/spell_types/invoked/acolyte/noc.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/noc.dm
@@ -16,7 +16,7 @@
 	miracle = TRUE
 	devotion_cost = 30
 
-/obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/invoked/blindness/miracle/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
 		if(target.anti_magic_check(TRUE, TRUE))

--- a/code/modules/spells/spell_types/invoked/acolyte/noc.dm
+++ b/code/modules/spells/spell_types/invoked/acolyte/noc.dm
@@ -7,6 +7,7 @@
 	range = 7
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
+	sound = 'sound/magic/churn.ogg'
 	req_items = list(/obj/item/clothing/neck/psycross/noc)
 	invocation = "Noc blinds thee of thy sins!"
 	invocation_type = "shout" //can be none, whisper, emote and shout

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -2312,6 +2312,7 @@
 #include "code\modules\spatial_grid\cell_tracking.dm"
 #include "code\modules\spells\spell.dm"
 #include "code\modules\spells\spell_types\aimed.dm"
+#include "code\modules\spells\spell_types\blindness.dm"
 #include "code\modules\spells\spell_types\conjure.dm"
 #include "code\modules\spells\spell_types\ethereal_jaunt.dm"
 #include "code\modules\spells\spell_types\godhand.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
1. Fixes Noc acolytes being unable to cast the miracle they get.
2. Detaches the files for the blindness miracle and the blindness spell, which is still used in scrolls for mapping and adminbus purposes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
Fixes a bug where the first miracle Noc acolytes unlock does nothing.
fixes #1895 
Using two separate files may improve maintainability, as they use different resources, and are obtained in different ways.

#### More information + changes needed:
Testing wise I checked both function, cooldown and resource cost of both the miracle and the spell, I can't confirm whether the mana drain of 30 works correctly for spell version since I do not know how to exactly check mana of a mob in-game.

Also "code/modules/spells/spell_types/blindness.dm" might not be the perfect path to put the spell version in.

I'd like to ask someone who's more knowledgeable in magic/lore matters on what the two values below should be:

```
	associated_skill = /datum/skill/magic/arcane
	attunements = list(
		/datum/attunement/arcyne = 0.1
		)
```

and on what the cooldown on the spell version should be since 2 minutes is huge and is definitely well balanced for an acolyte, not so much for a mage.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ :white_check_mark: ] You tested this on a local server.
- [ :white_check_mark: ] This code did not runtime during testing.
- [ :white_check_mark: ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
