### PR TITLE
Chair layers and rotations

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -17399,7 +17399,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
 "kZH" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/woodsman{
 	dir = 1
 	},
@@ -19068,6 +19070,12 @@
 /obj/structure/closet/crate/crafted_closet,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/church)
+"mkP" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/rogue/indoors/town/tavern)
 "mlk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -24705,7 +24713,9 @@
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/church)
 "pUX" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/adventurer{
 	dir = 1
 	},
@@ -36790,7 +36800,9 @@
 /turf/open/floor/blocks/stonered/tiny,
 /area/rogue/under/town/basement)
 "xSI" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /obj/effect/landmark/start/veteran{
 	dir = 1
 	},
@@ -102330,7 +102342,7 @@ toB
 toB
 toB
 aLy
-aCo
+mkP
 jZz
 jZz
 jZz
@@ -102936,7 +102948,7 @@ vNi
 kII
 toB
 nJP
-aCo
+mkP
 jZz
 kXL
 ifR

--- a/code/game/objects/hotspring.dm
+++ b/code/game/objects/hotspring.dm
@@ -185,6 +185,7 @@
 	icon = 'icons/obj/structures/hotspring.dmi'
 	buildstackamount = 1
 	item_chair = null
+	anchored = TRUE
 
 /obj/structure/chair/hotspring_bench/left
 	icon_state = "parkbench_sofaend_left"

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -3,7 +3,7 @@
 	desc = ""
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "chair"
-	anchored = TRUE
+	anchored = FALSE
 	can_buckle = 1
 	buckle_lying = 0 //you sit in a chair, not lay
 	resistance_flags = NONE
@@ -114,7 +114,6 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
 	metalizer_result = /obj/item/cooking/pan
-	anchored = FALSE
 
 /obj/structure/chair/stool/handle_layer()
 	return

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -66,10 +66,12 @@
 			buckled_mob.setDir(direction)
 
 /obj/structure/chair/proc/handle_layer()
-	if(has_buckled_mobs() && dir == NORTH)
+	if(dir == NORTH)
 		layer = ABOVE_MOB_LAYER
+		plane = GAME_PLANE_UPPER
 	else
 		layer = OBJ_LAYER
+		plane = GAME_PLANE
 
 /obj/structure/chair/post_buckle_mob(mob/living/M)
 	. = ..()
@@ -112,6 +114,10 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
 	metalizer_result = /obj/item/cooking/pan
+	anchored = FALSE
+
+/obj/structure/chair/stool/handle_layer()
+	return
 
 /obj/structure/chair/MouseDrop(over_object, src_location, over_location)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -26,13 +26,14 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	handle_layer()
 
-/obj/structure/chair/bench/handle_layer()
+/*obj/structure/chair/bench/handle_layer() // Handled in /obj/structure/chair/handle_layer()
 	if(dir == NORTH)
 		layer = ABOVE_MOB_LAYER
 		plane = GAME_PLANE_UPPER
 	else
 		layer = OBJ_LAYER
 		plane = GAME_PLANE
+*/
 
 /obj/structure/chair/bench/post_buckle_mob(mob/living/M)
 	..()
@@ -122,6 +123,7 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
 	metalizer_result = /obj/item/statue/iron/deformed
+	anchored = FALSE
 
 /obj/structure/chair/wood/alt/Initialize()
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -10,6 +10,7 @@
 //	pixel_y = 10
 	layer = OBJ_LAYER
 	metalizer_result = /obj/item/statue/iron/deformed
+	anchored = TRUE
 
 /obj/structure/chair/bench/church
 	icon_state = "church_benchleft"
@@ -25,15 +26,6 @@
 	var/static/list/loc_connections = list(COMSIG_ATOM_EXIT = PROC_REF(on_exit))
 	AddElement(/datum/element/connect_loc, loc_connections)
 	handle_layer()
-
-/*obj/structure/chair/bench/handle_layer() // Handled in /obj/structure/chair/handle_layer()
-	if(dir == NORTH)
-		layer = ABOVE_MOB_LAYER
-		plane = GAME_PLANE_UPPER
-	else
-		layer = OBJ_LAYER
-		plane = GAME_PLANE
-*/
 
 /obj/structure/chair/bench/post_buckle_mob(mob/living/M)
 	..()
@@ -123,7 +115,6 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
 	metalizer_result = /obj/item/statue/iron/deformed
-	anchored = FALSE
 
 /obj/structure/chair/wood/alt/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Chairs are not rendered the same way as benches, if their direction is set to NORTH, they appear on the layer above mobs. 
Chairs and stools are now unanchored, meaning you can pull, push and ROTATE them.
Also rotates some stools in the bar, so you no longer look away from the tavernkeep when sitting down.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
It is
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
