### PR TITLE
Prevent server crashes by cleaning up HTTP requests sent by SSelastic and Plexora

### DIFF
--- a/code/controllers/subsystem/elastic.dm
+++ b/code/controllers/subsystem/elastic.dm
@@ -17,6 +17,9 @@ SUBSYSTEM_DEF(elastic)
 	var/list/assoc_list_data = list() //! ### This NEEDS NEEDS NEEDS NEEDS NEEDS to be an assoclist. When 516 is in this will be an alist
 	///abstract information - basically want to keep track of spell casts over the round? do it like this
 	var/list/abstract_information = list()
+	/// list of /datum/http_request that we check to ensure they don't leak memory
+	var/list/active_requests = list()
+	var/shutting_down = FALSE
 
 /datum/controller/subsystem/elastic/Initialize(start_timeofday)
 	if(!CONFIG_GET(flag/elastic_middleware_enabled))
@@ -24,16 +27,33 @@ SUBSYSTEM_DEF(elastic)
 	set_abstract_data_zeros()
 	return ..()
 
+/datum/controller/subsystem/elastic/Shutdown()
+	shutting_down = TRUE
+	var/end_time = REALTIMEOFDAY + (5 SECONDS)
+	while((length(active_requests) > 0) && (REALTIMEOFDAY < end_time))
+		for(var/datum/http_request/request as anything in active_requests)
+			if(request.is_complete())
+				active_requests -= request
+				qdel(request)
+	active_requests.Cut()
+
 /datum/controller/subsystem/elastic/fire(resumed)
 	send_data()
+	for(var/datum/http_request/request as anything in active_requests)
+		if(request.is_complete()) // rust-g will clear the job once it's complete
+			active_requests -= request
+			qdel(request)
 
 /datum/controller/subsystem/elastic/proc/send_data()
+	if(shutting_down)
+		return
 	var/datum/http_request/request = new()
 	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/elastic_endpoint), get_compiled_data(), list(
 		"Authorization" = "ApiKey [CONFIG_GET(string/metrics_api_token)]",
 		"Content-Type" = "application/json"
 	))
 	request.begin_async()
+	active_requests += request
 
 /datum/controller/subsystem/elastic/proc/get_compiled_data()
 	var/list/compiled = list()


### PR DESCRIPTION
## About The Pull Request

okay so the logs from https://github.com/Monkestation/Vanderlin/pull/2374 made it clear what the issue was - SSplexora and SSelastic sent a lot of http requests, _which were never properly cleaned up_ due to how rust-g works, and they could eventually OOM BYOND (which is 32-bit) if they stacked for too long. so. those 2 subsystems properly clean up after themselves now.

## Why It's Good For The Game

bugfix goodn WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
