### PR TITLE
Vampires get their regenerate back and transfix fix for thralls.

### DIFF
--- a/code/modules/antagonists/villain/vampire/_vampire.dm
+++ b/code/modules/antagonists/villain/vampire/_vampire.dm
@@ -71,8 +71,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 	owner.current.cmode_music = 'sound/music/cmode/antag/CombatThrall.ogg'
 	owner.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
-    owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/transfix)
-    
+	owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/transfix)
+
 	vamp_look()
 	. = ..()
 	equip()
@@ -84,8 +84,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/antagonist/vampire/proc/after_gain()
 	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
-    owner.current.verbs |= /mob/living/carbon/human/proc/disguise_button
-    
+	owner.current.verbs |= /mob/living/carbon/human/proc/disguise_button
 
 /datum/antagonist/vampire/on_removal()
 	owner.current.has_reflection = TRUE

--- a/code/modules/antagonists/villain/vampire/_vampire.dm
+++ b/code/modules/antagonists/villain/vampire/_vampire.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		TRAIT_VAMP_DREAMS,
 		TRAIT_NOAMBUSH,
 		TRAIT_DARKVISION,
+        TRAIT_LIMBATTACHMENT,
 	)
 
 	var/vitae = 1000
@@ -70,6 +71,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 	owner.current.cmode_music = 'sound/music/cmode/antag/CombatThrall.ogg'
 	owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/transfix)
+    owner.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
 	vamp_look()
 	. = ..()
 	equip()
@@ -81,6 +83,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/antagonist/vampire/proc/after_gain()
 	owner.current.verbs |= /mob/living/carbon/human/proc/disguise_button
+    
+    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
 
 /datum/antagonist/vampire/on_removal()
 	owner.current.has_reflection = TRUE

--- a/code/modules/antagonists/villain/vampire/_vampire.dm
+++ b/code/modules/antagonists/villain/vampire/_vampire.dm
@@ -70,8 +70,9 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		vampdude.adv_hugboxing_cancel()
 
 	owner.current.cmode_music = 'sound/music/cmode/antag/CombatThrall.ogg'
-	owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/transfix)
-    owner.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
+	owner.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
+    owner.current.AddSpell(new /obj/effect/proc_holder/spell/targeted/transfix)
+    
 	vamp_look()
 	. = ..()
 	equip()
@@ -82,9 +83,9 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	owner.special_role = span_redtext("[name]")
 
 /datum/antagonist/vampire/proc/after_gain()
-	owner.current.verbs |= /mob/living/carbon/human/proc/disguise_button
+	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
+    owner.current.verbs |= /mob/living/carbon/human/proc/disguise_button
     
-    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
 
 /datum/antagonist/vampire/on_removal()
 	owner.current.has_reflection = TRUE

--- a/code/modules/antagonists/villain/vampire/lord.dm
+++ b/code/modules/antagonists/villain/vampire/lord.dm
@@ -37,8 +37,9 @@
 
 /datum/antagonist/vampire/lord/after_gain()
 	owner.current.verbs |= /mob/living/carbon/human/proc/demand_submission
-	owner.current.verbs |= /mob/living/carbon/human/proc/punish_spawn
-    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
+	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
+    owner.current.verbs |= /mob/living/carbon/human/proc/punish_spawn
+   
 
 /datum/antagonist/vampire/lord/on_removal()
 	if(!isnull(batform))
@@ -50,8 +51,9 @@
 		QDEL_NULL(portal)
 
 	owner.current.verbs -= /mob/living/carbon/human/proc/demand_submission
-	owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
-    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
+	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
+    owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
+   
 
 	. = ..()
 

--- a/code/modules/antagonists/villain/vampire/lord.dm
+++ b/code/modules/antagonists/villain/vampire/lord.dm
@@ -38,8 +38,8 @@
 /datum/antagonist/vampire/lord/after_gain()
 	owner.current.verbs |= /mob/living/carbon/human/proc/demand_submission
 	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
-    owner.current.verbs |= /mob/living/carbon/human/proc/punish_spawn
-   
+	owner.current.verbs |= /mob/living/carbon/human/proc/punish_spawn
+
 
 /datum/antagonist/vampire/lord/on_removal()
 	if(!isnull(batform))
@@ -52,8 +52,8 @@
 
 	owner.current.verbs -= /mob/living/carbon/human/proc/demand_submission
 	owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
-    owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
-   
+	owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
+
 
 	. = ..()
 
@@ -108,7 +108,7 @@
 
 /datum/outfit/job/vamplord/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.adjust_skillrank(/datum/skill/magic/blood, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/blood, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)

--- a/code/modules/antagonists/villain/vampire/lord.dm
+++ b/code/modules/antagonists/villain/vampire/lord.dm
@@ -38,6 +38,7 @@
 /datum/antagonist/vampire/lord/after_gain()
 	owner.current.verbs |= /mob/living/carbon/human/proc/demand_submission
 	owner.current.verbs |= /mob/living/carbon/human/proc/punish_spawn
+    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
 
 /datum/antagonist/vampire/lord/on_removal()
 	if(!isnull(batform))
@@ -50,6 +51,7 @@
 
 	owner.current.verbs -= /mob/living/carbon/human/proc/demand_submission
 	owner.current.verbs -= /mob/living/carbon/human/proc/punish_spawn
+    owner.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
 
 	. = ..()
 

--- a/code/modules/antagonists/villain/vampire/team.dm
+++ b/code/modules/antagonists/villain/vampire/team.dm
@@ -107,7 +107,6 @@
 			to_chat(lord, "<font color='red'>I am refreshed and have grown stronger. The visage of the bat is once again available to me. I can also once again access my portals.</font>")
 
 		if(2)
-			lord.current.verbs |= /mob/living/carbon/human/proc/vamp_regenerate
 			lord.current.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/bloodsteal)
 			lord.current.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/bloodlightning)
 			lord.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request
This is my first ever PR ever, I don't know if it will be considered or not but it was fun fucking around with code and github. 

This PR does 3 things:
1- readds regenerate for vampires
2- gives converted vampire spawns average blood sorcery so they can use their transfix (they need blood sorcery for it to work)
3- gives vampires the attach limb trait so they can reattach their severed arms or legs for aura farming purposes. 

## Why It's Good For The Game
I feel like vampires are in a pretty tough spot compared to liches and werewolves and the silver weakness of the vampire now works properly. 
Regeneration is in my opinion a vital part of a vampire, playing a vampire spawn currently feels nearly identical to playing a skeleton.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
