### PR TITLE
Assassin - Remove Whitecloak Disguise

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/rare/assassin.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/rare/assassin.dm
@@ -38,7 +38,7 @@
 	H.become_blind("TRAIT_GENERIC")
 	H.advjob = "Assassin"
 	// Assassin now spawns disguised as one of the non-combat drifters. You never know who will stab you in the back.
-	var/disguises = list("Bard", "Beggar", "Fisher", "Hunter", "Miner", "Noble", "Peasant", "Carpenter", "Thief", "Ranger", "Servant", "Assassin")
+	var/disguises = list("Bard", "Beggar", "Fisher", "Hunter", "Miner", "Noble", "Peasant", "Carpenter", "Thief", "Ranger", "Servant")
 	var/disguisechoice = input("Choose your cover", "Available disguises") as anything in disguises
 
 	if(disguisechoice)
@@ -257,21 +257,6 @@
 			else
 				cloak = /obj/item/clothing/cloak/apron
 			backpack_contents = list(/obj/item/recipe_book/cooking = 1)
-		if("Assassin") // Sacrifice the disguise for drip.
-			shirt = /obj/item/clothing/shirt/undershirt/fancy
-			gloves = /obj/item/clothing/gloves/fingerless
-			pants = /obj/item/clothing/pants/tights/uncolored
-			shoes = /obj/item/clothing/shoes/boots
-			backl = /obj/item/storage/backpack/satchel
-			belt = /obj/item/storage/belt/leather/knifebelt/black/steel
-			beltl = /obj/item/storage/belt/pouch/coins/poor
-			beltr = /obj/item/weapon/knife/dagger/steel
-			armor = /obj/item/clothing/shirt/tunic/noblecoat
-			cloak = /obj/item/clothing/cloak/raincloak
-			mask = /obj/item/clothing/face/spectacles/sglasses
-			ring = /obj/item/clothing/ring/silver/gemerald
-			backpack_contents = list(/obj/item/reagent_containers/glass/bottle/poison, /obj/item/weapon/knife/dagger/steel/profane, /obj/item/lockpick, /obj/item/storage/fancy/cigarettes/zig, /obj/item/flint)
-			H.set_hair_style(/datum/sprite_accessory/hair/head/bald, FALSE)
 
 	H.cure_blind("TRAIT_GENERIC")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Removes the Whitecloak assassin disguise. Requested change

## Why It's Good For The Game

There's another PR for a version of this that has far more effort - [The Faceless.](https://github.com/Monkestation/Vanderlin/pull/2021) There's also some issues with escalation/moderation, and people dropping the disguise for stealth - surpassing the entire point of the outfit in the first place. 

Perhaps someday the Whitecloak will return, but for now, it's being put on a raft and kicked out to sea. Go aura-farm in the great barrier reef dipshit

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
