### PR TITLE
Nukes Youngling Stats

### DIFF
--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -85,8 +85,6 @@
 				set_stat_modifier("innate_age", STATKEY_CON, -2)
 				set_stat_modifier("innate_age", STATKEY_PER, -1)
 				set_stat_modifier("innate_age", STATKEY_END, -2)
-				set_stat_modifier("innate_age", STATKEY_LCK, -1)
-				set_stat_modifier("innate_age", STATKEY_SPD, round(rand(-1,-2)))
 			// nothing for adults/immortals,
 			if(AGE_MIDDLEAGED)
 				set_stat_modifier("innate_age", STATKEY_END, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

[Destroy the child.](https://youtu.be/lBbQg8r8tdc)

![welcome to hell](https://github.com/user-attachments/assets/bd33c230-ffe2-4084-bce3-2aa52b78419f)

EDIT: Statspread changed:
STR from -4 to -3
CON from -3 to -2
END from -3 to -2
Fortune and Speed now have no +'s or -'s. Net neutral.

## Why It's Good For The Game

Requested by ook. Younglings are meant to be fragile and have bad stats, similar/on-par with kobolds. I'm sorry little one.


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
