### PR TITLE
Mercator's Eye

### DIFF
--- a/_maps/map_files/shared/CentCom.dmm
+++ b/_maps/map_files/shared/CentCom.dmm
@@ -3029,7 +3029,7 @@
 /turf/open/floor/herringbone,
 /area/rogue/indoors/vampire_manor)
 "qX" = (
-/obj/item/clothing/neck/horus,
+/obj/item/clothing/neck/mercator,
 /obj/item/clothing/neck/shalal,
 /obj/item/clothing/neck/psycross/silver/astrata,
 /obj/item/clothing/neck/psycross/silver/dendor,

--- a/code/modules/clothing/neck/misc.dm
+++ b/code/modules/clothing/neck/misc.dm
@@ -262,13 +262,31 @@
 	resistance_flags = FIRE_PROOF
 	sellprice = 98
 
-/obj/item/clothing/neck/horus
-	name = "eye of horuz"
-	desc = ""
+/obj/item/clothing/neck/mercator
+	name = "mercator's eye"
+	desc = "An enchanted amulet commissioned by the Mercator Guild to quickly determine the commercial value of bulk goods."
 	icon_state = "horus"
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
 	sellprice = 30
+
+/obj/item/clothing/neck/mercator/examine()
+	. = ..()
+	. += span_info("Click on a turf or an item to see how much it is worth.")
+
+/obj/item/clothing/neck/mercator/afterattack(atom/A, mob/user, params)
+	. = ..()
+	var/total_sellprice = 0
+	if(isturf(A))
+		for(var/obj/item/I in A.contents)
+			total_sellprice += I.sellprice
+		to_chat(user, span_notice("Everything on the ground is worth [total_sellprice] mammons."))
+	else if(istype(A, /obj/item))
+		var/obj/item/I = A
+		total_sellprice += I.sellprice
+		for(var/obj/item/item in I.contents)
+			total_sellprice += item.sellprice
+		to_chat(user, span_notice("The item and its contents is worth [total_sellprice] mammons."))
 
 /obj/item/clothing/neck/shalal
 	name = "desert rider medal"

--- a/code/modules/jobs/job_types/nobility/merchant.dm
+++ b/code/modules/jobs/job_types/nobility/merchant.dm
@@ -1,7 +1,7 @@
 /datum/job/merchant
 	title = "Merchant"
-	tutorial = "Born a wastrel in the dirt, you clawed your way up. Either by luck or, gods forbid, effort to earn a place in the Merchant's Guild.\
-	Now, you are either a ruthless economist or a disgraced steward from distant lands. Where you came from no longer matters.\
+	tutorial = "Born a wastrel in the dirt, you clawed your way up. Either by luck or, gods forbid, effort to earn a place in the Merchant's Guild. \
+	Now, you are either a ruthless economist or a disgraced steward from distant lands. Where you came from no longer matters. \
 	What matters now is you make sure the fools around you keep buying what you sell. Everything has a price, and you shall be the beating heart of this economy."
 	flag = MERCHANT
 	department_flag = COMPANY
@@ -36,7 +36,7 @@
 /datum/outfit/job/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
 
-	neck = /obj/item/clothing/neck/horus
+	neck = /obj/item/clothing/neck/mercator
 	backr = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/veryrich = 1, /obj/item/merctoken = 1)
 	beltr = /obj/item/weapon/sword/rapier


### PR DESCRIPTION
## About The Pull Request
- Changes Eye of Horuz name to Mercantor's Eye
- Mercantor's Eye can scan values of an items or all items on a turf.
- Fixes text spacing for merchant tutorial text.
![Mercator's Eye](https://github.com/user-attachments/assets/0374a914-e78c-4c93-9bbc-2320f44f150a)
Ported from this https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2768. Thank you.

## Why It's Good For The Game
I love examining 40 fish just to lowball the guy. The merchant can also lend out the eye to hired hands who don't have the knows prices trait so they can buy things for him while they're out of shop.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
