### PR TITLE
Man-at-arms total rework

### DIFF
--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -31,8 +31,8 @@
 /datum/outfit/job/watchman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	head =	/obj/item/clothing/head/helmet/kettle/slit
-	shirt =	/obj/item/clothing/armor/chainmail
+	head = /obj/item/clothing/head/helmet/kettle/slit
+	shirt = /obj/item/clothing/armor/chainmail
 	pants = /obj/item/clothing/pants/trou/leather/guard
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -31,12 +31,14 @@
 /datum/outfit/job/watchman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	wrists = /obj/item/clothing/wrists/bracers/leather
+	head =	/obj/item/clothing/head/helmet/kettle/slit
+	shirt =	/obj/item/clothing/armor/chainmail
 	pants = /obj/item/clothing/pants/trou/leather/guard
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/storage/keyring/manorguard
-
+	neck = /obj/item/clothing/neck/gorget
+	beltr = /obj/item/weapon/sword/arming
+	backpack_contents =	list(/obj/item/storage/keyring/manorguard) // this is done so that the marksmen can have their quiver on their hip
 /datum/outfit/job/watchman/post_equip(mob/living/carbon/human/H)
 	. = ..()
 	if(H.cloak)
@@ -47,10 +49,10 @@
 	..()
 
 /datum/advclass/menatarms/watchman_pikeman
-	name = "Pikeman Men-At-Arms"
+	name = "Men-At-Arms Conqueror"
 	tutorial = "You once warded the town, beating the poor and killing the senseless. \
-	Now you get to stare at them in the eyes, watching as they bleed, \
-	exanguinated personally by one of the Monarch's best. \
+	Now you get to stare at them in the eyes, watching as they writhe, \
+	skulls CRACKED personally by one of the Monarch's brutes. \
 	You are poor, and your belly is yet full."
 	outfit = /datum/outfit/job/watchman/pikeman
 
@@ -58,13 +60,9 @@
 
 /datum/outfit/job/watchman/pikeman/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/helmet/kettle
-	armor = /obj/item/clothing/armor/cuirass
-	shirt = /obj/item/clothing/armor/chainmail
-	neck = /obj/item/clothing/neck/chaincoif/iron
+	armor = /obj/item/clothing/armor/plate/iron
 	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/arming
-	backr = /obj/item/weapon/polearm/spear/billhook
+	backr = /obj/item/weapon/polearm/eaglebeak/lucerne
 	backl = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
@@ -75,22 +73,22 @@
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 	H.change_stat(STATKEY_STR, 2)
-	H.change_stat(STATKEY_PER, -1)
-	H.change_stat(STATKEY_END, -1)
-	H.change_stat(STATKEY_CON, 1)
-	H.change_stat(STATKEY_SPD, 1)
+	H.change_stat(STATKEY_END, 1)
+	H.change_stat(STATKEY_CON, 2)
+	H.change_stat(STATKEY_SPD, -1)
+	H.change_stat(STATKEY_INT, -2)
 	H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 
 /datum/advclass/menatarms/watchman_swordsmen
-	name = "Fencer Men-At-Arms"
-	tutorial = "You once warded the town, beating the poor and killing the senseless. \
-	You were quite a good dancer, you've blended that skill with your blade- \
+	name = "Men-At-Arms Bulwark"
+	tutorial = "You once warded the town, your shield acting as a second wall, just in case the REAL walls were breached. \
+	You were best with a shield in one hand, blade in the other. Nowadays, you love watching the living devolve to empty bloodbags on the ground, \
 	exanguinated personally by one of the Monarch's best. \
 	You are poor, and your belly is yet full."
 	outfit = /datum/outfit/job/watchman/swordsmen
@@ -98,16 +96,14 @@
 
 /datum/outfit/job/watchman/swordsmen/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = pick(/obj/item/clothing/head/roguehood/guard, /obj/item/clothing/head/roguehood/guardsecond)
-	armor = /obj/item/clothing/armor/leather/advanced
-	shirt = /obj/item/clothing/armor/gambeson
-	neck = /obj/item/clothing/neck/gorget
+	armor = /obj/item/clothing/armor/cuirass
 	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/rapier
+	backr =	/obj/item/weapon/shield/tower
 	backl = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
@@ -117,17 +113,20 @@
 		H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_END, 2)
-		H.change_stat(STATKEY_SPD, 2)
+		H.change_stat(STATKEY_CON, 1)
+		H.change_stat(STATKEY_SPD, -1)
 		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 		H.verbs |= /mob/proc/haltyell
 
 /datum/advclass/menatarms/watchman_ranger
-	name = "Archer Men-At-Arms"
-	tutorial = "You once warded the town, beating the poor and killing the senseless. \
-	Now you stare at them from above, raining hell down upon the knaves and the curs that see you a traitor. \
+	name = "Men-At-Arms Marksman"
+	tutorial = "You once warded the town, aiming for legs or head depending on the crime. \
+	With your precision, it's only natural you were awarded with a crossbow. \
+	While you may stay in the back, you're no coward, nor some fancy-foot ranger, and you may take up the blade if you need. \
+	You love hearing the crack of some itinerant knight's plate armor as your bolt pierces right through it, just a moment after they let slip an insult to your master. \
 	You are poor, and your belly is yet full."
 	outfit = /datum/outfit/job/watchman/ranger
 
@@ -135,18 +134,20 @@
 
 /datum/outfit/job/watchman/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/helmet/kettle
-	armor = /obj/item/clothing/armor/leather/hide
+	armor = /obj/item/clothing/armor/cuirass
 	shirt = /obj/item/clothing/armor/gambeson/heavy
-	beltr = /obj/item/weapon/mace/cudgel
 	neck = /obj/item/clothing/neck/chaincoif/iron
 	gloves = /obj/item/clothing/gloves/leather
+	backr =	/obj/item/storage/backpack/satchel
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	beltl = /obj/item/ammo_holder/quiver/bolts
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
@@ -156,16 +157,8 @@
 		H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_PER, 2)
-		H.change_stat(STATKEY_END, -2)
-		H.change_stat(STATKEY_SPD, 1)
+		H.change_stat(STATKEY_SPD, -1)
 		H.verbs |= /mob/proc/haltyell
 		ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		var/weapontypec = pickweight(list("Bow" = 6, "Crossbow" = 4)) // Rolls for either a bow or a Crossbow
-		switch(weapontypec)
-			if("Bow")
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/long
-				backr = /obj/item/ammo_holder/quiver/arrows
-			if("Crossbow")
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				backr = /obj/item/ammo_holder/quiver/bolts
+		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+


### PR DESCRIPTION
## About The Pull Request

All MAA roles:
- Removed leather bracers
- Keys spawn in backpack
- Added slitted kettle helmet, haubergeon, and gorget, as standard armor
- Added an arming sword on their hip

Pikeman:
- Renamed to conqueror(from basic pikeman to a dumb brutish warrior)
- Steel cuirass replaced with iron half-plate(less armor, but leg coverage)
- Billhook replaced with Lucerne
- Athletics raised from 3>4
- Perception malus removed
- Endurance malus of 1 replaced with an endurance bonus of 1
- Speed bonus of 1 replaced with a speed malus of 1
- Constitution bonus of 1 improved to 2
- Intelligence malus of 2 added

Fencer:
- Renamed to bulwark(from light armor dodgy attacker to classic sword and shield soldier)
- Coat replaced with steel cuirass
- Rapier removed(they're meant to use the arming sword that all MAA roles start with)
- Starts with an iron tower shield on their back
- 4 shields skill
- Speed bonus of 2 replaced with a speed malus of 1
- Constitution bonus of 1 added
- Strength bonus of 1 added
- Dodge expert replaced with medium armor training

Archer:
- Renamed to marksman(from light armor ranger esque, to hefty crossbow wielding bullseye striker)
- Hide armor replaced with steel cuirass(The fact a keep role ever had hide armor is hilarious to me)
- Cudgel backup weapon removed(they're meant to use the arming sword that all MAA roles start with for backup now)
- Guaranteed crossbow spawn, rather than chance of bow/crossbow
- Starts with a satchel, instead of no satchel
- 3 swords skill
- Speed bonus of 1 replaced with a speed malus of 1
- Endurance malus of 2 removed
- Dodge expert replaced with medium armor training

## Why It's Good For The Game

Men-at-arms classes will now both look, and act, like real soldiers. Currently, two thirds of the men-at-arms classes are lightweight squishy rogue type classes, who crumple like paper if they're ever attacked. The rapier is unfitting, as well as the bow. The pikeman now gets leg armor and a cool hammer, which they've always needed. There's now a classic sword/shield class instead of the unfitting rapier. The archer is now less of a pushover, and more of a soldier, with the horrendously bad hide armor gone, as well as the useless cudgel replaced with an arming sword, plus REAL armor and the beloved crossbow, every one of the men-at-arms subclasses are equally fear-inducing. Also, men-at-arms will now LOOK more uniform, like a king's army, instead of four people who happen to wear tabards of the same color.

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
