### PR TITLE
Removes moving through bushes causing you to take ten armor piercing damage. Adds it to running into/falling into bushes instead.

### DIFF
--- a/code/game/objects/structures/rogueflora.dm
+++ b/code/game/objects/structures/rogueflora.dm
@@ -426,7 +426,6 @@
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		var/was_hard_collision = (H.m_intent == MOVE_INTENT_RUN || H.throwing || H.atom_flags & Z_FALLING)
-		to_chat(world, "[was_hard_collision]")
 		if(was_hard_collision)
 			var/obj/item/bodypart/BP = pick(H.bodyparts)
 			BP.receive_damage(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

Removes the check for thorn damage from walking into bushes normally and adds it to running/falling into bushes instead.
Increases the odds of a bad outcome slightly from running/falling/being thrown into a bush because its funny when someone falls into a bush and gets hurt.

## Why It's Good For The Game

Taking ten damage from a lag spike is completely absurd. I do find the idea of having someone who falls/runs/is thrown into a thornbush funny so I kept that. Having your screen constantly flash red because of a single lag(or not, I don't judge) induced misstep is completely anti-qol, bushes already stun you while trying to walk through them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
