### PR TITLE
Allows the Inhumen Pantheon to be Clerics / Adds the respective gods as Templar/Cleric picks / Gives Xylix Templar a song

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -31,7 +31,7 @@
 #define RACES_PLAYER_FOREIGNNOBLE		list("Humen", "Harpy", "Rakshari", "Half-Elf", "Half-Drow", "Dark Elf", "Elf", "Dwarf", "Half-Orc", "Aasimar", "Kobold")
 
 #define ALL_TEMPLE_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)
-#define ALL_CLERIC_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora)
+#define ALL_CLERIC_PATRONS 		list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/inhumen/graggar, /datum/patron/inhumen/zizo, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)
 #define ALL_TEMPLAR_PATRONS 	list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/eora, /datum/patron/divine/necra, /datum/patron/divine/ravox, /datum/patron/divine/pestra, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/malum, /datum/patron/divine/xylix)
 
 GLOBAL_LIST_INIT(curse_names, list())

--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -9,7 +9,6 @@
 	category_tags = list(CTAG_ADVENTURER)
 	min_pq = 0
 	maximum_possible_slots = 4
-	cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
 
 /datum/outfit/job/adventurer/cleric
 	allowed_patrons = ALL_CLERIC_PATRONS
@@ -35,50 +34,91 @@
 			wrists = /obj/item/clothing/neck/psycross/silver/astrata
 			cloak = /obj/item/clothing/cloak/stabard/templar/astrata
 			neck = /obj/item/clothing/neck/chaincoif
+			H.cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
 		if(/datum/patron/divine/dendor)	// good helmet but no money
 			head = /obj/item/clothing/head/helmet/heavy/necked/dendorhelm
 			neck = /obj/item/clothing/neck/coif
 			wrists = /obj/item/clothing/neck/psycross/silver/dendor
 			cloak = /obj/item/clothing/cloak/raincloak/furcloak
 			beltr = /obj/item/weapon/knife/stone
+			H.cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
 		if(/datum/patron/divine/necra)
 			wrists = /obj/item/clothing/neck/psycross/silver/necra
 			cloak = /obj/item/clothing/cloak/stabard/templar/necra
 			neck = /obj/item/clothing/neck/gorget
+			H.cmode_music = 'sound/music/cmode/church/CombatGravekeeper.ogg'
 		if(/datum/patron/divine/eora)
 			wrists = /obj/item/clothing/neck/psycross/silver/eora
 			cloak = /obj/item/clothing/cloak/stabard/templar/eora
 			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/church/CombatEora.ogg'
 			H.virginity = FALSE
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
 		if(/datum/patron/divine/ravox)
 			wrists = /obj/item/clothing/neck/psycross/silver/ravox
 			cloak =  /obj/item/clothing/cloak/stabard/templar/ravox
 			neck = /obj/item/clothing/neck/gorget
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
 		if(/datum/patron/divine/noc)
 			wrists = /obj/item/clothing/neck/psycross/noc
 			cloak = /obj/item/clothing/cloak/stabard/templar/noc
 			neck = /obj/item/clothing/neck/chaincoif
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/pestra)
 			wrists = /obj/item/clothing/neck/psycross/silver/pestra
 			cloak = /obj/item/clothing/cloak/stabard/templar/pestra
 			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/abyssor)
 			wrists = /obj/item/clothing/neck/psycross/silver/abyssor
 			cloak = /obj/item/clothing/cloak/tabard/crusader
 			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/malum)
 			wrists = /obj/item/clothing/neck/psycross/silver/malum
 			cloak = /obj/item/clothing/cloak/stabard/templar/malum
 			neck = /obj/item/clothing/neck/gorget
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
 		if(/datum/patron/divine/xylix)
 			wrists = /obj/item/clothing/neck/psycross/silver/xylix
 			cloak = /obj/item/clothing/cloak/tabard/crusader
 			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+		if(/datum/patron/inhumen/graggar) // Heretical Patrons
+			cloak = /obj/item/clothing/cloak/raincloak/mortus
+			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.change_stat(STATKEY_LCK, -2)
+			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/graggar_zizo)
+			cloak = /obj/item/clothing/cloak/raincloak/mortus
+			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
+		if(/datum/patron/inhumen/zizo)
+			cloak = /obj/item/clothing/cloak/raincloak/mortus
+			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.change_stat(STATKEY_LCK, -2)
+			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/matthios)
+			cloak = /obj/item/clothing/cloak/raincloak/mortus
+			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.change_stat(STATKEY_LCK, -2)
+			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/baotha)
+			head = /obj/item/clothing/head/crown/circlet
+			mask = /obj/item/clothing/face/spectacles/sglasses
+			cloak = /obj/item/clothing/cloak/raincloak/purple
+			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.change_stat(STATKEY_LCK, -2)
+			H.cmode_music = 'sound/music/cmode/antag/combat_evilwizard.ogg'
+			GLOB.heretical_players += H.real_name
 		else // Failsafe
 			cloak = /obj/item/clothing/cloak/tabard/crusader // Give us a generic crusade tabard
 			wrists = /obj/item/clothing/neck/psycross/silver // Give us a silver psycross for protection against lickers
 			neck = /obj/item/clothing/neck/chaincoif/iron
+			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
 
 
 	if(H.mind)

--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -87,7 +87,7 @@
 		if(/datum/patron/inhumen/graggar) // Heretical Patrons
 			cloak = /obj/item/clothing/cloak/raincloak/mortus
 			neck = /obj/item/clothing/neck/chaincoif/iron
-			H.change_stat(STATKEY_LCK, -2)
+			H.change_stat(STATKEY_LCK, -1)
 			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/graggar_zizo)
@@ -97,13 +97,13 @@
 		if(/datum/patron/inhumen/zizo)
 			cloak = /obj/item/clothing/cloak/raincloak/mortus
 			neck = /obj/item/clothing/neck/chaincoif/iron
-			H.change_stat(STATKEY_LCK, -2)
+			H.change_stat(STATKEY_LCK, -1)
 			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/matthios)
 			cloak = /obj/item/clothing/cloak/raincloak/mortus
 			neck = /obj/item/clothing/neck/chaincoif/iron
-			H.change_stat(STATKEY_LCK, -2)
+			H.change_stat(STATKEY_LCK, -1)
 			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/baotha)
@@ -111,7 +111,7 @@
 			mask = /obj/item/clothing/face/spectacles/sglasses
 			cloak = /obj/item/clothing/cloak/raincloak/purple
 			neck = /obj/item/clothing/neck/chaincoif/iron
-			H.change_stat(STATKEY_LCK, -2)
+			H.change_stat(STATKEY_LCK, -1)
 			H.cmode_music = 'sound/music/cmode/antag/combat_evilwizard.ogg'
 			GLOB.heretical_players += H.real_name
 		else // Failsafe

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
@@ -63,7 +63,7 @@
 		if(/datum/patron/inhumen/graggar) // Heretical Patrons
 			head = /obj/item/clothing/head/helmet/heavy/sinistar
 			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
-			H.change_stat(STATKEY_LCK, -1)
+			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/graggar_zizo)
 			head = /obj/item/clothing/head/helmet/heavy/sinistar
@@ -71,29 +71,28 @@
 		if(/datum/patron/inhumen/zizo)
 			head = /obj/item/clothing/head/helmet/visored/zizo
 			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
-			H.change_stat(STATKEY_LCK, -1)
+			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/matthios)
 			head = /obj/item/clothing/head/helmet/heavy/matthios
 			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
-			H.change_stat(STATKEY_LCK, -1)
+			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/baotha)
 			head = /obj/item/clothing/head/crown/circlet
 			mask = /obj/item/clothing/face/spectacles/sglasses
 			H.cmode_music = 'sound/music/cmode/antag/combat_evilwizard.ogg'
-			H.change_stat(STATKEY_LCK, -1)
+			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/godless)
 			head = /obj/item/clothing/head/roguehood/green
 			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
-			H.change_stat(STATKEY_LCK, -1)
+			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		else // Failsafe
 			head = /obj/item/clothing/head/helmet/heavy/bucket
 			wrists = /obj/item/clothing/neck/psycross/silver
 			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
-			H.change_stat(STATKEY_LCK, -1)
 
 	armor = /obj/item/clothing/armor/plate
 	shirt = /obj/item/clothing/armor/chainmail

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
@@ -69,12 +69,12 @@
 			head = /obj/item/clothing/head/helmet/heavy/sinistar
 			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
 		if(/datum/patron/inhumen/zizo)
-			head = /obj/item/clothing/head/helmet/visored/zizo
+			head = /obj/item/clothing/head/helmet/skullcap/cult
 			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
 			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name
 		if(/datum/patron/inhumen/matthios)
-			head = /obj/item/clothing/head/helmet/heavy/matthios
+			head = /obj/item/clothing/head/helmet/heavy/rust
 			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
 			H.change_stat(STATKEY_LCK, -2)
 			GLOB.heretical_players += H.real_name

--- a/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/donator/paladin.dm
@@ -17,45 +17,83 @@
 		if(/datum/patron/psydon, /datum/patron/psydon/progressive)
 			head = /obj/item/clothing/head/helmet/heavy/bucket/gold
 			wrists = /obj/item/clothing/neck/psycross/g
+			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
 		if(/datum/patron/divine/astrata)
 			head = /obj/item/clothing/head/helmet/heavy/necked/astrata
 			wrists = /obj/item/clothing/neck/psycross/silver/astrata
+			H.cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
 		if(/datum/patron/divine/noc)
 			head = /obj/item/clothing/head/helmet/heavy/necked/noc
 			wrists = /obj/item/clothing/neck/psycross/noc
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/dendor)
 			head = /obj/item/clothing/head/helmet/heavy/necked/dendorhelm
 			wrists = /obj/item/clothing/neck/psycross/silver/dendor
+			H.cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
 		if(/datum/patron/divine/abyssor)
 			head = /obj/item/clothing/head/helmet/heavy/necked // Placeholder
 			wrists = /obj/item/clothing/neck/psycross/silver/abyssor
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/necra)
 			head = /obj/item/clothing/head/helmet/heavy/necked/necra
 			wrists = /obj/item/clothing/neck/psycross/silver/necra
+			H.cmode_music = 'sound/music/cmode/church/CombatGravekeeper.ogg'
 		if(/datum/patron/divine/ravox)
 			head = /obj/item/clothing/head/helmet/heavy/necked/ravox
 			wrists = /obj/item/clothing/neck/psycross/silver/ravox
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
 		if(/datum/patron/divine/xylix)
 			head = /obj/item/clothing/head/helmet/heavy/necked // Placeholder
 			wrists = /obj/item/clothing/neck/psycross/silver/xylix
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/pestra)
 			head = /obj/item/clothing/head/helmet/heavy/necked/pestrahelm
 			wrists = /obj/item/clothing/neck/psycross/silver/pestra
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 		if(/datum/patron/divine/malum)
 			head = /obj/item/clothing/head/helmet/heavy/necked/malumhelm
 			wrists = /obj/item/clothing/neck/psycross/silver/malum
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
 		if(/datum/patron/divine/eora)
 			head = /obj/item/clothing/head/helmet/sallet/eoran
 			wrists = /obj/item/clothing/neck/psycross/silver/eora
+			H.cmode_music = 'sound/music/cmode/church/CombatEora.ogg'
 			H.virginity = FALSE
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
-		if(/datum/patron/inhumen/baotha, /datum/patron/inhumen/graggar, /datum/patron/inhumen/zizo, /datum/patron/inhumen/matthios, /datum/patron/inhumen/graggar_zizo, /datum/patron/godless)
-			head = /obj/item/clothing/head/jester
-			if(H.mind)
-				H.change_stat(STATKEY_LCK, -20)
+		if(/datum/patron/inhumen/graggar) // Heretical Patrons
+			head = /obj/item/clothing/head/helmet/heavy/sinistar
+			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
+			H.change_stat(STATKEY_LCK, -1)
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/graggar_zizo)
+			head = /obj/item/clothing/head/helmet/heavy/sinistar
+			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
+		if(/datum/patron/inhumen/zizo)
+			head = /obj/item/clothing/head/helmet/visored/zizo
+			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
+			H.change_stat(STATKEY_LCK, -1)
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/matthios)
+			head = /obj/item/clothing/head/helmet/heavy/matthios
+			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
+			H.change_stat(STATKEY_LCK, -1)
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/inhumen/baotha)
+			head = /obj/item/clothing/head/crown/circlet
+			mask = /obj/item/clothing/face/spectacles/sglasses
+			H.cmode_music = 'sound/music/cmode/antag/combat_evilwizard.ogg'
+			H.change_stat(STATKEY_LCK, -1)
+			GLOB.heretical_players += H.real_name
+		if(/datum/patron/godless)
+			head = /obj/item/clothing/head/roguehood/green
+			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
+			H.change_stat(STATKEY_LCK, -1)
+			GLOB.heretical_players += H.real_name
 		else // Failsafe
 			head = /obj/item/clothing/head/helmet/heavy/bucket
 			wrists = /obj/item/clothing/neck/psycross/silver
+			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
+			H.change_stat(STATKEY_LCK, -1)
 
 	armor = /obj/item/clothing/armor/plate
 	shirt = /obj/item/clothing/armor/chainmail

--- a/code/modules/jobs/job_types/church/templar.dm
+++ b/code/modules/jobs/job_types/church/templar.dm
@@ -120,6 +120,7 @@
 		if(/datum/patron/divine/xylix)
 			wrists = /obj/item/clothing/neck/psycross/silver/xylix
 			H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
+			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

CHANGES:

Templar (Xylix) now has a song assigned to him. I saw this issue working on the PR and plugged it in.

The 4 are now added to the list of possible clerics.

Clerics & Paladins now have heretical god variants, complete with being branded as a heretic.

Clerics & Paladins now have their respective god's music. They also get -1 and -2 LCK respectively.

_For Paladins - Baothans get a crown and sunglasses. Graggarites get the Sinistar. Matthios worshippers get the Hedge Knight helmet, Zizo worshippers get the Lich hood.

All heretics do not have any religious iconography, they won't be able to cast spells off the bat. This is not an oversight. Suffer dipshit.

## Why It's Good For The Game

Previously if you played paladin as a heretic you got -20 luck. It's most certainly antithetical to play such a role as one, but I think freedom of choice overrules this. If people want to play a heretic, fuck it, let em. Gives the forest garrison more work to do anyways.

Paladin is capped at 1, Cleric is capped at 4. I doubt this will create issues with people using these roles as an excuse to be bandit-lite.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
