### PR TITLE
Witch Hunters with Psydon as a patron now get a Silver Psycross

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/rare/witchhunter.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/rare/witchhunter.dm
@@ -43,6 +43,8 @@
 		H.change_stat(STATKEY_PER, 2)
 		H.change_stat(STATKEY_CON, 2)
 		switch(H.patron?.name)
+			if ("Psydon")
+				wrists = /obj/item/clothing/neck/psycross/silver
 			if("Astrata")
 				wrists = /obj/item/clothing/neck/psycross/silver/astrata
 			if("Necra")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
A small PR that allows the Witch Hunter Class to spawn with a Silver Psycross if they worship Psydon as opposed to just standard leather bracers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
It's a missed opportunity for the class all about slaying the undead with silver and has a fair bit in common with the Inquisition (along with sharing combat music) to not spawn with a Psycross if the character has Psydon has a patron. This allows these characters to properly represent their faith right from the start.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
