### PR TITLE
Fixes the holes near the mercenary's guild on Rosewood.

### DIFF
--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -3870,12 +3870,6 @@
 	},
 /turf/open/floor/wood,
 /area/rogue/indoors/town/tavern)
-"cbQ" = (
-/obj/machinery/light/fueledstreet/blue/wall{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town)
 "cbT" = (
 /obj/structure/fake_machine/mail{
 	mailtag = "Shack"
@@ -109113,10 +109107,10 @@ cwC
 cwC
 jnM
 jnM
-jKl
+pmI
 jnM
 pmI
-jKl
+pmI
 jnM
 pmI
 jnM
@@ -109315,10 +109309,10 @@ cwC
 pmI
 vQB
 pmI
-jKl
+pmI
 pmI
 qVz
-cbQ
+pmI
 jnM
 jnM
 jnM

--- a/_maps/map_files/rosewood/rosewood.dmm
+++ b/_maps/map_files/rosewood/rosewood.dmm
@@ -30789,10 +30789,9 @@
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/church/inquisition)
 "qVz" = (
-/obj/structure/fluff/statue/gaffer{
-	pixel_y = 24
-	},
-/turf/open/floor/cobblerock/snow,
+/obj/structure/fluff/statue/gaffer,
+/obj/structure/fluff/statue/gaffer,
+/turf/open/floor/snow,
 /area/rogue/outdoors/town)
 "qVA" = (
 /obj/structure/fluff/railing/border{
@@ -108906,10 +108905,10 @@ pmI
 cwC
 cwC
 pmI
-jnM
-jnM
-jnM
-jnM
+pmI
+pmI
+pmI
+pmI
 pmI
 jnM
 jnM
@@ -109109,11 +109108,11 @@ jnM
 jnM
 pmI
 jnM
-pmI
-pmI
+jnM
+jnM
 jnM
 pmI
-jnM
+pmI
 pmI
 its
 gzt
@@ -109310,9 +109309,9 @@ pmI
 vQB
 pmI
 pmI
-pmI
+gzt
 qVz
-pmI
+gzt
 jnM
 jnM
 jnM


### PR DESCRIPTION
## About The Pull Request

Title. Fills the holes with adjacent tile textures. It's as if it never existed.

## Why It's Good For The Game

Soul.
![image](https://github.com/user-attachments/assets/ac74883a-c420-4f81-8f41-50c50fecb797)
![image](https://github.com/user-attachments/assets/c97a76d4-1a68-4daa-95bf-e6a3be34b660)

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
