### PR TITLE
Fixes hearth acolyte patron lock not working

### DIFF
--- a/code/modules/jobs/job_types/garrison/town_elder.dm
+++ b/code/modules/jobs/job_types/garrison/town_elder.dm
@@ -265,7 +265,7 @@
 	allowed_patrons = ALL_TEMPLE_PATRONS
 
 /datum/outfit/job/town_elder/hearth_acolyte/pre_equip(mob/living/carbon/human/H)
-	..()
+	. = ..()
 	head = /obj/item/clothing/head/roguehood/random
 	armor = /obj/item/clothing/shirt/robe
 	shoes = /obj/item/clothing/shoes/sandals


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

me being dumb, i thought it was working but it was not

## Why It's Good For The Game

Now you can't be a zizoid who somehow became an acolyte (it also made them a cultist)

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
