### PR TITLE
Vanderlin roundstart item revision

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2175,6 +2175,20 @@
 "bkg" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/cell)
+"bkx" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "bkH" = (
 /obj/structure/table/wood/large/corner{
 	dir = 1
@@ -2596,10 +2610,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/merc_guild)
-"byJ" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "byT" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/blocks,
@@ -3633,6 +3643,11 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/river)
+"chk" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "chp" = (
 /obj/structure/flora/grass,
 /turf/open/floor/grass,
@@ -3968,19 +3983,6 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
-"csb" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "csv" = (
 /obj/structure/closet/crate/crafted_closet,
 /obj/item/key/apartments/apartment3,
@@ -6134,6 +6136,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/garrison)
+"dNG" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "dNI" = (
 /obj/structure/table/wood/large/corner{
 	dir = 10
@@ -7276,6 +7293,11 @@
 /area/rogue/indoors/town/cell)
 "exf" = (
 /obj/structure/closet/crate/crafted_closet,
+/obj/item/reagent_containers/food/snacks/hardtack,
+/obj/item/clothing/cloak/tabard/knight,
+/obj/item/clothing/shoes/boots/leather,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/shirt/undershirt/fancy,
 /turf/open/floor/woodturned/nosmooth,
 /area/rogue/indoors/town/manor)
 "exg" = (
@@ -7360,24 +7382,6 @@
 	},
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
-"ezg" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/obj/item/storage/belt/leather,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "ezn" = (
 /obj/structure/bed/wool,
 /obj/item/bedsheet/cloth,
@@ -7838,34 +7842,6 @@
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/tile,
 /area/rogue/indoors/town/manor)
-"ePK" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "ePY" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -8109,11 +8085,6 @@
 /obj/item/bedsheet/cloth,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"eXJ" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "eXK" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/fueled/torchholder{
@@ -8691,21 +8662,6 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
-"fri" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "frI" = (
 /obj/structure/fake_machine/atm,
 /turf/open/floor/carpet/royalblack,
@@ -9998,13 +9954,6 @@
 "gmY" = (
 /turf/open/floor/blocks,
 /area/rogue/outdoors/rtfield)
-"gnk" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "gnn" = (
 /mob/living/simple_animal/hostile/retaliate/spider,
 /turf/open/floor/greenstone,
@@ -11514,6 +11463,11 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/church,
 /area/rogue/indoors/town/church)
+"hkO" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "hkX" = (
 /obj/structure/lever/hidden/keep{
 	redstone_id = 615
@@ -12333,9 +12287,9 @@
 /turf/open/floor/blocks,
 /area/rogue/indoors/dungeon)
 "hMz" = (
-/obj/structure/grindwheel,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
+/obj/structure/bookcase/random/myths,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "hMJ" = (
 /obj/machinery/light/fueled/firebowl/standing,
 /turf/open/floor/ruinedwood/spiral,
@@ -12612,20 +12566,6 @@
 	},
 /obj/item/paint_brush,
 /turf/open/floor/blocks/stonered/tiny,
-/area/rogue/indoors/town)
-"hVa" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "hVd" = (
 /turf/open/floor/rooftop{
@@ -12922,6 +12862,11 @@
 	},
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
+"igy" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "igz" = (
 /mob/living/simple_animal/hostile/retaliate/spider,
 /turf/open/water/sewer,
@@ -14808,6 +14753,13 @@
 "jpV" = (
 /obj/machinery/light/fueled/wallfire/candle,
 /obj/structure/closet/crate/chest/crate,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
 "jqq" = (
@@ -14956,13 +14908,6 @@
 /obj/item/key/atarms,
 /obj/item/key/atarms,
 /obj/item/key/atarms,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
-"jxl" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "jxo" = (
@@ -17345,7 +17290,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/machinery/tanningrack,
+/obj/structure/closet/crate/chest,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17807,15 +17752,6 @@
 /obj/item/clothing/pants/tights/black,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"lkd" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "lkq" = (
 /obj/structure/stairs{
 	dir = 1
@@ -17938,6 +17874,10 @@
 "lnG" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/magician)
+"lnQ" = (
+/obj/structure/grindwheel,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "lob" = (
 /obj/structure/table/wood/large/corner{
 	dir = 10
@@ -18970,6 +18910,10 @@
 /area/rogue/under/town/basement)
 "mbs" = (
 /obj/structure/rack,
+/obj/item/weapon/polearm/woodstaff/quarterstaff,
+/obj/item/weapon/polearm/woodstaff/quarterstaff{
+	pixel_x = -12
+	},
 /turf/open/floor/grass,
 /area/rogue/outdoors/town)
 "mbB" = (
@@ -19385,8 +19329,9 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -19927,6 +19872,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/churchrough,
 /area/rogue/under/town/sewer)
+"mIU" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "mJb" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/ruinedwood/darker,
@@ -20352,6 +20301,15 @@
 "mVj" = (
 /turf/open/floor/tile,
 /area/rogue/indoors/town/church)
+"mVk" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "mVv" = (
 /obj/structure/bed/inn,
 /obj/item/bedsheet/wool,
@@ -20770,13 +20728,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/greenstone,
 /area/rogue/under/town/sewer)
-"nhA" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "niE" = (
 /obj/structure/bed/wool,
 /obj/item/bedsheet/pelt,
@@ -21832,11 +21783,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
-"nRQ" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "nRZ" = (
 /turf/closed/mineral/random,
 /area/rogue/under/town/sewer)
@@ -25379,6 +25325,13 @@
 "qny" = (
 /turf/open/floor/greenstone/glyph5,
 /area/rogue/indoors/town/vault)
+"qnE" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "qnH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -26585,6 +26538,19 @@
 	dir = 8
 	},
 /area/rogue/under/town/caverogue)
+"raY" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "rbe" = (
 /obj/structure/fluff/walldeco/painting/castle,
 /turf/closed/wall/mineral/stone/moss,
@@ -27045,6 +27011,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town)
+"rrD" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "rrL" = (
 /turf/open/floor/metal/barograte,
 /area/rogue/indoors/town)
@@ -27967,6 +27937,34 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/soilsons)
+"rWq" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "rWI" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/dirt,
@@ -28040,6 +28038,12 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"sal" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "sap" = (
 /obj/item/bin/water,
 /turf/open/floor/blocks/paving,
@@ -29430,6 +29434,13 @@
 /area/rogue/indoors/town/smithy)
 "sTH" = (
 /obj/structure/closet/crate/chest/crate,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
 "sTL" = (
@@ -30097,11 +30108,6 @@
 /obj/structure/roguerock,
 /turf/open/floor/naturalstone,
 /area/rogue/outdoors/river)
-"toR" = (
-/obj/structure/flora/grass/bush,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "tpa" = (
 /obj/machinery/light/fueled/wallfire/candle/blue{
 	pixel_y = -32
@@ -31521,6 +31527,10 @@
 	},
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/magician)
+"ugn" = (
+/obj/structure/table/wood/plain_alt,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "ugP" = (
 /obj/structure/table/wood/crafted,
 /obj/item/reagent_containers/glass/bowl,
@@ -31928,10 +31938,6 @@
 /obj/machinery/light/fueled/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
-"uxt" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "uxx" = (
 /obj/machinery/light/fueled/hearth,
 /obj/machinery/light/fueled/oven/east,
@@ -32645,6 +32651,24 @@
 	dir = 1
 	},
 /area/rogue/under/town/caverogue)
+"uSw" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/obj/item/storage/belt/leather,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "uSF" = (
 /obj/structure/roguerock{
 	icon_state = "rock3"
@@ -33606,6 +33630,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
+/obj/item/weapon/whip,
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
 "vDc" = (
@@ -37177,6 +37202,13 @@
 /obj/item/paper/scroll,
 /turf/open/floor/concrete,
 /area/rogue/indoors/town/shop)
+"xWv" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "xWS" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /obj/machinery/light/fueled/torchholder,
@@ -95629,7 +95661,7 @@ iWy
 qTA
 iWy
 oDt
-uxt
+rrD
 gOl
 acs
 acs
@@ -96033,7 +96065,7 @@ jZn
 uie
 ckQ
 jZn
-nhA
+kSd
 gOl
 gqv
 acs
@@ -96437,7 +96469,7 @@ jZn
 xhJ
 iOP
 jZn
-kSd
+xWv
 gOl
 gqv
 acs
@@ -97432,9 +97464,9 @@ gOl
 srF
 vwo
 iPC
-ePK
+rWq
 iSJ
-jxl
+mso
 ofx
 jxg
 gOl
@@ -100058,9 +100090,9 @@ vgJ
 vgJ
 vgJ
 gOl
-eXJ
+chk
 ahA
-mso
+sal
 owl
 vwo
 gOl
@@ -100122,7 +100154,7 @@ mlm
 lfC
 kzd
 qLV
-fri
+dNG
 ylf
 elp
 elp
@@ -101334,7 +101366,7 @@ hsv
 oXQ
 cKJ
 qhM
-lkd
+mVk
 ehF
 fOL
 iSk
@@ -101937,7 +101969,7 @@ dsu
 lsl
 lsl
 wRB
-toR
+hkO
 cKJ
 oXQ
 gNi
@@ -102488,7 +102520,7 @@ gOl
 byj
 rTe
 rTe
-ezg
+uSw
 gOl
 gOl
 cGL
@@ -102718,7 +102750,7 @@ sWL
 ori
 cdP
 qhM
-hMz
+lnQ
 uFr
 teu
 mpR
@@ -104103,12 +104135,12 @@ rDr
 bET
 rDr
 gOl
-qSc
+hMz
 qSc
 kcY
 kcY
 qSc
-qSc
+hMz
 gOl
 bas
 bas
@@ -104305,7 +104337,7 @@ rDr
 bET
 rDr
 gOl
-qSc
+ugn
 faL
 faL
 faL
@@ -155263,7 +155295,7 @@ xMN
 voC
 voC
 voC
-nRQ
+igy
 daH
 kcp
 daH
@@ -178955,7 +178987,7 @@ iBK
 acx
 fdp
 wLs
-hVa
+bkx
 ocA
 ocA
 ocA
@@ -180171,7 +180203,7 @@ ocA
 dtq
 cBH
 dhG
-byJ
+mIU
 dtq
 gTT
 dhG
@@ -194263,7 +194295,7 @@ daH
 iTz
 vUd
 daH
-gnk
+qnE
 iTz
 vUd
 nnH
@@ -194872,7 +194904,7 @@ daH
 apa
 iTz
 vUd
-csb
+raY
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2596,6 +2596,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/merc_guild)
+"byJ" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "byT" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/blocks,
@@ -3964,6 +3968,19 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
+"csb" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "csv" = (
 /obj/structure/closet/crate/crafted_closet,
 /obj/item/key/apartments/apartment3,
@@ -6501,20 +6518,6 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
-"dWS" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "dWX" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/whitewine,
@@ -7357,6 +7360,24 @@
 	},
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
+"ezg" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/obj/item/storage/belt/leather,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "ezn" = (
 /obj/structure/bed/wool,
 /obj/item/bedsheet/cloth,
@@ -7701,34 +7722,6 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/under/cavelava)
-"eMA" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "eME" = (
 /obj/machinery/light/fueled/torchholder{
 	pixel_y = 26
@@ -7844,6 +7837,34 @@
 "ePF" = (
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/tile,
+/area/rogue/indoors/town/manor)
+"ePK" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "ePY" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -8088,6 +8109,11 @@
 /obj/item/bedsheet/cloth,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"eXJ" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "eXK" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/fueled/torchholder{
@@ -8665,6 +8691,21 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
+"fri" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "frI" = (
 /obj/structure/fake_machine/atm,
 /turf/open/floor/carpet/royalblack,
@@ -9957,6 +9998,13 @@
 "gmY" = (
 /turf/open/floor/blocks,
 /area/rogue/outdoors/rtfield)
+"gnk" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "gnn" = (
 /mob/living/simple_animal/hostile/retaliate/spider,
 /turf/open/floor/greenstone,
@@ -10939,11 +10987,6 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"gSQ" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "gTi" = (
 /obj/machinery/light/fueled/wallfire/big_fireplace{
 	pixel_y = 32
@@ -11576,10 +11619,6 @@
 "hpa" = (
 /turf/closed/mineral,
 /area/rogue/outdoors/woods_safe)
-"hpp" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "hpq" = (
 /obj/structure/bed/shit,
 /obj/machinery/light/fueled/wallfire/candle{
@@ -11594,21 +11633,6 @@
 	},
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/town/merc_guild)
-"hpH" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "hpQ" = (
 /turf/open/floor/wood,
 /area/rogue/indoors/town/cell)
@@ -12168,11 +12192,6 @@
 /obj/structure/bed/bear,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"hIZ" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "hJg" = (
 /turf/open/floor/dirt/road,
 /area/rogue/under/cave)
@@ -12314,9 +12333,9 @@
 /turf/open/floor/blocks,
 /area/rogue/indoors/dungeon)
 "hMz" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
+/obj/structure/grindwheel,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "hMJ" = (
 /obj/machinery/light/fueled/firebowl/standing,
 /turf/open/floor/ruinedwood/spiral,
@@ -12594,6 +12613,20 @@
 /obj/item/paint_brush,
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"hVa" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "hVd" = (
 /turf/open/floor/rooftop{
 	dir = 4
@@ -12641,15 +12674,6 @@
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
-"hXB" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "hXL" = (
 /obj/structure/door/fancy{
 	name = "Hand's Chambers"
@@ -14932,6 +14956,13 @@
 /obj/item/key/atarms,
 /obj/item/key/atarms,
 /obj/item/key/atarms,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
+"jxl" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "jxo" = (
@@ -17235,19 +17266,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town/roofs)
-"kPt" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "kPu" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /obj/machinery/light/fueled/torchholder,
@@ -17327,7 +17345,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/structure/closet/crate/chest,
+/obj/machinery/tanningrack,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17789,6 +17807,15 @@
 /obj/item/clothing/pants/tights/black,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"lkd" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "lkq" = (
 /obj/structure/stairs{
 	dir = 1
@@ -19358,9 +19385,8 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -20744,6 +20770,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/greenstone,
 /area/rogue/under/town/sewer)
+"nhA" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "niE" = (
 /obj/structure/bed/wool,
 /obj/item/bedsheet/pelt,
@@ -21653,13 +21686,6 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/tavern)
-"nLz" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "nLC" = (
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/church)
@@ -21806,6 +21832,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
+"nRQ" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "nRZ" = (
 /turf/closed/mineral/random,
 /area/rogue/under/town/sewer)
@@ -24661,13 +24692,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/blocks,
 /area/rogue/under/dungeon)
-"pOj" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "pOn" = (
 /obj/item/key/houses/waterfront5{
 	lockid = "waterfront5";
@@ -25017,11 +25041,6 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/tile/bfloorz,
 /area/rogue/indoors/town/bath)
-"qah" = (
-/obj/structure/flora/grass/bush,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "qai" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
@@ -28372,12 +28391,6 @@
 	},
 /turf/open/floor/church,
 /area/rogue/indoors/town/clinic_large)
-"sme" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "smD" = (
 /turf/open/floor/blocks/paving,
 /area/rogue/under/town/basement)
@@ -30084,6 +30097,11 @@
 /obj/structure/roguerock,
 /turf/open/floor/naturalstone,
 /area/rogue/outdoors/river)
+"toR" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "tpa" = (
 /obj/machinery/light/fueled/wallfire/candle/blue{
 	pixel_y = -32
@@ -31640,10 +31658,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"ulJ" = (
-/obj/structure/grindwheel,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "ulQ" = (
 /obj/structure/bookcase/random/legends,
 /turf/open/floor/ruinedwood/spiral,
@@ -31914,6 +31928,10 @@
 /obj/machinery/light/fueled/torchholder/c,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"uxt" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "uxx" = (
 /obj/machinery/light/fueled/hearth,
 /obj/machinery/light/fueled/oven/east,
@@ -32178,24 +32196,6 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
-"uEm" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/obj/item/storage/belt/leather,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "uEn" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/fluff/walldeco/church/line,
@@ -95629,7 +95629,7 @@ iWy
 qTA
 iWy
 oDt
-hMz
+uxt
 gOl
 acs
 acs
@@ -96033,7 +96033,7 @@ jZn
 uie
 ckQ
 jZn
-kSd
+nhA
 gOl
 gqv
 acs
@@ -96437,7 +96437,7 @@ jZn
 xhJ
 iOP
 jZn
-nLz
+kSd
 gOl
 gqv
 acs
@@ -97432,9 +97432,9 @@ gOl
 srF
 vwo
 iPC
-eMA
-ulJ
-mso
+ePK
+iSJ
+jxl
 ofx
 jxg
 gOl
@@ -97638,7 +97638,7 @@ faL
 faL
 faL
 faL
-iSJ
+vwo
 gOl
 wMy
 bET
@@ -100058,9 +100058,9 @@ vgJ
 vgJ
 vgJ
 gOl
-gSQ
+eXJ
 ahA
-sme
+mso
 owl
 vwo
 gOl
@@ -100122,7 +100122,7 @@ mlm
 lfC
 kzd
 qLV
-hpH
+fri
 ylf
 elp
 elp
@@ -101334,7 +101334,7 @@ hsv
 oXQ
 cKJ
 qhM
-hXB
+lkd
 ehF
 fOL
 iSk
@@ -101937,7 +101937,7 @@ dsu
 lsl
 lsl
 wRB
-qah
+toR
 cKJ
 oXQ
 gNi
@@ -102488,7 +102488,7 @@ gOl
 byj
 rTe
 rTe
-uEm
+ezg
 gOl
 gOl
 cGL
@@ -102718,7 +102718,7 @@ sWL
 ori
 cdP
 qhM
-jdk
+hMz
 uFr
 teu
 mpR
@@ -155263,7 +155263,7 @@ xMN
 voC
 voC
 voC
-hIZ
+nRQ
 daH
 kcp
 daH
@@ -178955,7 +178955,7 @@ iBK
 acx
 fdp
 wLs
-dWS
+hVa
 ocA
 ocA
 ocA
@@ -180171,7 +180171,7 @@ ocA
 dtq
 cBH
 dhG
-hpp
+byJ
 dtq
 gTT
 dhG
@@ -194263,7 +194263,7 @@ daH
 iTz
 vUd
 daH
-pOj
+gnk
 iTz
 vUd
 nnH
@@ -194872,7 +194872,7 @@ daH
 apa
 iTz
 vUd
-kPt
+csb
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -4545,10 +4545,6 @@
 /obj/machinery/light/fueled/firebowl,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/river)
-"cNi" = (
-/obj/structure/grindwheel,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "cNl" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/essence_vial{
@@ -4571,12 +4567,6 @@
 	},
 /turf/open/floor/twig,
 /area/rogue/indoors/town)
-"cNv" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "cNG" = (
 /obj/machinery/light/fueled/torchholder{
 	dir = 4
@@ -6511,6 +6501,20 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
+"dWS" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "dWX" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/whitewine,
@@ -7697,6 +7701,34 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/under/cavelava)
+"eMA" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "eME" = (
 /obj/machinery/light/fueled/torchholder{
 	pixel_y = 26
@@ -9991,13 +10023,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"gpe" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "gpj" = (
 /obj/machinery/light/fueledstreet,
 /turf/open/floor/cobble,
@@ -10914,6 +10939,11 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"gSQ" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "gTi" = (
 /obj/machinery/light/fueled/wallfire/big_fireplace{
 	pixel_y = 32
@@ -11546,6 +11576,10 @@
 "hpa" = (
 /turf/closed/mineral,
 /area/rogue/outdoors/woods_safe)
+"hpp" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "hpq" = (
 /obj/structure/bed/shit,
 /obj/machinery/light/fueled/wallfire/candle{
@@ -11560,6 +11594,21 @@
 	},
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/town/merc_guild)
+"hpH" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "hpQ" = (
 /turf/open/floor/wood,
 /area/rogue/indoors/town/cell)
@@ -12119,6 +12168,11 @@
 /obj/structure/bed/bear,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"hIZ" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "hJg" = (
 /turf/open/floor/dirt/road,
 /area/rogue/under/cave)
@@ -12260,9 +12314,8 @@
 /turf/open/floor/blocks,
 /area/rogue/indoors/dungeon)
 "hMz" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "hMJ" = (
 /obj/machinery/light/fueled/firebowl/standing,
@@ -12588,6 +12641,15 @@
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
+"hXB" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "hXL" = (
 /obj/structure/door/fancy{
 	name = "Hand's Chambers"
@@ -13988,15 +14050,6 @@
 "iTT" = (
 /turf/closed/wall/mineral/decorstone,
 /area/rogue/outdoors/river)
-"iUl" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "iUu" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/cobble,
@@ -16064,20 +16117,6 @@
 /mob/living/carbon/human/species/rousman/npc,
 /turf/open/floor/cobble,
 /area/rogue/under/dungeon)
-"kgE" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "kgK" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -16842,21 +16881,6 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/garrison)
-"kCR" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "kDi" = (
 /turf/open/floor/rooftop,
 /area/rogue/indoors/town)
@@ -17211,6 +17235,19 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town/roofs)
+"kPt" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "kPu" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /obj/machinery/light/fueled/torchholder,
@@ -17947,10 +17984,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor/tile/masonic,
-/area/rogue/indoors/town/manor)
-"lqh" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "lqr" = (
 /turf/open/floor/herringbone,
@@ -21620,6 +21653,13 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/tavern)
+"nLz" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "nLC" = (
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/church)
@@ -22369,34 +22409,6 @@
 	},
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town)
-"olA" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "olI" = (
 /obj/structure/rotation_piece/cog,
 /turf/open/water/river{
@@ -24649,6 +24661,13 @@
 /obj/item/natural/stone,
 /turf/open/floor/blocks,
 /area/rogue/under/dungeon)
+"pOj" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "pOn" = (
 /obj/item/key/houses/waterfront5{
 	lockid = "waterfront5";
@@ -24998,6 +25017,11 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/tile/bfloorz,
 /area/rogue/indoors/town/bath)
+"qah" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "qai" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
@@ -25879,24 +25903,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/woods_safe)
-"qFt" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/obj/item/storage/belt/leather,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "qFU" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/paper/confession,
@@ -26474,11 +26480,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/river)
-"qWX" = (
-/obj/effect/landmark/start/vagrant,
-/obj/structure/flora/grass/bush,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "qXq" = (
 /obj/structure/noticeboard{
 	dir = 4;
@@ -28371,6 +28372,12 @@
 	},
 /turf/open/floor/church,
 /area/rogue/indoors/town/clinic_large)
+"sme" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "smD" = (
 /turf/open/floor/blocks/paving,
 /area/rogue/under/town/basement)
@@ -31633,6 +31640,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"ulJ" = (
+/obj/structure/grindwheel,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "ulQ" = (
 /obj/structure/bookcase/random/legends,
 /turf/open/floor/ruinedwood/spiral,
@@ -32167,6 +32178,24 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
+"uEm" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/obj/item/storage/belt/leather,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "uEn" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/fluff/walldeco/church/line,
@@ -32690,11 +32719,6 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/manor)
-"uUS" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "uUT" = (
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/woodturned,
@@ -32977,19 +33001,6 @@
 /obj/structure/plough,
 /turf/open/floor/cobble/mossy,
 /area/rogue/outdoors/rtfield/safe)
-"veW" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "vfc" = (
 /obj/structure/flora/grass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -33755,10 +33766,6 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/ruinedwood,
 /area/rogue/indoors/town/magician)
-"vIl" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "vJa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35621,13 +35628,6 @@
 "wTF" = (
 /turf/open/floor/dirt,
 /area/rogue/under/cave)
-"wTY" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "wUm" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/cobble,
@@ -95629,7 +95629,7 @@ iWy
 qTA
 iWy
 oDt
-lqh
+hMz
 gOl
 acs
 acs
@@ -96437,7 +96437,7 @@ jZn
 xhJ
 iOP
 jZn
-gpe
+nLz
 gOl
 gqv
 acs
@@ -97432,8 +97432,8 @@ gOl
 srF
 vwo
 iPC
-olA
-cNi
+eMA
+ulJ
 mso
 ofx
 jxg
@@ -100058,9 +100058,9 @@ vgJ
 vgJ
 vgJ
 gOl
-hMz
+gSQ
 ahA
-cNv
+sme
 owl
 vwo
 gOl
@@ -100122,7 +100122,7 @@ mlm
 lfC
 kzd
 qLV
-kCR
+hpH
 ylf
 elp
 elp
@@ -101334,7 +101334,7 @@ hsv
 oXQ
 cKJ
 qhM
-iUl
+hXB
 ehF
 fOL
 iSk
@@ -101937,7 +101937,7 @@ dsu
 lsl
 lsl
 wRB
-qWX
+qah
 cKJ
 oXQ
 gNi
@@ -102488,7 +102488,7 @@ gOl
 byj
 rTe
 rTe
-qFt
+uEm
 gOl
 gOl
 cGL
@@ -155263,7 +155263,7 @@ xMN
 voC
 voC
 voC
-uUS
+hIZ
 daH
 kcp
 daH
@@ -178955,7 +178955,7 @@ iBK
 acx
 fdp
 wLs
-kgE
+dWS
 ocA
 ocA
 ocA
@@ -180171,7 +180171,7 @@ ocA
 dtq
 cBH
 dhG
-vIl
+hpp
 dtq
 gTT
 dhG
@@ -194263,7 +194263,7 @@ daH
 iTz
 vUd
 daH
-wTY
+pOj
 iTz
 vUd
 nnH
@@ -194872,7 +194872,7 @@ daH
 apa
 iTz
 vUd
-veW
+kPt
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -4887,19 +4887,6 @@
 "cZn" = (
 /turf/closed/wall/mineral/roofwall/innercorner,
 /area/rogue/indoors/town)
-"cZz" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "cZG" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/paper,
@@ -6566,34 +6553,6 @@
 /obj/structure/bars/bent,
 /turf/open/floor/carpet/green,
 /area/rogue/indoors/town/merc_guild)
-"dYy" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "dYD" = (
 /obj/machinery/light/fueled/chand,
 /turf/open/transparent/openspace,
@@ -7639,6 +7598,13 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/butchershop)
+"eJI" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "eJJ" = (
 /obj/structure/table/wood/counter{
 	dir = 1
@@ -10772,10 +10738,6 @@
 /obj/structure/fluff/telescope,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/town/roofs)
-"gMT" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "gNi" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/flora/grass,
@@ -14879,11 +14841,6 @@
 	},
 /turf/open/floor/twig,
 /area/rogue/outdoors/rtfield/safe)
-"jvm" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "jvH" = (
 /turf/open/floor/metal/alt,
 /area/rogue/outdoors/town)
@@ -17296,7 +17253,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/structure/closet/crate/chest,
+/obj/machinery/tanningrack,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -19326,8 +19283,9 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -20274,6 +20232,23 @@
 /obj/structure/flora/grass,
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/town)
+"mUQ" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "mVc" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -21508,6 +21483,21 @@
 /obj/machinery/light/fueled/wallfire/candle/blue/r,
 /turf/open/floor/greenstone,
 /area/rogue/indoors/town/magician)
+"nHU" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "nHZ" = (
 /obj/machinery/light/fueled/firebowl/standing,
 /turf/open/floor/dirt/road,
@@ -24947,6 +24937,13 @@
 /obj/effect/mapping_helpers/access/keyset/town/inn,
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/tavern)
+"pYO" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "pYQ" = (
 /obj/structure/window/openclose{
 	dir = 4
@@ -25234,6 +25231,19 @@
 	},
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
+"qko" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "qkT" = (
 /obj/structure/bars/passage/shutter/open{
 	redstone_id = "nite_shutter"
@@ -25376,13 +25386,34 @@
 	},
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
-"qpf" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+"qpe" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "qpi" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/whitewine,
@@ -25965,21 +25996,6 @@
 	},
 /turf/open/floor/cobble/alt,
 /area/rogue/under/town/sewer)
-"qJC" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "qKb" = (
 /obj/structure/fluff/railing/wood,
 /obj/effect/landmark/start/vagrant,
@@ -26476,6 +26492,10 @@
 /obj/item/ore/iron,
 /turf/open/floor/naturalstone,
 /area/rogue/under/town/sewer)
+"qXT" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "qYb" = (
 /obj/structure/well/climb_up,
 /turf/open/water/cleanshallow,
@@ -26689,6 +26709,11 @@
 /obj/item/reagent_containers/food/snacks/meat/sausage,
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /turf/open/floor/hexstone,
+/area/rogue/indoors/town/church)
+"rhm" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/church)
 "rhv" = (
 /obj/structure/fluff/railing/border,
@@ -28582,22 +28607,6 @@
 "stI" = (
 /turf/open/floor/blocks,
 /area/rogue/outdoors/river)
-"stW" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "stX" = (
 /obj/machinery/light/fueled/wallfire/candle/l{
 	pixel_x = 0;
@@ -29384,13 +29393,6 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/concrete,
 /area/rogue/indoors/town/shop)
-"sSP" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "sSR" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/blocks,
@@ -31765,13 +31767,6 @@
 "uqG" = (
 /turf/open/floor/metal/barograte,
 /area/rogue/indoors/town/warehouse)
-"uqO" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "urr" = (
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
@@ -33209,6 +33204,12 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
+"vpU" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "vqk" = (
 /obj/structure/flora/grass/water,
 /turf/open/floor/naturalstone,
@@ -95593,7 +95594,7 @@ iWy
 qTA
 iWy
 oDt
-gMT
+qXT
 gOl
 acs
 acs
@@ -95997,7 +95998,7 @@ jZn
 uie
 ckQ
 jZn
-kSd
+pYO
 gOl
 gqv
 acs
@@ -96401,7 +96402,7 @@ jZn
 xhJ
 iOP
 jZn
-sSP
+kSd
 gOl
 gqv
 acs
@@ -97396,9 +97397,9 @@ gOl
 srF
 vwo
 iPC
-dYy
+qpe
 iSJ
-uqO
+mso
 ofx
 jxg
 gOl
@@ -100024,7 +100025,7 @@ vgJ
 gOl
 tpL
 ahA
-mso
+vpU
 owl
 vwo
 gOl
@@ -100086,7 +100087,7 @@ mlm
 lfC
 kzd
 qLV
-qJC
+nHU
 ylf
 elp
 elp
@@ -102452,7 +102453,7 @@ gOl
 byj
 rTe
 rTe
-stW
+mUQ
 gOl
 gOl
 cGL
@@ -155227,7 +155228,7 @@ xMN
 voC
 voC
 voC
-jvm
+rhm
 daH
 kcp
 daH
@@ -194227,7 +194228,7 @@ daH
 iTz
 vUd
 daH
-qpf
+eJI
 iTz
 vUd
 nnH
@@ -194836,7 +194837,7 @@ daH
 apa
 iTz
 vUd
-cZz
+qko
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2175,20 +2175,6 @@
 "bkg" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/cell)
-"bkx" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "bkH" = (
 /obj/structure/table/wood/large/corner{
 	dir = 1
@@ -2708,6 +2694,10 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"bCa" = (
+/obj/structure/table/wood/plain_alt,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "bCi" = (
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/church)
@@ -3643,11 +3633,6 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/river)
-"chk" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "chp" = (
 /obj/structure/flora/grass,
 /turf/open/floor/grass,
@@ -3862,6 +3847,10 @@
 	},
 /turf/open/floor/dirt,
 /area/rogue/outdoors/rtfield/safe)
+"cnz" = (
+/obj/structure/grindwheel,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "cnG" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/fueled/wallfire/candle,
@@ -5997,6 +5986,13 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/cobblerock,
 /area/rogue/indoors/town/merc_guild)
+"dKL" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "dKM" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -6136,21 +6132,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/garrison)
-"dNG" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "dNI" = (
 /obj/structure/table/wood/large/corner{
 	dir = 10
@@ -9204,6 +9185,11 @@
 /obj/machinery/light/fueled/hearth,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
+"fKq" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "fKD" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/orphanage)
@@ -9362,6 +9348,10 @@
 	},
 /obj/effect/spawner/map_spawner/loot/food{
 	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/bottle/beer{
+	pixel_x = -5;
 	pixel_y = 11
 	},
 /turf/open/floor/ruinedwood/spiralfade,
@@ -10732,6 +10722,10 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/villagegarrison)
+"gLs" = (
+/obj/structure/bookcase/random/myths,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "gLw" = (
 /obj/machinery/light/fueled/wallfire/candle/blue{
 	pixel_y = -32
@@ -11463,11 +11457,6 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/church,
 /area/rogue/indoors/town/church)
-"hkO" = (
-/obj/structure/flora/grass/bush,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "hkX" = (
 /obj/structure/lever/hidden/keep{
 	redstone_id = 615
@@ -11951,6 +11940,10 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
+"hCy" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "hCB" = (
 /obj/structure/fake_machine/drugmachine,
 /turf/open/floor/blocks/stonered,
@@ -12287,8 +12280,22 @@
 /turf/open/floor/blocks,
 /area/rogue/indoors/dungeon)
 "hMz" = (
-/obj/structure/bookcase/random/myths,
-/turf/open/floor/woodturned/nosmooth,
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/obj/item/storage/belt/leather,
+/turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/manor)
 "hMJ" = (
 /obj/machinery/light/fueled/firebowl/standing,
@@ -12660,6 +12667,21 @@
 /obj/structure/bookcase/random/myths,
 /turf/open/floor/greenstone,
 /area/rogue/under/town/basement)
+"hYY" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "hZc" = (
 /obj/structure/table/wood/plain/alt,
 /turf/open/floor/churchmarble,
@@ -12862,11 +12884,6 @@
 	},
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/dwarfin)
-"igy" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "igz" = (
 /mob/living/simple_animal/hostile/retaliate/spider,
 /turf/open/water/sewer,
@@ -13396,6 +13413,13 @@
 /obj/structure/toilet,
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
+"izF" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "izM" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = 32;
@@ -14005,6 +14029,7 @@
 	pixel_y = 0
 	},
 /obj/machinery/light/fueled/wallfire/candle/blue/l,
+/obj/item/natural/poo,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/shop)
 "iTz" = (
@@ -16968,6 +16993,34 @@
 	},
 /turf/open/floor/cobble,
 /area/rogue/under/town/caverogue)
+"kHe" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "kHj" = (
 /obj/structure/flora/grass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -17290,7 +17343,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/structure/closet/crate/chest,
+/obj/machinery/tanningrack,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17758,6 +17811,11 @@
 	},
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
+"lkA" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "lkB" = (
 /obj/effect/decal/cobblerockedge/alt{
 	dir = 4
@@ -17874,10 +17932,6 @@
 "lnG" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/magician)
-"lnQ" = (
-/obj/structure/grindwheel,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "lob" = (
 /obj/structure/table/wood/large/corner{
 	dir = 10
@@ -19329,9 +19383,8 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -19872,10 +19925,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/churchrough,
 /area/rogue/under/town/sewer)
-"mIU" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "mJb" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/ruinedwood/darker,
@@ -20301,15 +20350,6 @@
 "mVj" = (
 /turf/open/floor/tile,
 /area/rogue/indoors/town/church)
-"mVk" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "mVv" = (
 /obj/structure/bed/inn,
 /obj/item/bedsheet/wool,
@@ -25265,6 +25305,15 @@
 	},
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"qkV" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "qlb" = (
 /obj/structure/roguerock,
 /turf/open/water,
@@ -25325,13 +25374,6 @@
 "qny" = (
 /turf/open/floor/greenstone/glyph5,
 /area/rogue/indoors/town/vault)
-"qnE" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "qnH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -26084,6 +26126,13 @@
 "qOm" = (
 /turf/open/floor/wood,
 /area/rogue/indoors/town/church/chapel)
+"qOq" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "qOK" = (
 /obj/machinery/light/fueled/chand,
 /turf/open/transparent/openspace,
@@ -26421,6 +26470,20 @@
 "qWa" = (
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
+"qWc" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "qWj" = (
 /obj/structure/flora/grass/bush/wall/tall{
 	pixel_x = -8
@@ -26538,19 +26601,6 @@
 	dir = 8
 	},
 /area/rogue/under/town/caverogue)
-"raY" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "rbe" = (
 /obj/structure/fluff/walldeco/painting/castle,
 /turf/closed/wall/mineral/stone/moss,
@@ -27011,10 +27061,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town)
-"rrD" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "rrL" = (
 /turf/open/floor/metal/barograte,
 /area/rogue/indoors/town)
@@ -27937,34 +27983,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/soilsons)
-"rWq" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "rWI" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/dirt,
@@ -28038,12 +28056,6 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"sal" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "sap" = (
 /obj/item/bin/water,
 /turf/open/floor/blocks/paving,
@@ -28267,6 +28279,11 @@
 /obj/effect/landmark/start/gaffer_assistant,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/merc_guild)
+"sik" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "siz" = (
 /obj/structure/closet/crate/crafted_closet/dark,
 /obj/item/book/law,
@@ -31077,6 +31094,10 @@
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
+"tQx" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "tQB" = (
 /obj/structure/window/solid,
 /turf/open/floor/ruinedwood/spiral,
@@ -31527,10 +31548,6 @@
 	},
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/magician)
-"ugn" = (
-/obj/structure/table/wood/plain_alt,
-/turf/open/floor/woodturned/nosmooth,
-/area/rogue/indoors/town/manor)
 "ugP" = (
 /obj/structure/table/wood/crafted,
 /obj/item/reagent_containers/glass/bowl,
@@ -32651,24 +32668,6 @@
 	dir = 1
 	},
 /area/rogue/under/town/caverogue)
-"uSw" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/obj/item/storage/belt/leather,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "uSF" = (
 /obj/structure/roguerock{
 	icon_state = "rock3"
@@ -34080,6 +34079,19 @@
 	},
 /turf/open/floor/ruinedwood/chevron,
 /area/rogue/indoors/town/orphanage)
+"vTe" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "vTy" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -37202,13 +37214,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/concrete,
 /area/rogue/indoors/town/shop)
-"xWv" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "xWS" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /obj/machinery/light/fueled/torchholder,
@@ -95661,7 +95666,7 @@ iWy
 qTA
 iWy
 oDt
-rrD
+tQx
 gOl
 acs
 acs
@@ -96065,7 +96070,7 @@ jZn
 uie
 ckQ
 jZn
-kSd
+qOq
 gOl
 gqv
 acs
@@ -96469,7 +96474,7 @@ jZn
 xhJ
 iOP
 jZn
-xWv
+kSd
 gOl
 gqv
 acs
@@ -97464,9 +97469,9 @@ gOl
 srF
 vwo
 iPC
-rWq
+kHe
 iSJ
-mso
+izF
 ofx
 jxg
 gOl
@@ -100090,9 +100095,9 @@ vgJ
 vgJ
 vgJ
 gOl
-chk
+sik
 ahA
-sal
+mso
 owl
 vwo
 gOl
@@ -100154,7 +100159,7 @@ mlm
 lfC
 kzd
 qLV
-dNG
+hYY
 ylf
 elp
 elp
@@ -101366,7 +101371,7 @@ hsv
 oXQ
 cKJ
 qhM
-mVk
+qkV
 ehF
 fOL
 iSk
@@ -101969,7 +101974,7 @@ dsu
 lsl
 lsl
 wRB
-hkO
+fKq
 cKJ
 oXQ
 gNi
@@ -102520,7 +102525,7 @@ gOl
 byj
 rTe
 rTe
-uSw
+hMz
 gOl
 gOl
 cGL
@@ -102750,7 +102755,7 @@ sWL
 ori
 cdP
 qhM
-lnQ
+cnz
 uFr
 teu
 mpR
@@ -104135,12 +104140,12 @@ rDr
 bET
 rDr
 gOl
-hMz
+gLs
 qSc
 kcY
 kcY
 qSc
-hMz
+gLs
 gOl
 bas
 bas
@@ -104337,7 +104342,7 @@ rDr
 bET
 rDr
 gOl
-ugn
+bCa
 faL
 faL
 faL
@@ -155295,7 +155300,7 @@ xMN
 voC
 voC
 voC
-igy
+lkA
 daH
 kcp
 daH
@@ -178987,7 +178992,7 @@ iBK
 acx
 fdp
 wLs
-bkx
+qWc
 ocA
 ocA
 ocA
@@ -180203,7 +180208,7 @@ ocA
 dtq
 cBH
 dhG
-mIU
+hCy
 dtq
 gTT
 dhG
@@ -194295,7 +194300,7 @@ daH
 iTz
 vUd
 daH
-qnE
+dKL
 iTz
 vUd
 nnH
@@ -194904,7 +194909,7 @@ daH
 apa
 iTz
 vUd
-raY
+vTe
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2277,6 +2277,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"bom" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "box" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/cobble,
@@ -2877,6 +2884,21 @@
 	},
 /turf/open/floor/naturalstone,
 /area/rogue/under/town/sewer)
+"bHI" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "bIc" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/ore/copper,
@@ -3089,6 +3111,8 @@
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
+/obj/item/reagent_containers/food/snacks/produce/grain/wheat,
+/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
@@ -4297,6 +4321,22 @@
 /obj/machinery/light/fueled/torchholder,
 /turf/open/floor/cobble,
 /area/rogue/indoors/villagegarrison)
+"cEQ" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "cFp" = (
 /obj/structure/table/wood/plain/alt,
 /obj/item/clothing/face/druid,
@@ -4758,6 +4798,12 @@
 /area/rogue/under/town/basement)
 "cUs" = (
 /obj/structure/rack/shelf/biggest,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/smithy)
 "cUv" = (
@@ -4881,6 +4927,13 @@
 /area/rogue/indoors/town)
 "cZG" = (
 /obj/structure/table/wood/plain_alt,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
 /turf/open/floor/tile,
 /area/rogue/indoors/town/clinic_large)
 "cZU" = (
@@ -6012,6 +6065,7 @@
 /obj/item/clothing/shirt/robe/phys,
 /obj/item/clothing/shirt/robe/phys,
 /obj/item/clothing/shirt/robe/phys,
+/obj/item/clothing/neck/psycross/silver/pestra,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "dLL" = (
@@ -6588,6 +6642,19 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"eal" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "ean" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/greenstone,
@@ -8602,6 +8669,7 @@
 "frh" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/storage/belt/pouch/coins/poor,
+/obj/item/key/courtphys,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
 "frI" = (
@@ -9586,6 +9654,7 @@
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/structure/closet/crate/chest,
+/obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/church)
 "gcl" = (
@@ -9640,11 +9709,21 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
-/obj/item/clothing/neck/psycross/silver/astrata,
-/obj/item/clothing/neck/psycross/silver/ravox,
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
+/obj/item/clothing/neck/psycross/silver/dendor,
+/obj/item/clothing/neck/psycross/silver/dendor,
+/obj/item/clothing/neck/psycross/silver/dendor,
+/obj/item/clothing/neck/psycross/silver/xylix,
+/obj/item/clothing/neck/psycross/silver/xylix,
+/obj/item/clothing/neck/psycross/silver/xylix,
+/obj/item/clothing/neck/psycross/silver/ravox,
+/obj/item/clothing/neck/psycross/silver/ravox,
+/obj/item/clothing/neck/psycross/silver/ravox,
+/obj/item/clothing/neck/psycross/silver/malum_steel,
+/obj/item/clothing/neck/psycross/silver/malum_steel,
+/obj/item/clothing/neck/psycross/silver/malum_steel,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "gdZ" = (
@@ -11351,16 +11430,19 @@
 /turf/closed/wall/mineral/stone/window,
 /area/rogue/indoors/town/shop)
 "hiK" = (
-/obj/structure/rack,
-/obj/item/clothing/neck/psycross/silver/eora,
-/obj/item/clothing/neck/psycross/silver/malum_steel,
-/obj/item/clothing/neck/psycross/silver/pestra,
-/obj/item/clothing/neck/psycross/silver/xylix,
-/obj/item/clothing/neck/psycross/noc,
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/shirt/robe/necra,
+/obj/item/clothing/shirt/robe/necra,
+/obj/item/clothing/shirt/robe/necra,
+/obj/item/clothing/head/padded/deathshroud,
+/obj/item/clothing/head/padded/deathshroud,
+/obj/item/clothing/head/padded/deathshroud,
+/obj/item/clothing/neck/psycross/silver/necra,
+/obj/item/clothing/neck/psycross/silver/necra,
+/obj/item/clothing/neck/psycross/silver/necra,
+/obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "hjh" = (
@@ -11917,6 +11999,8 @@
 /area/rogue/under/dungeon)
 "hDm" = (
 /obj/structure/closet/crate/crafted_closet,
+/obj/item/key/merchant,
+/obj/item/key/merchant,
 /turf/open/floor/wood/nosmooth,
 /area/rogue/indoors/town/shop)
 "hEs" = (
@@ -12894,6 +12978,10 @@
 	},
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/under/town/basement)
+"ikF" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "ikG" = (
 /turf/open/floor/hexstone,
 /area/rogue/indoors/villagegarrison)
@@ -13930,8 +14018,6 @@
 /obj/structure/rack/shelf/big{
 	pixel_y = 0
 	},
-/obj/item/key/merchant,
-/obj/item/key/merchant,
 /obj/machinery/light/fueled/wallfire/candle/blue/l,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/shop)
@@ -14058,6 +14144,8 @@
 /obj/item/reagent_containers/food/snacks/truffles,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
+/obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
+/obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "iWK" = (
@@ -14825,6 +14913,8 @@
 /obj/structure/closet/crate/chest,
 /obj/item/key/atarms,
 /obj/item/key/atarms,
+/obj/item/key/atarms,
+/obj/item/key/atarms,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "jxo" = (
@@ -14888,6 +14978,8 @@
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
+/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
+/obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /turf/open/floor/tile/kitchen,
 /area/rogue/indoors/town/tavern)
@@ -16605,6 +16697,9 @@
 /obj/item/clothing/head/roguehood/astrata,
 /obj/item/clothing/head/roguehood/astrata,
 /obj/item/clothing/head/roguehood/astrata,
+/obj/item/clothing/neck/psycross/silver/astrata,
+/obj/item/clothing/neck/psycross/silver/astrata,
+/obj/item/clothing/neck/psycross/silver/astrata,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "kyS" = (
@@ -16992,6 +17087,13 @@
 /area/rogue/indoors/town)
 "kLc" = (
 /obj/structure/table/wood/crafted,
+/obj/item/reagent_containers/glass/bottle/water{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/bottle{
+	pixel_x = 6
+	},
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/manor)
 "kLl" = (
@@ -17415,6 +17517,7 @@
 /obj/machinery/light/fueled/wallfire/candle/l{
 	pixel_x = 32
 	},
+/obj/item/storage/belt/pouch,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/town/manor)
 "kZN" = (
@@ -19227,6 +19330,7 @@
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
 /obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -19835,6 +19939,8 @@
 /obj/item/weapon/sword/rapier/dec,
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /obj/item/ammo_holder/quiver/bolts,
+/obj/item/clothing/armor/leather/jacket/handjacket,
+/obj/item/clothing/cloak/raincloak/purple,
 /turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/manor)
 "mKJ" = (
@@ -20757,6 +20863,7 @@
 /obj/item/clothing/head/roguehood/eora,
 /obj/item/clothing/head/roguehood/eora,
 /obj/item/clothing/head/roguehood/eora,
+/obj/item/clothing/neck/psycross/silver/eora,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "nnK" = (
@@ -20996,6 +21103,13 @@
 /obj/item/reagent_containers/food/snacks/meat/salami,
 /obj/item/reagent_containers/food/snacks/bread,
 /obj/machinery/light/fueled/wallfire/candle/blue/r,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "nxE" = (
@@ -22037,6 +22151,8 @@
 	pixel_y = 0
 	},
 /obj/item/clothing/shoes/boots/leather,
+/obj/item/clothing/shoes/boots/leather,
+/obj/item/clothing/shoes/boots/leather,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "ofH" = (
@@ -22680,6 +22796,12 @@
 /area/rogue/indoors/town/manor)
 "oyt" = (
 /obj/structure/rack,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather,
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/smithy)
 "oyv" = (
@@ -23747,6 +23869,9 @@
 /obj/item/clothing/pants/tights/black,
 /obj/item/clothing/shirt/undershirt/fancy,
 /obj/machinery/light/fueled/wallfire/candle/blue,
+/obj/item/clothing/shirt/tunic/green,
+/obj/item/clothing/gloves/leather/phys,
+/obj/item/clothing/face/spectacles/golden,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "pnc" = (
@@ -24892,6 +25017,11 @@
 /obj/effect/mapping_helpers/access/keyset/manor/general,
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
+"qbc" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "qbm" = (
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/carpet/royalblack,
@@ -25222,7 +25352,10 @@
 /turf/open/floor/metal/alt,
 /area/rogue/indoors/town/magician)
 "qom" = (
-/obj/structure/bookcase/random/myths,
+/obj/structure/rack,
+/obj/item/weapon/polearm/woodstaff/quarterstaff,
+/obj/item/weapon/polearm/woodstaff/quarterstaff,
+/obj/item/weapon/polearm/woodstaff/quarterstaff,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "qox" = (
@@ -25868,14 +26001,15 @@
 /area/rogue/indoors/soilsons)
 "qLV" = (
 /obj/structure/flora/grass,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
 /obj/structure/fake_machine/scomm{
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/structure/flora/grass/bush,
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = 7
+	},
 /turf/open/floor/grass,
 /area/rogue/outdoors/town)
 "qMe" = (
@@ -25959,6 +26093,9 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
+/obj/item/lockpick,
+/obj/item/lockpick,
+/obj/item/lockpick,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "qPq" = (
@@ -25974,6 +26111,9 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/item/key/church,
+/obj/item/key/church,
+/obj/item/key/church,
 /turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/church)
 "qPt" = (
@@ -30675,8 +30815,8 @@
 /turf/open/floor/twig,
 /area/rogue/under/town/basement)
 "tMz" = (
-/obj/structure/chair/wood/alt,
 /obj/machinery/light/fueled/wallfire/candle,
+/obj/structure/bookcase/random/myths,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "tMD" = (
@@ -30916,6 +31056,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/fueled/wallfire/candle/r,
+/obj/item/key/warehouse,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/steward)
 "tSr" = (
@@ -31794,6 +31935,13 @@
 	},
 /turf/open/floor/cobble,
 /area/rogue/outdoors/town)
+"uzq" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "uzB" = (
 /obj/effect/spawner/map_spawner/hauntz_random,
 /turf/open/floor/ruinedwood/turned,
@@ -34315,6 +34463,7 @@
 "wjt" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
 /obj/item/clothing/shoes/boots/leather,
+/obj/item/clothing/shoes/boots/leather,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "wjy" = (
@@ -34339,6 +34488,9 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
 	},
+/obj/item/clothing/neck/psycross/noc,
+/obj/item/clothing/neck/psycross/noc,
+/obj/item/clothing/neck/psycross/noc,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/church)
 "wjJ" = (
@@ -35465,6 +35617,7 @@
 	dir = 10;
 	icon_state = "largetable"
 	},
+/obj/item/storage/sack,
 /turf/open/floor/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
 "wXr" = (
@@ -35797,6 +35950,13 @@
 /obj/structure/fake_machine/mail/r,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town/theatre)
+"xgD" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "xgK" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -35859,6 +36019,34 @@
 	dir = 9
 	},
 /turf/open/floor/tile/masonic,
+/area/rogue/indoors/town/manor)
+"xis" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "xiD" = (
 /obj/structure/closet/crate/drawer{
@@ -64544,7 +64732,7 @@ vgJ
 vgJ
 vgJ
 oJY
-gCP
+rDj
 gCP
 oOv
 vJz
@@ -95402,7 +95590,7 @@ iWy
 qTA
 iWy
 oDt
-hZm
+ikF
 gOl
 acs
 acs
@@ -95806,7 +95994,7 @@ jZn
 uie
 ckQ
 jZn
-kSd
+bom
 gOl
 gqv
 acs
@@ -97205,9 +97393,9 @@ gOl
 srF
 vwo
 iPC
-tpL
+xis
 iSJ
-mso
+xgD
 ofx
 jxg
 gOl
@@ -99895,7 +100083,7 @@ mlm
 lfC
 kzd
 qLV
-kzd
+bHI
 ylf
 elp
 elp
@@ -102261,7 +102449,7 @@ gOl
 byj
 rTe
 rTe
-gOl
+cEQ
 gOl
 gOl
 cGL
@@ -155036,7 +155224,7 @@ xMN
 voC
 voC
 voC
-cnf
+qbc
 daH
 kcp
 daH
@@ -194036,7 +194224,7 @@ daH
 iTz
 vUd
 daH
-vzL
+uzq
 iTz
 vUd
 nnH
@@ -194645,7 +194833,7 @@ daH
 apa
 iTz
 vUd
-knk
+eal
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2211,6 +2211,20 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/ruinedwood,
 /area/rogue/indoors/town)
+"blJ" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "blT" = (
 /obj/structure/fake_machine/scomm,
 /obj/structure/table/wood/plain_alt,
@@ -3269,6 +3283,11 @@
 /obj/machinery/light/fueledstreet,
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town)
+"bUP" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "bVe" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/fueled/wallfire/candle{
@@ -3936,6 +3955,34 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"cqI" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "cqY" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/item/clothing/face/shepherd/clothmask,
@@ -4632,12 +4679,6 @@
 /obj/structure/flora/grass/bush_meagre,
 /turf/open/floor/cobble/mossy,
 /area/rogue/outdoors/town)
-"cOS" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "cOT" = (
 /obj/structure/door{
 	name = "Storage"
@@ -4766,6 +4807,11 @@
 /area/rogue/under/town/basement)
 "cUs" = (
 /obj/structure/rack/shelf/biggest,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
 /obj/item/paper,
 /obj/item/paper,
 /obj/item/paper,
@@ -5758,10 +5804,6 @@
 /obj/structure/fake_machine/mail,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/town/merc_guild)
-"dDA" = (
-/obj/machinery/light/fueled/oven,
-/turf/closed/wall/mineral/craftstone,
-/area/rogue/indoors/town/merc_guild)
 "dDB" = (
 /obj/machinery/light/fueled/firebowl/stump,
 /turf/open/floor/dirt,
@@ -6614,6 +6656,19 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"eam" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "ean" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/greenstone,
@@ -8426,6 +8481,11 @@
 "fkZ" = (
 /turf/closed/mineral/bedrock,
 /area/rogue/under/town/caverogue)
+"flv" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "flF" = (
 /obj/effect/landmark/start/shepherd{
 	dir = 1
@@ -9285,6 +9345,10 @@
 "fNY" = (
 /turf/open/floor/dirt,
 /area/rogue/outdoors/town/roofs)
+"fOs" = (
+/obj/structure/grindwheel,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "fOt" = (
 /obj/structure/chair/wood/alt{
 	dir = 8
@@ -10349,10 +10413,6 @@
 /obj/structure/fake_machine/scomm/l,
 /turf/open/floor/ruinedwood,
 /area/rogue/indoors/town/church)
-"gAD" = (
-/obj/structure/table/wood/plain_alt,
-/turf/open/floor/woodturned/nosmooth,
-/area/rogue/indoors/town/manor)
 "gAQ" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = 32;
@@ -11760,6 +11820,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
+"hxA" = (
+/obj/structure/bookcase/random/myths,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "hxF" = (
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/dirt/road,
@@ -12454,6 +12518,10 @@
 "hRL" = (
 /turf/closed/wall/mineral/stone/moss,
 /area/rogue/under/cave)
+"hRU" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "hRX" = (
 /obj/structure/table/vtable,
 /obj/item/toy/cards/deck{
@@ -12835,20 +12903,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/rogue/indoors/town/steward)
-"ieN" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "iff" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = -32;
@@ -13647,10 +13701,6 @@
 	},
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/church)
-"iGX" = (
-/obj/structure/grindwheel,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "iHf" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -15792,6 +15842,12 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/under/town/sewer)
+"jYv" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "jYA" = (
 /turf/open/water/river{
 	dir = 8
@@ -16988,6 +17044,10 @@
 /obj/item/book/cardgame,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
+"kHw" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "kHz" = (
 /turf/closed/wall/mineral/wooddark,
 /area/rogue/under/town/basement)
@@ -17297,7 +17357,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/structure/closet/crate/chest,
+/obj/machinery/tanningrack,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17785,6 +17845,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"lkW" = (
+/obj/machinery/light/fueled/oven,
+/turf/closed/wall/mineral/craftstone,
+/area/rogue/indoors/town/merc_guild)
 "lli" = (
 /obj/structure/fluff/walldeco/vinez,
 /turf/closed/wall/mineral/stonebrick,
@@ -17843,19 +17907,6 @@
 /obj/structure/minecart_rail,
 /turf/open/floor/naturalstone,
 /area/rogue/under/cave)
-"lmL" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "lmW" = (
 /obj/effect/landmark/bounty_location{
 	location_name = "End of the Cargo Docks";
@@ -20560,6 +20611,10 @@
 "nbe" = (
 /turf/open/floor/cobblerock,
 /area/rogue/under/cave)
+"nbl" = (
+/obj/structure/table/wood/plain_alt,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "ncv" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -20960,13 +21015,6 @@
 	},
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town)
-"nqB" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "nqJ" = (
 /obj/item/needle/thorn,
 /turf/open/floor/dirt,
@@ -21102,34 +21150,6 @@
 /obj/item/bin/water,
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/church/chapel)
-"nwI" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "nxh" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -22855,6 +22875,11 @@
 /obj/item/paper,
 /obj/item/paper,
 /obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
 /obj/item/natural/feather,
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/smithy)
@@ -23929,11 +23954,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/garrison)
-"png" = (
-/obj/structure/flora/grass/bush,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "pns" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -24389,10 +24409,6 @@
 	},
 /turf/open/floor/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
-"pDF" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "pDW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -24400,13 +24416,6 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/river)
-"pDY" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "pEm" = (
 /obj/machinery/light/fueled/lanternpost/fixed{
 	pixel_x = -5;
@@ -24765,6 +24774,11 @@
 	},
 /turf/open/floor/metal/alt,
 /area/rogue/outdoors/town)
+"pQz" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "pQE" = (
 /obj/machinery/light/fueled/lanternpost/fixed{
 	pixel_x = -2
@@ -26431,11 +26445,6 @@
 /obj/structure/fluff/walldeco/vinez,
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/cell)
-"qUX" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "qVh" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/cobble,
@@ -26591,6 +26600,13 @@
 /obj/structure/fluff/walldeco/painting/castle,
 /turf/closed/wall/mineral/stone/moss,
 /area/rogue/under/town/basement)
+"rbu" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "rbP" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/shop)
@@ -31357,11 +31373,6 @@
 /obj/structure/bed/shit,
 /turf/open/floor/twig,
 /area/rogue/indoors/butchershop)
-"ubA" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "ubD" = (
 /obj/structure/table/vtable/v2,
 /obj/item/toy/cards/deck/syndicate{
@@ -31511,6 +31522,15 @@
 /obj/structure/dock_bell,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/outdoors/river)
+"ufN" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "ufS" = (
 /obj/structure/table/wood/plain,
 /obj/item/candle/yellow/lit{
@@ -31784,10 +31804,6 @@
 /obj/structure/minecart_rail,
 /turf/open/floor/naturalstone,
 /area/rogue/outdoors/town)
-"upm" = (
-/obj/structure/bookcase/random/myths,
-/turf/open/floor/woodturned/nosmooth,
-/area/rogue/indoors/town/manor)
 "upK" = (
 /obj/structure/hotspring,
 /obj/effect/lily_petal/two,
@@ -32600,6 +32616,21 @@
 	},
 /turf/open/floor/metal,
 /area/rogue/indoors/town)
+"uQE" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "uQX" = (
 /obj/structure/toilet,
 /turf/open/floor/wood,
@@ -33191,10 +33222,6 @@
 /obj/structure/stairs,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/under/town/basement)
-"vnk" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "vnp" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -35720,21 +35747,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/river)
-"wXB" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "wXI" = (
 /obj/structure/fluff/wallclock/r,
 /obj/structure/rack/shelf/biggest,
@@ -36172,6 +36184,13 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/smithy)
+"xkA" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "xle" = (
 /obj/effect/mapping_helpers/secret_door_creator/keep{
 	redstone_id = 604
@@ -37363,15 +37382,6 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
-"ybF" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "ybI" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -95682,7 +95692,7 @@ iWy
 qTA
 iWy
 oDt
-vnk
+kHw
 gOl
 acs
 acs
@@ -96086,7 +96096,7 @@ jZn
 uie
 ckQ
 jZn
-kSd
+xkA
 gOl
 gqv
 acs
@@ -96490,7 +96500,7 @@ jZn
 xhJ
 iOP
 jZn
-nqB
+kSd
 gOl
 gqv
 acs
@@ -97485,7 +97495,7 @@ gOl
 srF
 vwo
 iPC
-nwI
+cqI
 iSJ
 mso
 ofx
@@ -100111,9 +100121,9 @@ vgJ
 vgJ
 vgJ
 gOl
-qUX
+flv
 ahA
-cOS
+jYv
 owl
 vwo
 gOl
@@ -100175,7 +100185,7 @@ mlm
 lfC
 kzd
 qLV
-wXB
+uQE
 ylf
 elp
 elp
@@ -101387,7 +101397,7 @@ hsv
 oXQ
 cKJ
 qhM
-ybF
+ufN
 ehF
 fOL
 iSk
@@ -101990,7 +102000,7 @@ dsu
 lsl
 lsl
 wRB
-png
+bUP
 cKJ
 oXQ
 gNi
@@ -102771,7 +102781,7 @@ sWL
 ori
 cdP
 qhM
-iGX
+fOs
 uFr
 teu
 mpR
@@ -104156,12 +104166,12 @@ rDr
 bET
 rDr
 gOl
-upm
+hxA
 qSc
 kcY
 kcY
 qSc
-upm
+hxA
 gOl
 bas
 bas
@@ -104358,7 +104368,7 @@ rDr
 bET
 rDr
 gOl
-gAD
+nbl
 faL
 faL
 faL
@@ -134386,7 +134396,7 @@ vgJ
 vgJ
 vgJ
 vgJ
-dDA
+lkW
 sXv
 pGO
 pGO
@@ -134588,7 +134598,7 @@ vgJ
 vgJ
 vgJ
 vgJ
-dDA
+lkW
 mAT
 pGO
 pGO
@@ -155316,7 +155326,7 @@ xMN
 voC
 voC
 voC
-ubA
+pQz
 daH
 kcp
 daH
@@ -179008,7 +179018,7 @@ iBK
 acx
 fdp
 wLs
-ieN
+blJ
 ocA
 ocA
 ocA
@@ -180224,7 +180234,7 @@ ocA
 dtq
 cBH
 dhG
-pDF
+hRU
 dtq
 gTT
 dhG
@@ -194316,7 +194326,7 @@ daH
 iTz
 vUd
 daH
-pDY
+rbu
 iTz
 vUd
 nnH
@@ -194925,7 +194935,7 @@ daH
 apa
 iTz
 vUd
-lmL
+eam
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2694,10 +2694,6 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"bCa" = (
-/obj/structure/table/wood/plain_alt,
-/turf/open/floor/woodturned/nosmooth,
-/area/rogue/indoors/town/manor)
 "bCi" = (
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/church)
@@ -3094,10 +3090,10 @@
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
-/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /obj/item/reagent_containers/food/snacks/produce/grain/wheat,
-/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
-/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/food/snacks/meat/steak,
 /turf/open/floor/tile/kitchen,
 /area/rogue/indoors/town/tavern)
 "bPb" = (
@@ -3847,10 +3843,6 @@
 	},
 /turf/open/floor/dirt,
 /area/rogue/outdoors/rtfield/safe)
-"cnz" = (
-/obj/structure/grindwheel,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "cnG" = (
 /obj/structure/table/wood/plain_alt,
 /obj/machinery/light/fueled/wallfire/candle,
@@ -4640,6 +4632,12 @@
 /obj/structure/flora/grass/bush_meagre,
 /turf/open/floor/cobble/mossy,
 /area/rogue/outdoors/town)
+"cOS" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "cOT" = (
 /obj/structure/door{
 	name = "Storage"
@@ -5760,6 +5758,10 @@
 /obj/structure/fake_machine/mail,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/town/merc_guild)
+"dDA" = (
+/obj/machinery/light/fueled/oven,
+/turf/closed/wall/mineral/craftstone,
+/area/rogue/indoors/town/merc_guild)
 "dDB" = (
 /obj/machinery/light/fueled/firebowl/stump,
 /turf/open/floor/dirt,
@@ -5986,13 +5988,6 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/cobblerock,
 /area/rogue/indoors/town/merc_guild)
-"dKL" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "dKM" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -9185,11 +9180,6 @@
 /obj/machinery/light/fueled/hearth,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
-"fKq" = (
-/obj/structure/flora/grass/bush,
-/obj/effect/landmark/start/vagrant,
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "fKD" = (
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/orphanage)
@@ -10359,6 +10349,10 @@
 /obj/structure/fake_machine/scomm/l,
 /turf/open/floor/ruinedwood,
 /area/rogue/indoors/town/church)
+"gAD" = (
+/obj/structure/table/wood/plain_alt,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "gAQ" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = 32;
@@ -10722,10 +10716,6 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/indoors/villagegarrison)
-"gLs" = (
-/obj/structure/bookcase/random/myths,
-/turf/open/floor/woodturned/nosmooth,
-/area/rogue/indoors/town/manor)
 "gLw" = (
 /obj/machinery/light/fueled/wallfire/candle/blue{
 	pixel_y = -32
@@ -11940,10 +11930,6 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/clinic_large)
-"hCy" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "hCB" = (
 /obj/structure/fake_machine/drugmachine,
 /turf/open/floor/blocks/stonered,
@@ -12281,20 +12267,18 @@
 /area/rogue/indoors/dungeon)
 "hMz" = (
 /obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
 /obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
 /obj/item/clothing/shoes/boots,
 /obj/item/clothing/shirt/undershirt/random,
 /obj/item/clothing/shirt/undershirt/black,
 /obj/item/clothing/shirt/tunic/noblecoat,
 /obj/item/clothing/cloak/raincloak/random,
 /obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
 /obj/item/clothing/head/hooded,
 /obj/item/clothing/head/roguehood/random,
 /obj/item/storage/belt/leather,
+/obj/item/clothing/head/bardhat,
+/obj/item/clothing/cloak/raincloak/furcloak/brown,
 /turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/manor)
 "hMJ" = (
@@ -12514,6 +12498,8 @@
 /area/rogue/outdoors/rtfield/safe)
 "hTt" = (
 /obj/structure/table/wood/plain,
+/obj/item/paper,
+/obj/item/paper,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/smithy)
 "hTB" = (
@@ -12667,21 +12653,6 @@
 /obj/structure/bookcase/random/myths,
 /turf/open/floor/greenstone,
 /area/rogue/under/town/basement)
-"hYY" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "hZc" = (
 /obj/structure/table/wood/plain/alt,
 /turf/open/floor/churchmarble,
@@ -12864,6 +12835,20 @@
 	},
 /turf/open/floor/carpet/green,
 /area/rogue/indoors/town/steward)
+"ieN" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "iff" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = -32;
@@ -13413,13 +13398,6 @@
 /obj/structure/toilet,
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
-"izF" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "izM" = (
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_x = 32;
@@ -13669,6 +13647,10 @@
 	},
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/church)
+"iGX" = (
+/obj/structure/grindwheel,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "iHf" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -14691,9 +14673,9 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/obj/item/candle/yellow{
-	pixel_x = 11;
-	pixel_y = -3
+/obj/item/candle/yellow/lit/infinite/strong/skull{
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
@@ -14997,7 +14979,7 @@
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/potato,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
-/obj/item/reagent_containers/food/snacks/produce/grain/wheat,
+/obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /obj/item/reagent_containers/food/snacks/produce/vegetable/onion,
 /turf/open/floor/tile/kitchen,
 /area/rogue/indoors/town/tavern)
@@ -16993,34 +16975,6 @@
 	},
 /turf/open/floor/cobble,
 /area/rogue/under/town/caverogue)
-"kHe" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "kHj" = (
 /obj/structure/flora/grass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -17343,7 +17297,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/machinery/tanningrack,
+/obj/structure/closet/crate/chest,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17811,11 +17765,6 @@
 	},
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
-"lkA" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "lkB" = (
 /obj/effect/decal/cobblerockedge/alt{
 	dir = 4
@@ -17894,6 +17843,19 @@
 /obj/structure/minecart_rail,
 /turf/open/floor/naturalstone,
 /area/rogue/under/cave)
+"lmL" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "lmW" = (
 /obj/effect/landmark/bounty_location{
 	location_name = "End of the Cargo Docks";
@@ -18120,6 +18082,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/bottle/beer,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "lvl" = (
@@ -19383,8 +19346,9 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -20996,6 +20960,13 @@
 	},
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town)
+"nqB" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "nqJ" = (
 /obj/item/needle/thorn,
 /turf/open/floor/dirt,
@@ -21131,6 +21102,34 @@
 /obj/item/bin/water,
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"nwI" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "nxh" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -23484,10 +23483,6 @@
 /obj/structure/table/wood/reinforced_alt{
 	dir = 8
 	},
-/obj/item/natural/feather{
-	pixel_x = 5;
-	pixel_y = 4
-	},
 /obj/machinery/loom,
 /turf/open/floor/tile/kitchen,
 /area/rogue/indoors/town)
@@ -23934,6 +23929,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/garrison)
+"png" = (
+/obj/structure/flora/grass/bush,
+/obj/effect/landmark/start/vagrant,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "pns" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
@@ -24389,6 +24389,10 @@
 	},
 /turf/open/floor/tile/checkeralt,
 /area/rogue/indoors/town/tavern)
+"pDF" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "pDW" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -24396,6 +24400,13 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/river)
+"pDY" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "pEm" = (
 /obj/machinery/light/fueled/lanternpost/fixed{
 	pixel_x = -5;
@@ -25305,15 +25316,6 @@
 	},
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"qkV" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/dirt,
-/area/rogue/outdoors/town)
 "qlb" = (
 /obj/structure/roguerock,
 /turf/open/water,
@@ -26126,13 +26128,6 @@
 "qOm" = (
 /turf/open/floor/wood,
 /area/rogue/indoors/town/church/chapel)
-"qOq" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "qOK" = (
 /obj/machinery/light/fueled/chand,
 /turf/open/transparent/openspace,
@@ -26436,6 +26431,11 @@
 /obj/structure/fluff/walldeco/vinez,
 /turf/closed/wall/mineral/stone,
 /area/rogue/indoors/town/cell)
+"qUX" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "qVh" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/cobble,
@@ -26470,20 +26470,6 @@
 "qWa" = (
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
-"qWc" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/turf/open/floor/ruinedwood/turned/darker,
-/area/rogue/indoors/town)
 "qWj" = (
 /obj/structure/flora/grass/bush/wall/tall{
 	pixel_x = -8
@@ -28279,11 +28265,6 @@
 /obj/effect/landmark/start/gaffer_assistant,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/merc_guild)
-"sik" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "siz" = (
 /obj/structure/closet/crate/crafted_closet/dark,
 /obj/item/book/law,
@@ -31094,10 +31075,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
-"tQx" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "tQB" = (
 /obj/structure/window/solid,
 /turf/open/floor/ruinedwood/spiral,
@@ -31380,6 +31357,11 @@
 /obj/structure/bed/shit,
 /turf/open/floor/twig,
 /area/rogue/indoors/butchershop)
+"ubA" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "ubD" = (
 /obj/structure/table/vtable/v2,
 /obj/item/toy/cards/deck/syndicate{
@@ -31802,6 +31784,10 @@
 /obj/structure/minecart_rail,
 /turf/open/floor/naturalstone,
 /area/rogue/outdoors/town)
+"upm" = (
+/obj/structure/bookcase/random/myths,
+/turf/open/floor/woodturned/nosmooth,
+/area/rogue/indoors/town/manor)
 "upK" = (
 /obj/structure/hotspring,
 /obj/effect/lily_petal/two,
@@ -33205,6 +33191,10 @@
 /obj/structure/stairs,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/under/town/basement)
+"vnk" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "vnp" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/fluff/railing/wood{
@@ -34079,19 +34069,6 @@
 	},
 /turf/open/floor/ruinedwood/chevron,
 /area/rogue/indoors/town/orphanage)
-"vTe" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "vTy" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -35743,6 +35720,21 @@
 	dir = 8
 	},
 /area/rogue/outdoors/river)
+"wXB" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "wXI" = (
 /obj/structure/fluff/wallclock/r,
 /obj/structure/rack/shelf/biggest,
@@ -35919,6 +35911,11 @@
 /area/rogue/outdoors/town/roofs)
 "xdk" = (
 /obj/structure/closet/crate/crafted_closet/dark,
+/obj/item/clothing/shirt/undershirt/fancy,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/shoes/nobleboot,
+/obj/item/clothing/cloak/tabard/knight,
+/obj/item/reagent_containers/food/snacks/hardtack,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "xdm" = (
@@ -36543,6 +36540,16 @@
 /area/rogue/indoors/town/shop)
 "xAO" = (
 /obj/structure/closet/crate/crafted_closet,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/natural/feather{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/tile/kitchen,
 /area/rogue/indoors/town)
 "xBk" = (
@@ -37356,6 +37363,15 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
+"ybF" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "ybI" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -95666,7 +95682,7 @@ iWy
 qTA
 iWy
 oDt
-tQx
+vnk
 gOl
 acs
 acs
@@ -96070,7 +96086,7 @@ jZn
 uie
 ckQ
 jZn
-qOq
+kSd
 gOl
 gqv
 acs
@@ -96474,7 +96490,7 @@ jZn
 xhJ
 iOP
 jZn
-kSd
+nqB
 gOl
 gqv
 acs
@@ -97469,9 +97485,9 @@ gOl
 srF
 vwo
 iPC
-kHe
+nwI
 iSJ
-izF
+mso
 ofx
 jxg
 gOl
@@ -100095,9 +100111,9 @@ vgJ
 vgJ
 vgJ
 gOl
-sik
+qUX
 ahA
-mso
+cOS
 owl
 vwo
 gOl
@@ -100159,7 +100175,7 @@ mlm
 lfC
 kzd
 qLV
-hYY
+wXB
 ylf
 elp
 elp
@@ -101371,7 +101387,7 @@ hsv
 oXQ
 cKJ
 qhM
-qkV
+ybF
 ehF
 fOL
 iSk
@@ -101974,7 +101990,7 @@ dsu
 lsl
 lsl
 wRB
-fKq
+png
 cKJ
 oXQ
 gNi
@@ -102755,7 +102771,7 @@ sWL
 ori
 cdP
 qhM
-cnz
+iGX
 uFr
 teu
 mpR
@@ -104140,12 +104156,12 @@ rDr
 bET
 rDr
 gOl
-gLs
+upm
 qSc
 kcY
 kcY
 qSc
-gLs
+upm
 gOl
 bas
 bas
@@ -104342,7 +104358,7 @@ rDr
 bET
 rDr
 gOl
-bCa
+gAD
 faL
 faL
 faL
@@ -134370,7 +134386,7 @@ vgJ
 vgJ
 vgJ
 vgJ
-jMD
+dDA
 sXv
 pGO
 pGO
@@ -134572,7 +134588,7 @@ vgJ
 vgJ
 vgJ
 vgJ
-jMD
+dDA
 mAT
 pGO
 pGO
@@ -155300,7 +155316,7 @@ xMN
 voC
 voC
 voC
-lkA
+ubA
 daH
 kcp
 daH
@@ -178992,7 +179008,7 @@ iBK
 acx
 fdp
 wLs
-qWc
+ieN
 ocA
 ocA
 ocA
@@ -180208,7 +180224,7 @@ ocA
 dtq
 cBH
 dhG
-hCy
+pDF
 dtq
 gTT
 dhG
@@ -194300,7 +194316,7 @@ daH
 iTz
 vUd
 daH
-dKL
+pDY
 iTz
 vUd
 nnH
@@ -194909,7 +194925,7 @@ daH
 apa
 iTz
 vUd
-vTe
+lmL
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -2277,13 +2277,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"bom" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "box" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/cobble,
@@ -2884,21 +2877,6 @@
 	},
 /turf/open/floor/naturalstone,
 /area/rogue/under/town/sewer)
-"bHI" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "bIc" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/ore/copper,
@@ -4321,22 +4299,6 @@
 /obj/machinery/light/fueled/torchholder,
 /turf/open/floor/cobble,
 /area/rogue/indoors/villagegarrison)
-"cEQ" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "cFp" = (
 /obj/structure/table/wood/plain/alt,
 /obj/item/clothing/face/druid,
@@ -4925,6 +4887,19 @@
 "cZn" = (
 /turf/closed/wall/mineral/roofwall/innercorner,
 /area/rogue/indoors/town)
+"cZz" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "cZG" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/paper,
@@ -6591,6 +6566,34 @@
 /obj/structure/bars/bent,
 /turf/open/floor/carpet/green,
 /area/rogue/indoors/town/merc_guild)
+"dYy" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "dYD" = (
 /obj/machinery/light/fueled/chand,
 /turf/open/transparent/openspace,
@@ -6642,19 +6645,6 @@
 /obj/effect/landmark/start/villager,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
-"eal" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "ean" = (
 /obj/structure/spider/cocoon,
 /turf/open/floor/greenstone,
@@ -10782,6 +10772,10 @@
 /obj/structure/fluff/telescope,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/town/roofs)
+"gMT" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "gNi" = (
 /obj/structure/fluff/railing/wood,
 /obj/structure/flora/grass,
@@ -12978,10 +12972,6 @@
 	},
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/under/town/basement)
-"ikF" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "ikG" = (
 /turf/open/floor/hexstone,
 /area/rogue/indoors/villagegarrison)
@@ -13404,6 +13394,7 @@
 "izz" = (
 /obj/structure/table/wood/plain_alt,
 /obj/structure/fake_machine/mail/r,
+/obj/item/rope/chain,
 /turf/open/floor/ruinedwood/spiralfade,
 /area/rogue/indoors/town/manorgate)
 "izE" = (
@@ -14888,6 +14879,11 @@
 	},
 /turf/open/floor/twig,
 /area/rogue/outdoors/rtfield/safe)
+"jvm" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "jvH" = (
 /turf/open/floor/metal/alt,
 /area/rogue/outdoors/town)
@@ -17300,6 +17296,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
+/obj/structure/closet/crate/chest,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -21760,6 +21757,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
+/obj/item/key/graveyard,
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/church)
 "nQS" = (
@@ -25017,11 +25015,6 @@
 /obj/effect/mapping_helpers/access/keyset/manor/general,
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
-"qbc" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "qbm" = (
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/carpet/royalblack,
@@ -25383,6 +25376,13 @@
 	},
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
+"qpf" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "qpi" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/whitewine,
@@ -25965,6 +25965,21 @@
 	},
 /turf/open/floor/cobble/alt,
 /area/rogue/under/town/sewer)
+"qJC" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "qKb" = (
 /obj/structure/fluff/railing/wood,
 /obj/effect/landmark/start/vagrant,
@@ -28567,6 +28582,22 @@
 "stI" = (
 /turf/open/floor/blocks,
 /area/rogue/outdoors/river)
+"stW" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "stX" = (
 /obj/machinery/light/fueled/wallfire/candle/l{
 	pixel_x = 0;
@@ -29353,6 +29384,13 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/concrete,
 /area/rogue/indoors/town/shop)
+"sSP" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "sSR" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/blocks,
@@ -31727,6 +31765,13 @@
 "uqG" = (
 /turf/open/floor/metal/barograte,
 /area/rogue/indoors/town/warehouse)
+"uqO" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "urr" = (
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
@@ -31935,13 +31980,6 @@
 	},
 /turf/open/floor/cobble,
 /area/rogue/outdoors/town)
-"uzq" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "uzB" = (
 /obj/effect/spawner/map_spawner/hauntz_random,
 /turf/open/floor/ruinedwood/turned,
@@ -35950,13 +35988,6 @@
 /obj/structure/fake_machine/mail/r,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town/theatre)
-"xgD" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "xgK" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -36019,34 +36050,6 @@
 	dir = 9
 	},
 /turf/open/floor/tile/masonic,
-/area/rogue/indoors/town/manor)
-"xis" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "xiD" = (
 /obj/structure/closet/crate/drawer{
@@ -95590,7 +95593,7 @@ iWy
 qTA
 iWy
 oDt
-ikF
+gMT
 gOl
 acs
 acs
@@ -95994,7 +95997,7 @@ jZn
 uie
 ckQ
 jZn
-bom
+kSd
 gOl
 gqv
 acs
@@ -96398,7 +96401,7 @@ jZn
 xhJ
 iOP
 jZn
-kSd
+sSP
 gOl
 gqv
 acs
@@ -97393,9 +97396,9 @@ gOl
 srF
 vwo
 iPC
-xis
+dYy
 iSJ
-xgD
+uqO
 ofx
 jxg
 gOl
@@ -100083,7 +100086,7 @@ mlm
 lfC
 kzd
 qLV
-bHI
+qJC
 ylf
 elp
 elp
@@ -102449,7 +102452,7 @@ gOl
 byj
 rTe
 rTe
-cEQ
+stW
 gOl
 gOl
 cGL
@@ -155224,7 +155227,7 @@ xMN
 voC
 voC
 voC
-qbc
+jvm
 daH
 kcp
 daH
@@ -194224,7 +194227,7 @@ daH
 iTz
 vUd
 daH
-uzq
+qpf
 iTz
 vUd
 nnH
@@ -194833,7 +194836,7 @@ daH
 apa
 iTz
 vUd
-eal
+cZz
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -1103,6 +1103,34 @@
 /obj/machinery/light/fueled/wallfire/candle/l,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/manor)
+"aEL" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "aEM" = (
 /obj/structure/door{
 	lockid = "apartment19";
@@ -3717,6 +3745,23 @@
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/tile,
 /area/rogue/indoors/town/magician)
+"cjs" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "cjt" = (
 /turf/closed/wall/mineral/wooddark,
 /area/rogue/indoors/town)
@@ -7598,13 +7643,6 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/butchershop)
-"eJI" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "eJJ" = (
 /obj/structure/table/wood/counter{
 	dir = 1
@@ -8522,6 +8560,10 @@
 	},
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
+"foi" = (
+/obj/structure/grindwheel,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "fol" = (
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/town/roofs)
@@ -9297,6 +9339,19 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
+"fOw" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "fOC" = (
 /obj/structure/bed/shit,
 /turf/open/floor/dirt/road,
@@ -12907,6 +12962,21 @@
 	},
 /turf/open/floor/metal,
 /area/rogue/indoors/town)
+"iji" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "ijE" = (
 /obj/effect/landmark/start/steward{
 	dir = 4
@@ -13060,6 +13130,13 @@
 "iqh" = (
 /turf/closed/wall/mineral/wooddark/vertical,
 /area/rogue/indoors/town/smithy)
+"iqZ" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "irf" = (
 /obj/structure/flora/grass/bush_meagre,
 /turf/open/floor/dirt,
@@ -14562,7 +14639,7 @@
 	dir = 5;
 	icon_state = "largetable"
 	},
-/obj/item/storage/sack,
+/obj/item/dice,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "jmD" = (
@@ -17044,9 +17121,6 @@
 	pixel_x = -7;
 	pixel_y = 1
 	},
-/obj/item/reagent_containers/glass/bottle{
-	pixel_x = 6
-	},
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/manor)
 "kLl" = (
@@ -17253,7 +17327,7 @@
 /obj/machinery/light/fueled/wallfire/candle{
 	pixel_y = -32
 	},
-/obj/machinery/tanningrack,
+/obj/structure/closet/crate/chest,
 /turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "kSz" = (
@@ -17517,6 +17591,7 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
+/obj/item/reagent_containers/glass/bottle/healthpot,
 /turf/open/floor/churchrough,
 /area/rogue/indoors/town/manor)
 "lbu" = (
@@ -19283,9 +19358,8 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -20232,23 +20306,6 @@
 /obj/structure/flora/grass,
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/town)
-"mUQ" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "mVc" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -21483,21 +21540,6 @@
 /obj/machinery/light/fueled/wallfire/candle/blue/r,
 /turf/open/floor/greenstone,
 /area/rogue/indoors/town/magician)
-"nHU" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "nHZ" = (
 /obj/machinery/light/fueled/firebowl/standing,
 /turf/open/floor/dirt/road,
@@ -24084,6 +24126,13 @@
 	},
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"ptM" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "ptN" = (
 /obj/machinery/light/fueledstreet,
 /turf/open/floor/dirt,
@@ -24453,6 +24502,13 @@
 /obj/effect/mapping_helpers/access/keyset/church/grave,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/church)
+"pIm" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "pIz" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/blocks/newstone/alt,
@@ -24937,13 +24993,6 @@
 /obj/effect/mapping_helpers/access/keyset/town/inn,
 /turf/open/floor/woodturned,
 /area/rogue/indoors/town/tavern)
-"pYO" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "pYQ" = (
 /obj/structure/window/openclose{
 	dir = 4
@@ -25231,19 +25280,6 @@
 	},
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
-"qko" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "qkT" = (
 /obj/structure/bars/passage/shutter/open{
 	redstone_id = "nite_shutter"
@@ -25386,34 +25422,6 @@
 	},
 /turf/open/floor/blocks,
 /area/rogue/under/town/basement)
-"qpe" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "qpi" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/whitewine,
@@ -26492,10 +26500,6 @@
 /obj/item/ore/iron,
 /turf/open/floor/naturalstone,
 /area/rogue/under/town/sewer)
-"qXT" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "qYb" = (
 /obj/structure/well/climb_up,
 /turf/open/water/cleanshallow,
@@ -26709,11 +26713,6 @@
 /obj/item/reagent_containers/food/snacks/meat/sausage,
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /turf/open/floor/hexstone,
-/area/rogue/indoors/town/church)
-"rhm" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
 /area/rogue/indoors/town/church)
 "rhv" = (
 /obj/structure/fluff/railing/border,
@@ -27425,6 +27424,11 @@
 /obj/structure/chair/wood/alt,
 /turf/open/floor/wood,
 /area/rogue/indoors/soilsons)
+"rFF" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "rFI" = (
 /obj/structure/fluff/statue/knight/interior{
 	layer = 4.2
@@ -29870,6 +29874,11 @@
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
+"tiu" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "tiQ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -31223,6 +31232,10 @@
 	dir = 6;
 	icon_state = "largetable"
 	},
+/obj/item/toy/cards/deck/syndicate{
+	pixel_x = -4;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "tXV" = (
@@ -31378,6 +31391,10 @@
 /obj/structure/bed/hay,
 /turf/open/floor/cobble,
 /area/rogue/under/town/basement)
+"udN" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "udT" = (
 /obj/structure/stairs{
 	dir = 8
@@ -33204,12 +33221,6 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/steward)
-"vpU" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "vqk" = (
 /obj/structure/flora/grass/water,
 /turf/open/floor/naturalstone,
@@ -34501,8 +34512,10 @@
 /area/rogue/outdoors/town)
 "wjt" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots/leather,
-/obj/item/clothing/shoes/boots/leather,
+/obj/item/clothing/pants/tights/guard,
+/obj/item/clothing/pants/tights/guard,
+/obj/item/clothing/shirt/undershirt/guard,
+/obj/item/clothing/shirt/undershirt/guard,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "wjy" = (
@@ -36394,12 +36407,12 @@
 	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 11;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 2;
 	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 11;
+	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
@@ -95594,7 +95607,7 @@ iWy
 qTA
 iWy
 oDt
-qXT
+udN
 gOl
 acs
 acs
@@ -95998,7 +96011,7 @@ jZn
 uie
 ckQ
 jZn
-pYO
+kSd
 gOl
 gqv
 acs
@@ -96402,7 +96415,7 @@ jZn
 xhJ
 iOP
 jZn
-kSd
+pIm
 gOl
 gqv
 acs
@@ -97397,9 +97410,9 @@ gOl
 srF
 vwo
 iPC
-qpe
-iSJ
-mso
+aEL
+foi
+ptM
 ofx
 jxg
 gOl
@@ -97603,7 +97616,7 @@ faL
 faL
 faL
 faL
-vwo
+iSJ
 gOl
 wMy
 bET
@@ -100023,9 +100036,9 @@ vgJ
 vgJ
 vgJ
 gOl
-tpL
+tiu
 ahA
-vpU
+mso
 owl
 vwo
 gOl
@@ -100087,7 +100100,7 @@ mlm
 lfC
 kzd
 qLV
-nHU
+iji
 ylf
 elp
 elp
@@ -102453,7 +102466,7 @@ gOl
 byj
 rTe
 rTe
-mUQ
+cjs
 gOl
 gOl
 cGL
@@ -155228,7 +155241,7 @@ xMN
 voC
 voC
 voC
-rhm
+rFF
 daH
 kcp
 daH
@@ -194228,7 +194241,7 @@ daH
 iTz
 vUd
 daH
-eJI
+iqZ
 iTz
 vUd
 nnH
@@ -194837,7 +194850,7 @@ daH
 apa
 iTz
 vUd
-qko
+fOw
 daH
 aOl
 iWm

--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -1103,34 +1103,6 @@
 /obj/machinery/light/fueled/wallfire/candle/l,
 /turf/open/floor/herringbone,
 /area/rogue/indoors/town/manor)
-"aEL" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/tabard/knight/guard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/obj/item/clothing/cloak/stabard/guard{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "aEM" = (
 /obj/structure/door{
 	lockid = "apartment19";
@@ -3745,23 +3717,6 @@
 /obj/effect/landmark/start/wapprentice,
 /turf/open/floor/tile,
 /area/rogue/indoors/town/magician)
-"cjs" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/pants/tights/black,
-/obj/item/clothing/pants/tights/random,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shirt/undershirt/random,
-/obj/item/clothing/shirt/undershirt/black,
-/obj/item/clothing/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/raincloak/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/shirt/tunic/random,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/hooded,
-/obj/item/clothing/head/roguehood/random,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/manor)
 "cjt" = (
 /turf/closed/wall/mineral/wooddark,
 /area/rogue/indoors/town)
@@ -4590,6 +4545,10 @@
 /obj/machinery/light/fueled/firebowl,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/river)
+"cNi" = (
+/obj/structure/grindwheel,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "cNl" = (
 /obj/structure/table/wood/plain_alt,
 /obj/item/essence_vial{
@@ -4612,6 +4571,12 @@
 	},
 /turf/open/floor/twig,
 /area/rogue/indoors/town)
+"cNv" = (
+/obj/structure/closet/crate/crafted_closet/crafted,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "cNG" = (
 /obj/machinery/light/fueled/torchholder{
 	dir = 4
@@ -8560,10 +8525,6 @@
 	},
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor)
-"foi" = (
-/obj/structure/grindwheel,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "fol" = (
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/town/roofs)
@@ -8668,6 +8629,8 @@
 /obj/structure/closet/crate/drawer,
 /obj/item/storage/belt/pouch/coins/poor,
 /obj/item/key/courtphys,
+/obj/item/reagent_containers/glass/bottle,
+/obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/hexstone,
 /area/rogue/indoors/town/manor)
 "frI" = (
@@ -9295,17 +9258,7 @@
 /turf/open/floor/cobble/alt,
 /area/rogue/under/dungeon)
 "fNc" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/food/snacks/meat/steak,
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/powder/flour{
-	pixel_x = 3;
-	pixel_y = 5
-	},
+/obj/structure/fermentation_keg/water,
 /turf/open/floor/ruinedwood/turned/darker,
 /area/rogue/indoors/town)
 "fNh" = (
@@ -9339,19 +9292,6 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
-"fOw" = (
-/obj/structure/closet/crate/crafted_closet,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/head/padded/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/shirt/robe/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/obj/item/clothing/neck/psycross/silver/abyssor,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "fOC" = (
 /obj/structure/bed/shit,
 /turf/open/floor/dirt/road,
@@ -10051,6 +9991,13 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/rogue/indoors/town)
+"gpe" = (
+/obj/machinery/light/fueled/wallfire/candle{
+	pixel_y = -32
+	},
+/obj/machinery/tanningrack,
+/turf/open/floor/blocks/stonered,
+/area/rogue/indoors/town/manor)
 "gpj" = (
 /obj/machinery/light/fueledstreet,
 /turf/open/floor/cobble,
@@ -12313,10 +12260,10 @@
 /turf/open/floor/blocks,
 /area/rogue/indoors/dungeon)
 "hMz" = (
-/obj/structure/flora/grass,
-/obj/structure/flora/newtree,
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood/plain_alt,
+/obj/item/storage/sack,
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "hMJ" = (
 /obj/machinery/light/fueled/firebowl/standing,
 /turf/open/floor/ruinedwood/spiral,
@@ -12962,21 +12909,6 @@
 	},
 /turf/open/floor/metal,
 /area/rogue/indoors/town)
-"iji" = (
-/obj/structure/flora/grass/bush_meagre,
-/obj/structure/fluff/railing/wood{
-	dir = 4
-	},
-/obj/structure/flora/grass/bush{
-	pixel_x = -1;
-	pixel_y = -20
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/grass,
-/area/rogue/outdoors/town)
 "ijE" = (
 /obj/effect/landmark/start/steward{
 	dir = 4
@@ -13130,13 +13062,6 @@
 "iqh" = (
 /turf/closed/wall/mineral/wooddark/vertical,
 /area/rogue/indoors/town/smithy)
-"iqZ" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/alt,
-/turf/open/floor/churchmarble,
-/area/rogue/indoors/town/church)
 "irf" = (
 /obj/structure/flora/grass/bush_meagre,
 /turf/open/floor/dirt,
@@ -14063,6 +13988,15 @@
 "iTT" = (
 /turf/closed/wall/mineral/decorstone,
 /area/rogue/outdoors/river)
+"iUl" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/flora/grass,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "iUu" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/cobble,
@@ -16130,6 +16064,20 @@
 /mob/living/carbon/human/species/rousman/npc,
 /turf/open/floor/cobble,
 /area/rogue/under/dungeon)
+"kgE" = (
+/obj/structure/closet/crate/chest/crate,
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/powder/flour{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/meat/steak,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "kgK" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -16894,6 +16842,21 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/garrison)
+"kCR" = (
+/obj/structure/flora/grass/bush_meagre,
+/obj/structure/fluff/railing/wood{
+	dir = 4
+	},
+/obj/structure/flora/grass/bush{
+	pixel_x = -1;
+	pixel_y = -20
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/grass,
+/area/rogue/outdoors/town)
 "kDi" = (
 /turf/open/floor/rooftop,
 /area/rogue/indoors/town)
@@ -17984,6 +17947,10 @@
 	pixel_y = 0
 	},
 /turf/open/floor/tile/masonic,
+/area/rogue/indoors/town/manor)
+"lqh" = (
+/obj/structure/rack/shelf/biggest,
+/turf/open/floor/blocks/stonered,
 /area/rogue/indoors/town/manor)
 "lqr" = (
 /turf/open/floor/herringbone,
@@ -19358,8 +19325,9 @@
 /area/rogue/indoors/town/church)
 "mso" = (
 /obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/shoes/boots,
-/obj/item/clothing/shoes/boots,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
+/obj/item/clothing/armor/gambeson,
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "msC" = (
@@ -22401,6 +22369,34 @@
 	},
 /turf/open/floor/blocks,
 /area/rogue/outdoors/town)
+"olA" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/tabard/knight/guard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/item/clothing/cloak/stabard/guard{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/manor)
 "olI" = (
 /obj/structure/rotation_piece/cog,
 /turf/open/water/river{
@@ -24126,13 +24122,6 @@
 	},
 /turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"ptM" = (
-/obj/structure/closet/crate/crafted_closet/crafted,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/obj/item/clothing/armor/gambeson,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "ptN" = (
 /obj/machinery/light/fueledstreet,
 /turf/open/floor/dirt,
@@ -24502,13 +24491,6 @@
 /obj/effect/mapping_helpers/access/keyset/church/grave,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/church)
-"pIm" = (
-/obj/machinery/light/fueled/wallfire/candle{
-	pixel_y = -32
-	},
-/obj/machinery/tanningrack,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "pIz" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/blocks/newstone/alt,
@@ -25897,6 +25879,24 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors/woods_safe)
+"qFt" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/pants/tights/black,
+/obj/item/clothing/pants/tights/random,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shoes/boots,
+/obj/item/clothing/shirt/undershirt/random,
+/obj/item/clothing/shirt/undershirt/black,
+/obj/item/clothing/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/raincloak/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/shirt/tunic/random,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/hooded,
+/obj/item/clothing/head/roguehood/random,
+/obj/item/storage/belt/leather,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/manor)
 "qFU" = (
 /obj/structure/rack/shelf/biggest,
 /obj/item/paper/confession,
@@ -26474,6 +26474,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/ruinedwood/darker,
 /area/rogue/outdoors/river)
+"qWX" = (
+/obj/effect/landmark/start/vagrant,
+/obj/structure/flora/grass/bush,
+/turf/open/floor/dirt,
+/area/rogue/outdoors/town)
 "qXq" = (
 /obj/structure/noticeboard{
 	dir = 4;
@@ -27424,11 +27429,6 @@
 /obj/structure/chair/wood/alt,
 /turf/open/floor/wood,
 /area/rogue/indoors/soilsons)
-"rFF" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/clothing/neck/psycross/silver,
-/turf/open/floor/blocks/newstone,
-/area/rogue/indoors/town/church)
 "rFI" = (
 /obj/structure/fluff/statue/knight/interior{
 	layer = 4.2
@@ -29874,11 +29874,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/mountains)
-"tiu" = (
-/obj/structure/table/wood/plain_alt,
-/obj/item/storage/sack,
-/turf/open/floor/wood,
-/area/rogue/indoors/town/manor)
 "tiQ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -31391,10 +31386,6 @@
 /obj/structure/bed/hay,
 /turf/open/floor/cobble,
 /area/rogue/under/town/basement)
-"udN" = (
-/obj/structure/rack/shelf/biggest,
-/turf/open/floor/blocks/stonered,
-/area/rogue/indoors/town/manor)
 "udT" = (
 /obj/structure/stairs{
 	dir = 8
@@ -32699,6 +32690,11 @@
 /obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/churchmarble,
 /area/rogue/indoors/town/manor)
+"uUS" = (
+/obj/structure/table/wood/plain_alt,
+/obj/item/clothing/neck/psycross/silver,
+/turf/open/floor/blocks/newstone,
+/area/rogue/indoors/town/church)
 "uUT" = (
 /obj/structure/table/wood/plain_alt,
 /turf/open/floor/woodturned,
@@ -32981,6 +32977,19 @@
 /obj/structure/plough,
 /turf/open/floor/cobble/mossy,
 /area/rogue/outdoors/rtfield/safe)
+"veW" = (
+/obj/structure/closet/crate/crafted_closet,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/head/padded/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/shirt/robe/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/obj/item/clothing/neck/psycross/silver/abyssor,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "vfc" = (
 /obj/structure/flora/grass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -33746,6 +33755,10 @@
 /obj/machinery/light/fueled/wallfire/candle/blue,
 /turf/open/floor/ruinedwood,
 /area/rogue/indoors/town/magician)
+"vIl" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/ruinedwood/turned/darker,
+/area/rogue/indoors/town)
 "vJa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35551,8 +35564,10 @@
 	dir = 1
 	},
 /obj/structure/flora/grass,
-/obj/effect/landmark/start/vagrant,
-/obj/structure/flora/grass/bush,
+/obj/structure/flora/newtree{
+	pixel_x = 0;
+	pixel_y = -7
+	},
 /turf/open/floor/grass,
 /area/rogue/outdoors/town)
 "wRK" = (
@@ -35606,6 +35621,13 @@
 "wTF" = (
 /turf/open/floor/dirt,
 /area/rogue/under/cave)
+"wTY" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/alt,
+/turf/open/floor/churchmarble,
+/area/rogue/indoors/town/church)
 "wUm" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/cobble,
@@ -95607,7 +95629,7 @@ iWy
 qTA
 iWy
 oDt
-udN
+lqh
 gOl
 acs
 acs
@@ -96415,7 +96437,7 @@ jZn
 xhJ
 iOP
 jZn
-pIm
+gpe
 gOl
 gqv
 acs
@@ -97410,9 +97432,9 @@ gOl
 srF
 vwo
 iPC
-aEL
-foi
-ptM
+olA
+cNi
+mso
 ofx
 jxg
 gOl
@@ -100036,9 +100058,9 @@ vgJ
 vgJ
 vgJ
 gOl
-tiu
+hMz
 ahA
-mso
+cNv
 owl
 vwo
 gOl
@@ -100100,7 +100122,7 @@ mlm
 lfC
 kzd
 qLV
-iji
+kCR
 ylf
 elp
 elp
@@ -101311,8 +101333,8 @@ lsl
 hsv
 oXQ
 cKJ
-hMz
-hwZ
+qhM
+iUl
 ehF
 fOL
 iSk
@@ -101915,7 +101937,7 @@ dsu
 lsl
 lsl
 wRB
-bDv
+qWX
 cKJ
 oXQ
 gNi
@@ -102466,7 +102488,7 @@ gOl
 byj
 rTe
 rTe
-cjs
+qFt
 gOl
 gOl
 cGL
@@ -155241,7 +155263,7 @@ xMN
 voC
 voC
 voC
-rFF
+uUS
 daH
 kcp
 daH
@@ -178933,7 +178955,7 @@ iBK
 acx
 fdp
 wLs
-ocA
+kgE
 ocA
 ocA
 ocA
@@ -180149,9 +180171,9 @@ ocA
 dtq
 cBH
 dhG
-gTT
+vIl
 dtq
-ocA
+gTT
 dhG
 ocA
 gFb
@@ -194241,7 +194263,7 @@ daH
 iTz
 vUd
 daH
-iqZ
+wTY
 iTz
 vUd
 nnH
@@ -194850,7 +194872,7 @@ daH
 apa
 iTz
 vUd
-fOw
+veW
 daH
 aOl
 iWm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

### Church:

- Added 3 of each amulet to match the 3 already present robes and hoods for acolytes.
- Added a necran closet with shrouds and robes
- Added 1 extra Death shroud to the gravetender room.
- Added missing abyssor acolyte robes.
- Added missing dendor amulets.
- Added 3 quarterstaves to match roundstart acolyte gear.
- Doubled Church keys from 3 to 6 so the Priest can hand them to clerics and paladins too and still have room to hire more acolytes and churchlings.
- Added 1 silver psycross to the Priest room (I'm not sure about this one) as it's a powerful anti black magic symbol. Kept the one upstairs for a total of 2.
- Added 1 spare graveyard key to the gravetender room.
- Added 1 grain to the kitchen.

### Town:

- Added parchment and feathers to most tradesmen. This could make the smith lines take less time as multiple orders can be written down on paper.
- Moved 2 merchant keys that were metad constantly from the merchant backroom to his own room. The merchant keys are precious items and shouldn't be this easily accessible.
- Removed the bush next to the SCOM South of the Keep gate along the fence that was blocking it. NO MORE WOE
- Switched places between trees and bushes in the fountain square near North of the inn, this makes it easier to traverse and not get stuck because a single person is drinking from the fountain

Inn:
- Added 1 sack to the Inn kitchen and one apron downstairs.
- Changed the duplicate 3 onions into 3 steaks for variety.

Veteran's House/Elder's:
- Added a water barrel, a life of adventuring and he couldn't buy himself a keg of water? Now you can invite your old friends to your house for some homemade stew if you buy the ingredients.

Gatehouse:
- Added 1 ale for guards on gate duty.

Mercenaries guild:
- Added 2 ovens upstairs so the ring servant or gaffer can cook for the mercs.


### Keep:

Outside:
- Added 1 grinding wheel similar to WPP keep grinding wheel.
- Added 2 quarterstaves to the training grounds to train polearms.

Kitchen:
- Added a rack to hold utensils.
- Added 1 one grain to both chests so you can actually use all of it for dough.
- Added 1 extra potato now you got 3 onions and 3 potatoes.
- Added a drying rack

Hand's Office:
- Added an extra fancy coat for the Hand as the one you have cannot be repaired nor made. Added a raincloak, it's incredible someone acting in the shadows doesn't have access to a raincloak and has to roundstart rush the one at the keep entrance. Added a pouch to the hands quarters. Added 3 lockpicks akin to WPP total of 3 for your agents or yourself to use.
- Added an additional closet to the Hand's room with some basic commoner clothes disguises.

Court physician's office:
- Added 2 empty bottles so you can actually save people.
- Added one spare tunic, gloves and golden spectacles.
- Added a spare court physician key for your apprentice or for a newly hired physician.
- Added 1 lifeblood potion.

Steward's office:
- Added 1 extra warehouse key.

Armory:
- Added 3 surcoats and 3 guard tabards.
- Added 3 gambesons 3 leather boots to the closets, moved black boots outside.
- Garrison keys are now 3 from 2.
- Added 2 tights and 2 shirts to an empty closet.
- Added 1 deck of cards and 1 die.

Squire's room:
- Added clothes.
- Added 2 bookcases and 1 table, squires study too.

Royal knight's room:
- Added formal clothing, they will never wear it but if they decide to take off their armor they have something fancy to wear.
- Added 1 tabard each.
- Added 1 hardtack in the closet like in rosewood.

Gatekeeper's room.
- Added 1 chain to their room
- Added 1 ale bottle so the gatekeeper can refill and drink at his post, the man needs it.
Dungeoneer:
- Added a generic whip in the closet for hired dungeoneers.
- Replaced the normal candle with a skull candle.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game

Vanderlin is an old map. It's kind of devoid of flavour and lacks many items that come from many different PRs that were merged. This PR brings many small changes that will not change balance but will add QoL or address missing items. I will keep adding more changes as suggestions come in.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
