### PR TITLE
Removes EXTREMELY easy gate bypass/path to break into town watch

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -99525,9 +99525,9 @@ twR
 rZO
 oDZ
 qUP
-mZi
-mZi
-mZi
+jKg
+jKg
+jKg
 wMs
 wMs
 wMs
@@ -99728,9 +99728,9 @@ vCA
 oDZ
 lBA
 mZi
-mZi
-nlp
-nlp
+wvf
+jKg
+wvf
 wMs
 wMs
 wMs
@@ -99932,7 +99932,7 @@ lBA
 rAU
 fYR
 msN
-nlp
+jKg
 wMs
 wMs
 wMs


### PR DESCRIPTION
Adds rocks to stop the very easy way into the town watch captain's office

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Adds rocks to stop the very easy way into the town watch captain's office
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
It is, currently so easy and obvious to break into the town watch, there's a one tile jump between the entrance bridge and a ledge that lets you easily break a single window (image 1), and then have access to a good chunk of the building. The past 5 town watch rounds I've played, every single time, as soon as we look away to watch the town for like 10 minutes, as soon as I get back I see the captain's window broken, the other one open, and half the equipment gone..
It's also a pretty easy way to get around the town gate, all you need to do is break a door and a window to do so. 
This is both extremely annoying for the town watch, as well as an easy way for bandits to just grab town watch gear, pretend to be town watch, and then just grief.

![Screenshot 2025-06-02 103349](https://github.com/user-attachments/assets/d1c0df34-d2b2-43bc-a653-b7a661c7cf92)
![Screenshot 2025-06-02 103503](https://github.com/user-attachments/assets/906c585c-8283-4f75-b495-237ed5c93730)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
