### PR TITLE
Masochist update and rebalance + redundant flaw removal

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -499,7 +499,9 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	var/current_pain = user.get_complex_pain()
 	// Bloodloss makes the pain count as extra large to allow people to bloodlet themselves with cutting weapons to satisfy vice
 	var/bloodloss_factor = clamp(1.0 - (user.blood_volume / BLOOD_VOLUME_NORMAL), 0.0, 0.5)
-	var/new_pain_threshold = get_pain_threshold(current_pain * (1.0 + (bloodloss_factor * 1.4) * (user.STAEND / 10))) // Bloodloss factor goes up to 50%, and then counts at 140% value of that
+	var/new_pain_threshold = get_pain_threshold(current_pain * (1.0 + (bloodloss_factor * 1.4)) * clamp(2 - (user.STAEND / 10), 0.5, 1.5)) // Bloodloss factor goes up to 50%, and then counts at 140% value of that
+	to_chat(world, "PT: [new_pain_threshold] NewPain: [current_pain * (1.0 + (bloodloss_factor * 1.4)) * clamp(2 - (user.STAEND / 10), 0.5, 1.5)] CP: [current_pain] BL: [1.0 + (bloodloss_factor * 1.4)] EM: [clamp(2 - (user.STAEND / 10), 0.5, 1.5)]")
+
 	if(last_pain_threshold == NONE)
 		to_chat(user, span_boldwarning("I could really use some pain right now..."))
 	else if (new_pain_threshold != last_pain_threshold)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Isolationist"=/datum/charflaw/isolationist,
 	"Fire Servant"=/datum/charflaw/addiction/pyromaniac,
 	"Thief-Borne"=/datum/charflaw/addiction/kleptomaniac,
-	"Pain Freek"=/datum/charflaw/addiction/masochist,
 	"Hunted"=/datum/charflaw/hunted,
 	"Random Flaw or No Flaw"=/datum/charflaw/randflaw,
 	"Guaranteed No Flaw (3 TRI)"=/datum/charflaw/noflaw,))
@@ -500,7 +499,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	var/current_pain = user.get_complex_pain()
 	// Bloodloss makes the pain count as extra large to allow people to bloodlet themselves with cutting weapons to satisfy vice
 	var/bloodloss_factor = clamp(1.0 - (user.blood_volume / BLOOD_VOLUME_NORMAL), 0.0, 0.5)
-	var/new_pain_threshold = get_pain_threshold(current_pain * (1.0 + (bloodloss_factor * 1.4))) // Bloodloss factor goes up to 50%, and then counts at 140% value of that
+	var/new_pain_threshold = get_pain_threshold(current_pain * (1.0 + (bloodloss_factor * 1.4) * (user.STAEND / 10))) // Bloodloss factor goes up to 50%, and then counts at 140% value of that
 	if(last_pain_threshold == NONE)
 		to_chat(user, span_boldwarning("I could really use some pain right now..."))
 	else if (new_pain_threshold != last_pain_threshold)
@@ -526,13 +525,13 @@ GLOBAL_LIST_INIT(character_flaws, list(
 
 /datum/charflaw/masochist/proc/get_pain_threshold(pain_amt)
 	switch(pain_amt)
-		if(-INFINITY to 50)
+		if(-INFINITY to 25)
 			return MASO_THRESHOLD_ONE
-		if(50 to 95)
+		if(25 to 50)
 			return MASO_THRESHOLD_TWO
-		if(95 to 140)
+		if(50 to 95)
 			return MASO_THRESHOLD_THREE
-		if(140 to INFINITY)
+		if(95 to INFINITY)
 			return MASO_THRESHOLD_FOUR
 
 /proc/get_mammons_in_atom(atom/movable/movable)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -500,8 +500,6 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	// Bloodloss makes the pain count as extra large to allow people to bloodlet themselves with cutting weapons to satisfy vice
 	var/bloodloss_factor = clamp(1.0 - (user.blood_volume / BLOOD_VOLUME_NORMAL), 0.0, 0.5)
 	var/new_pain_threshold = get_pain_threshold(current_pain * (1.0 + (bloodloss_factor * 1.4)) * clamp(2 - (user.STAEND / 10), 0.5, 1.5)) // Bloodloss factor goes up to 50%, and then counts at 140% value of that
-	to_chat(world, "PT: [new_pain_threshold] NewPain: [current_pain * (1.0 + (bloodloss_factor * 1.4)) * clamp(2 - (user.STAEND / 10), 0.5, 1.5)] CP: [current_pain] BL: [1.0 + (bloodloss_factor * 1.4)] EM: [clamp(2 - (user.STAEND / 10), 0.5, 1.5)]")
-
 	if(last_pain_threshold == NONE)
 		to_chat(user, span_boldwarning("I could really use some pain right now..."))
 	else if (new_pain_threshold != last_pain_threshold)

--- a/code/datums/character_flaw/addiction.dm
+++ b/code/datums/character_flaw/addiction.dm
@@ -110,14 +110,6 @@
 	time = 30 MINUTES
 	needsate_text = "I need to STEAL something! I'll die if I don't!"
 
-/// PAIN FREEK
-
-/datum/charflaw/addiction/masochist
-	name = "Pain Freek"
-	desc = "They call me a freek, but it just feels so good..."
-	time = 25 MINUTES
-	needsate_text = "I need to feel good... punch me in the face!"
-
 /// LOVES SEEING VISCERA OR SOME SHIT
 
 /datum/charflaw/addiction/maniac // this will probably NOT be used as an actual flaw

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -816,25 +816,11 @@
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 
-/datum/emote/living/scream/painscream/run_emote(mob/user, params, type_override, intentional, targetted)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.has_flaw(/datum/charflaw/addiction/masochist))
-			H.sate_addiction()
-
 /datum/emote/living/scream/agony
 	key = "agony"
 	message = "screams in agony!"
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
-
-/datum/emote/living/screan/agony/run_emote(mob/user, params, type_override, intentional, targetted)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.has_flaw(/datum/charflaw/addiction/masochist))
-			H.sate_addiction()
 
 /datum/emote/living/scream/firescream
 	key = "firescream"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -828,13 +828,6 @@
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 
-/datum/emote/living/scream/firescream/run_emote(mob/user, params, type_override, intentional, targetted)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.has_flaw(/datum/charflaw/addiction/masochist))
-			H.sate_addiction()
-
 /datum/emote/living/aggro
 	key = "aggro"
 	emote_type = EMOTE_AUDIBLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->
Removes pain freek entirely for its redundancy.

Reduced the pain requirement for masochist to be a lot less extreme.

Added an endurance-based modifier to the amount of pain required, capping at 50% for endurance 5 and 150% for endurance 15.


## Why It's Good For The Game
Pain freek and masochist co-existing was confusing and unintuitive, with one of them acting as scream activated and the other caused by specific levels of pain, only one of them needed to exist.

Masochist had two major problems with its pain calculation. For starters, it didn't take into consideration the pain tolerance(endurance) of the character. This means that a tiny frail wizard and a monk had to reach the same level of pain to get the same rewards, given how pain tolerance effects how you experience pain, this made little sense. Additionally, the amount of pain required to satisfy the flaw was frankly absurd. Every 25 or less minutes you would have to _almost_ kill yourself just to reach a high enough pain level. Once you had reached this level you were most likely constantly flopping over from pain (unless you used blood loss primarily, but good luck doing that safely.) 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
