### PR TITLE
thenerfsgohard

### DIFF
--- a/code/controllers/subsystem/migration.dm
+++ b/code/controllers/subsystem/migration.dm
@@ -4,12 +4,12 @@ SUBSYSTEM_DEF(migrants)
 	runlevels = RUNLEVEL_GAME
 	var/wave_number = 1
 	var/current_wave = null
-	var/time_until_next_wave = 2 MINUTES
+	var/time_until_next_wave = 30 MINUTES
 	var/wave_timer = 0
 
-	var/time_between_waves = 3 MINUTES
-	var/time_between_fail_wave = 90 SECONDS
-	var/wave_wait_time = 30 SECONDS
+	var/time_between_waves = 15 MINUTES
+	var/time_between_fail_wave = 10 MINUTES
+	var/wave_wait_time = 60 SECONDS
 
 	var/list/spawned_waves = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
extends the time until the first migration wave starts to 30 minutes
upon successful migration wave, there will be a 15 minute cooldown instead of 3 minute
upon fail, there will be a 10 minute cooldown instead of 90
players will have 60 seconds to get in the migrant wave instead of 30 seconds

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Migration rollers have had it good for too long.

This will encourage players to play the game instead of sit in lobby by directly hindering migrant rolling. Migrants are supposed to be rare, not an uncommon sighting in rounds.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
