### PR TITLE
Man At Arms AGAIN

### DIFF
--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -34,7 +34,7 @@
 	head = /obj/item/clothing/head/helmet/kettle
 	shirt = /obj/item/clothing/armor/chainmail
 	armor = /obj/item/clothing/armor/medium/scale
-	neck = /obj/item/clothing/neck/gorget
+	neck = /obj/item/clothing/neck/chaincoif
 	pants = /obj/item/clothing/pants/trou/leather/guard
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -31,11 +31,17 @@
 /datum/outfit/job/watchman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	wrists = /obj/item/clothing/wrists/bracers/leather
+	head = /obj/item/clothing/head/helmet/kettle/slit
+	shirt = /obj/item/clothing/armor/chainmail
+	armor = /obj/item/clothing/armor/medium/scale
+	neck = /obj/item/clothing/neck/gorget
 	pants = /obj/item/clothing/pants/trou/leather/guard
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/storage/keyring/manorguard
+	beltl = /obj/item/weapon/sword/arming
+	backl = /obj/item/storage/backpack/satchel
+	gloves = /obj/item/clothing/gloves/chain
+	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special, /obj/item/storage/keyring/manorguard)
 
 /datum/outfit/job/watchman/post_equip(mob/living/carbon/human/H)
 	. = ..()
@@ -58,15 +64,7 @@
 
 /datum/outfit/job/watchman/pikeman/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/helmet/kettle
-	armor = /obj/item/clothing/armor/cuirass
-	shirt = /obj/item/clothing/armor/chainmail
-	neck = /obj/item/clothing/neck/chaincoif/iron
-	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/arming
 	backr = /obj/item/weapon/polearm/spear/billhook
-	backl = /obj/item/storage/backpack/satchel
-	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -79,18 +77,17 @@
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 	H.change_stat(STATKEY_STR, 2)
-	H.change_stat(STATKEY_PER, -1)
-	H.change_stat(STATKEY_END, -1)
+	H.change_stat(STATKEY_END, 1)
 	H.change_stat(STATKEY_CON, 1)
-	H.change_stat(STATKEY_SPD, 1)
+	H.change_stat(STATKEY_SPD, -1)
 	H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 /datum/advclass/menatarms/watchman_swordsmen
-	name = "Fencer Men-At-Arms"
+	name = "Footman Men-At-Arms"
 	tutorial = "You once warded the town, beating the poor and killing the senseless. \
-	You were quite a good dancer, you've blended that skill with your blade- \
+	You were quite good with a shield, you've blended that skill with your blade- \
 	exanguinated personally by one of the Monarch's best. \
 	You are poor, and your belly is yet full."
 	outfit = /datum/outfit/job/watchman/swordsmen
@@ -98,17 +95,12 @@
 
 /datum/outfit/job/watchman/swordsmen/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = pick(/obj/item/clothing/head/roguehood/guard, /obj/item/clothing/head/roguehood/guardsecond)
-	armor = /obj/item/clothing/armor/leather/advanced
-	shirt = /obj/item/clothing/armor/gambeson
-	neck = /obj/item/clothing/neck/gorget
-	gloves = /obj/item/clothing/gloves/chain
-	beltr = /obj/item/weapon/sword/rapier
-	backl = /obj/item/storage/backpack/satchel
+	backr = /obj/item/weapon/shield/tower
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
@@ -117,15 +109,16 @@
 		H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
-		H.change_stat(STATKEY_END, 2)
-		H.change_stat(STATKEY_SPD, 2)
+		H.change_stat(STATKEY_END, 1)
+		H.change_stat(STATKEY_CON, 1)
+		H.change_stat(STATKEY_STR, 2)
+		H.change_stat(STATKEY_SPD, -1)
 		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
 		H.verbs |= /mob/proc/haltyell
 
 /datum/advclass/menatarms/watchman_ranger
-	name = "Archer Men-At-Arms"
+	name = "Crossbowman Men-At-Arms"
 	tutorial = "You once warded the town, beating the poor and killing the senseless. \
 	Now you stare at them from above, raining hell down upon the knaves and the curs that see you a traitor. \
 	You are poor, and your belly is yet full."
@@ -135,12 +128,8 @@
 
 /datum/outfit/job/watchman/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/helmet/kettle
-	armor = /obj/item/clothing/armor/leather/hide
-	shirt = /obj/item/clothing/armor/gambeson/heavy
-	beltr = /obj/item/weapon/mace/cudgel
-	neck = /obj/item/clothing/neck/chaincoif/iron
-	gloves = /obj/item/clothing/gloves/leather
+	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	hipr = /obj/item/ammo_holder/quiver/bolts
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
@@ -156,16 +145,8 @@
 		H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.change_stat(STATKEY_STR, 1)
 		H.change_stat(STATKEY_PER, 2)
-		H.change_stat(STATKEY_END, -2)
-		H.change_stat(STATKEY_SPD, 1)
+		H.change_stat(STATKEY_END, 1)
+		H.change_stat(STATKEY_SPD, -1)
 		H.verbs |= /mob/proc/haltyell
 		ADD_TRAIT(H, TRAIT_KNOWBANDITS, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		var/weapontypec = pickweight(list("Bow" = 6, "Crossbow" = 4)) // Rolls for either a bow or a Crossbow
-		switch(weapontypec)
-			if("Bow")
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/long
-				backr = /obj/item/ammo_holder/quiver/arrows
-			if("Crossbow")
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				backr = /obj/item/ammo_holder/quiver/bolts
+		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -31,7 +31,7 @@
 /datum/outfit/job/watchman/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	head = /obj/item/clothing/head/helmet/kettle/slit
+	head = /obj/item/clothing/head/helmet/kettle
 	shirt = /obj/item/clothing/armor/chainmail
 	armor = /obj/item/clothing/armor/medium/scale
 	neck = /obj/item/clothing/neck/gorget


### PR DESCRIPTION
I deleted it on accident like a GOOF, so I remade it and changed a few things

## About The Pull Request

All MAA subclasses:
Armor completely standardized, all three subclasses receive identical armor, and armor training. They each get:
NORMAL Kettle helmet (doesn't conceal the face), I forgot how much I love this thing, <3
Scalemail (don't freek out, this is fine. It protects less than a steel cuirass, but covers the legs, that's it.)
Haubergeon
STEEL Chain Coif
Chain gloves
They also all get an arming sword on their left hip, as a backup weapon
Pikeman:
Now gets:
+2 STR // same as before
+1 END // from -1
+1 CON // same as before
-1 SPD // from +1
0 PER // from -1
Fencer:
Reworked into the footman. Bye bye rapier! Gets a tower shield, and 3 shields skill
Now gets:
+2 STR // from 0
+1 END // from +2
-1 SPD // from +2
+1 CON // from 0
Archer:
Reworked into the crossbowman. Gets a crossbow guaranteed. 3 sword skill, for use of their backup sword
Now gets:
+1 STR // same as before
+2 PER // same as before
-1 SPD // from +1
+1 END // from -2

## Why It's Good For The Game

The men-at-arms are far too multifarious. The fencer is extremely out of place, without even a helmet, as well as using the RAPIER, a noble weapon. The archer was also odd, with light armor, and a chance of crossbow/archer. This makes the men-at-arms much more uniform, like an actual standing army. Also, the pikeman and archer got endurance debuffs but speed buffs for no damn reason. The speed debuff will incentivize them to stay in the keep. Now the ranger and swordsman will be more threatening as well, the two of them are currently paper thin when it comes to durability, which is unfitting for a crown soldier. The armor of the pikeman was hardly better too.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

