### PR TITLE
cleric gear balanceslop

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -17,8 +17,8 @@
 	..()
 	H.virginity = TRUE
 
-	armor = /obj/item/clothing/armor/cuirass/iron // Adventurers are not supposed to have fricking steel, at all
 	head = /obj/item/clothing/head/helmet/ironpot
+	armor = /obj/item/clothing/armor/cuirass/iron // Adventurers are not supposed to have fricking steel, at all
 	shirt = /obj/item/clothing/armor/gambeson/light
 	pants = /obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots/leather


### PR DESCRIPTION

## About The Pull Request

Steel cuirass replaced with iron
Shirt replaced with light gambeson
Given an iron pot helmet
Variable neck armors replaced with an iron chain coif.

## Why It's Good For The Game

Adventurers aren't supposed to have steel, so I removed it.
Currently a cleric's neck armor depends on their patron which is dumb, so I removed it.
The cleric doesn't have a helmet, or any armor under the cuirass, so I added a crappy light gambeson and a crappy iron pot helmet.

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.