### PR TITLE
Fixes Black Bag Perma Blindness

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -182,7 +182,7 @@
 /obj/item/clothing/head/sack/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot & ITEM_SLOT_HEAD)
-		user.become_blind("blindfold[REF(src)]")
+		user.become_blind("blindfold_[REF(src)]")
 
 /obj/item/clothing/head/sack/dropped(mob/living/carbon/human/user)
 	..()


### PR DESCRIPTION
## About The Pull Request
The black bag wasn't removing the blindness effect when removed. This should fix that.

## Why It's Good For The Game
The bag shouldn't be making people permanently blind.
Before
![black square](https://github.com/user-attachments/assets/f458e8c0-2979-40e0-aedf-492f5fc96a1d)
After
![images](https://github.com/user-attachments/assets/362f1109-cd96-45ae-a72b-d6b96872ff9b)

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
