### PR TITLE
Alchemy and Magic Tweaks

### DIFF
--- a/code/modules/crafting/alchemy/grind_recipes.dm
+++ b/code/modules/crafting/alchemy/grind_recipes.dm
@@ -54,8 +54,8 @@
 /datum/alch_grind_recipe/fish
 	picky = FALSE
 	valid_input = /obj/item/reagent_containers/food/snacks/fish
-	valid_outputs = list(/obj/item/alch/waterdust = 1)
-	bonus_chance_outputs = list(/obj/item/alch/bonemeal = 50)
+	valid_outputs = list(/obj/item/alch/waterdust = 2) // makes fish worth buying , fisher/apothecary combo
+	bonus_chance_outputs = list(/obj/item/alch/waterdust = 25 ,/obj/item/alch/bonemeal = 33)
 
 /datum/alch_grind_recipe/swampweed
 	valid_input = /obj/item/reagent_containers/food/snacks/produce/swampweed
@@ -80,11 +80,17 @@
 /datum/alch_grind_recipe/fyritius
 	valid_input = /obj/item/reagent_containers/food/snacks/produce/fyritius
 	valid_outputs = list(/obj/item/alch/firedust = 1)
+	bonus_chance_outputs = list(/obj/item/alch/firedust = 50)
 
 /datum/alch_grind_recipe/poppy
 	valid_input = /obj/item/reagent_containers/food/snacks/produce/poppy
 	valid_outputs = list(/obj/item/reagent_containers/powder/ozium = 1)
-	bonus_chance_outputs = list(/obj/item/alch/airdust =33,/obj/item/alch/earthdust = 33)
+	bonus_chance_outputs = list(/obj/item/alch/airdust =33 ,/obj/item/alch/earthdust = 33)
+
+/datum/alch_grind_recipe/manabloom
+	valid_input = /obj/item/reagent_containers/food/snacks/produce/manabloom
+	valid_outputs = list(/obj/item/reagent_containers/powder/manabloom = 1)
+	bonus_chance_outputs = list(/obj/item/reagent_containers/powder/manabloom =33, /obj/item/alch/runedust= 33)
 
 /datum/alch_grind_recipe/seeds
 	picky = FALSE

--- a/code/modules/crafting/quality_of_crafting/crafting.dm
+++ b/code/modules/crafting/quality_of_crafting/crafting.dm
@@ -516,18 +516,3 @@
 	attacked_atom = /obj/item/natural/cloth
 	uses_attacked_atom = TRUE
 	subtypes_allowed = TRUE
-
-/datum/repeatable_crafting_recipe/crafting/manabloom_powder
-	name = "manabloom powder"
-	reagent_requirements = list()
-	tool_usage = list()
-	requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/manabloom = 1,
-	)
-	tool_usage = list(
-		/obj/item/weapon/hammer = list("starts to crush the manabloom", "start to crush the manabloom")
-	)
-	output = /obj/item/reagent_containers/powder/manabloom
-	attacked_atom = /obj/item/reagent_containers/food/snacks/produce/manabloom
-	starting_atom = /obj/item/weapon/hammer
-	uses_attacked_atom = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Manabloom flowers can now be grinded with a pestle.
Removed "choice" menu from the mortar in favor of the following behaviour , ( left click = alchemy , righ click = grind/juice) this is because it was insanely anoying for apothecaries to grind multiple products with a menu popping over and over.
Removed Manabloon Powder "crafting" recipe.
Manablooms now have a chance to give 1 extra dust and 1 extra runedust when grinded.
Increased fish water dust Yield.
Increased Fyritus fire dust Yield.


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Fixed some small anoyances of alchemy and mages. 
Adds a way to obtain runedust.
makes fish and firitus farming a little more rewarding considering they are not readily available.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
