### PR TITLE
Necran cleric gets a shovel

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -23,6 +23,8 @@
 	shoes = /obj/item/clothing/shoes/boots/leather
 	belt = /obj/item/storage/belt/leather
 	backr = /obj/item/weapon/shield/heater
+	if(ispath(H.patron?.type, /datum/patron/divine/necra))
+		backl = /obj/item/weapon/shovel
 	if(ispath(H.patron?.type, /datum/patron/divine/abyssor))
 		backl = /obj/item/weapon/polearm/woodstaff/quarterstaff
 	else
@@ -135,6 +137,8 @@
 		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
+		if(ispath(H.patron?.type, /datum/patron/divine/necra))
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		var/datum/skill/to_add = /datum/skill/combat/axesmaces
 		if(ispath(H.patron?.type, /datum/patron/divine/abyssor))
 			to_add = /datum/skill/combat/polearms


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Necran Templars now start with a shovel on their back and average polearm skill. Someone mentioned that having a shovel would be nice to allow the travelling necran to bury deceased adventurers on their way, and average polearm skill seemed fitting if they wanna go gung ho with their shovel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
![Byeah](https://static.wikitide.net/allthetropeswiki/thumb/7/7e/ShovelKnightRun_-_AllTheTropes.png/1200px-ShovelKnightRun_-_AllTheTropes.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
