### PR TITLE
Harlequin balance adjustment bullshit

### DIFF
--- a/code/modules/antagonists/villain/harlequinn/_harlequin.dm
+++ b/code/modules/antagonists/villain/harlequinn/_harlequin.dm
@@ -40,6 +40,7 @@
 
 	H.unequip_everything()
 	H.equipOutfit(/datum/outfit/job/harlequin)
+	H.cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
 
 /datum/antagonist/harlequinn/proc/give_objectives()
 	var/list/contract_choices = list()

--- a/code/modules/antagonists/villain/harlequinn/outfit.dm
+++ b/code/modules/antagonists/villain/harlequinn/outfit.dm
@@ -9,14 +9,15 @@
 	pants = /obj/item/clothing/pants/trou/leather
 	armor = /obj/item/clothing/armor/leather/jacket
 	beltl = /obj/item/weapon/knife/dagger/steel
+	beltr = /obj/item/instrument/flute
 	backr = /obj/item/storage/backpack/satchel
 	backl = /obj/item/storage/belt/pouch/coins/poor
 	cloak = /obj/item/clothing/cloak/half/shadowcloak
 	head = /obj/item/clothing/head/roguehood/black
 
-	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/music, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
@@ -25,24 +26,23 @@
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enhanced_mimicry)
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("perception", 1)
-	H.change_stat("speed", 2)
+	H.change_stat("speed", 3)
 
 	backpack_contents = list(
 		/obj/item/harlequinn_disguise_kit,
 		/obj/item/reagent_containers/glass/bottle/poison,
 		/obj/item/lockpick,
 		/obj/item/rope,
-		/obj/item/smokebomb,
-		/obj/item/smokebomb,
+		/obj/item/smokebomb = 2,
 	)
 
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/antagonists/villain/harlequinn/outfit.dm
+++ b/code/modules/antagonists/villain/harlequinn/outfit.dm
@@ -6,6 +6,7 @@
 	mask = /obj/item/clothing/face/mask/facemask/steel/harlequin
 	gloves = /obj/item/clothing/gloves/fingerless
 	belt = /obj/item/storage/belt/leather/black
+	wrists = /obj/item/rope
 	pants = /obj/item/clothing/pants/trou/leather
 	armor = /obj/item/clothing/armor/leather/jacket
 	beltl = /obj/item/weapon/knife/dagger/steel
@@ -41,7 +42,6 @@
 		/obj/item/harlequinn_disguise_kit,
 		/obj/item/reagent_containers/glass/bottle/poison,
 		/obj/item/lockpick,
-		/obj/item/rope,
 		/obj/item/smokebomb = 2,
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

4 athletics because they're a dodgetank and slurp stamina

3 in lockpicks

4 in knives, they're an antagonist

4 in swimming, helps for escape

gives them the forest garrison theme, proper song on the way

5 in climbing for slowfall

3 in Speed

fixes smokebomb only having one instance spawn in the bag, moves rope to wrists so it has room to spawn

## Why It's Good For The Game

they seem a little underpowered for being an antagonist, but i haven't seen one proper. if i fucked this up in the wrong direction for the role please let me know

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
