### PR TITLE
Fixes luxury room VI being listed using the wrong object. Typo fix.

### DIFF
--- a/code/game/objects/items/keys.dm
+++ b/code/game/objects/items/keys.dm
@@ -689,7 +689,7 @@
 	icon_state = "brownkey"
 	lockids = list("luxroomv")
 
-/obj/item/key/luxroomiv
+/obj/item/key/luxroomvi
 	name = "luxury room VI key"
 	desc = "The key to the sixth luxury room."
 	icon_state = "brownkey"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Changes one line as a typo fix. 

## Why It's Good For The Game

Fixes Luxury Room Key IV and VI having overlap, potentially fixing issues with the latter not working on certain maps. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
