### PR TITLE
Migration fluff removal

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -37,7 +37,6 @@
 
 /datum/migrant_wave/pilgrim
 	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_one
 	roles = list(
 		/datum/migrant_role/pilgrim = 4,
 	)
@@ -46,7 +45,6 @@
 
 /datum/migrant_wave/adventurer
 	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_one
 	roles = list(
 		/datum/migrant_role/adventurer = 4,
 	)
@@ -56,7 +54,6 @@
 /datum/migrant_wave/bandit
 	name = "Bandit Raid"
 	spawn_landmark = "Bandit"
-	downgrade_wave = /datum/migrant_wave/bandit_down_one
 	weight = 8
 	roles = list(
 		/datum/migrant_role/bandit = 4,
@@ -65,7 +62,6 @@
 
 /datum/migrant_wave/merc
 	name = "Band of Mercenaries"
-	downgrade_wave = /datum/migrant_wave/merc_down_one
 	weight = 8
 	roles = list(
 		/datum/migrant_role/mercenary = 4,

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -43,31 +43,6 @@
 	)
 	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Vanderlin, looking for refuge and work, finally almost being there, almost..."
 
-/datum/migrant_wave/pilgrim_down_one
-	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/pilgrim = 3,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Vanderlin, looking for refuge and work, finally almost being there, almost..."
-
-/datum/migrant_wave/pilgrim_down_two
-	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/pilgrim = 2,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Vanderlin, looking for refuge and work, finally almost being there, almost..."
-
-/datum/migrant_wave/pilgrim_down_three
-	name = "Pilgrimage"
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/pilgrim = 1,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Vanderlin, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/adventurer
 	name = "Adventure Party"
@@ -77,31 +52,6 @@
 	)
 	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Vanderlin, perhaps getting ourselves into more than what we bargained for."
 
-/datum/migrant_wave/adventurer_down_one
-	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/adventurer = 3,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Vanderlin, perhaps getting ourselves into more than what we bargained for."
-
-/datum/migrant_wave/adventurer_down_two
-	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/adventurer = 2,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Vanderlin, perhaps getting ourselves into more than what we bargained for."
-
-/datum/migrant_wave/adventurer_down_three
-	name = "Adventure Party"
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/adventurer = 1,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Vanderlin, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/bandit
 	name = "Bandit Raid"
@@ -113,32 +63,6 @@
 	)
 	can_roll = FALSE
 
-/datum/migrant_wave/bandit_down_one
-	name = "Bandit Raid"
-	spawn_landmark = "Bandit"
-	downgrade_wave = /datum/migrant_wave/bandit_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/bandit = 3,
-	)
-
-/datum/migrant_wave/bandit_down_two
-	name = "Bandit Raid"
-	spawn_landmark = "Bandit"
-	downgrade_wave = /datum/migrant_wave/bandit_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/bandit = 2,
-	)
-
-/datum/migrant_wave/bandit_down_three
-	name = "Bandit Raid"
-	spawn_landmark = "Bandit"
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/bandit = 1,
-	)
-
 /datum/migrant_wave/merc
 	name = "Band of Mercenaries"
 	downgrade_wave = /datum/migrant_wave/merc_down_one
@@ -146,26 +70,4 @@
 	roles = list(
 		/datum/migrant_role/mercenary = 4,
 	)
-
-/datum/migrant_wave/merc_down_one
-	name = "Band of Mercenaries"
-	downgrade_wave = /datum/migrant_wave/merc_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/mercenary = 3,
-	)
-
-/datum/migrant_wave/merc_down_two
-	name = "Band of Mercenaries"
-	downgrade_wave = /datum/migrant_wave/merc_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/mercenary = 2,
-	)
-
-/datum/migrant_wave/merc_down_three
-	name = "Band of Mercenaries"
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/mercenary = 1,
-	)
+	greet_text = "A group of mercenaries, hired by the Vanderlin nobility to protect the city from threats, has arrived. They are well equipped and ready to face any challenge that comes their way."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request

Removes (down x) lineation from basic migration events. Rapidly speeds up the amount of time it takes to cycle through common roles such as pilgrim/adventurer/mercenary/bandit, since they're available through latejoin. 

## Why It's Good For The Game

The redundancy is fairly obvious outside of the niche of wanting to queue roundstart in a combined group diegetically, or when adventurer/mercenary/bandit/pilgrim slots are full. Otherwise, migration roles that are actually desired are almost always inaccessible without absurd amounts of time spent waiting. This should help massively alleviate that without actually removing said content. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
