### PR TITLE
Lets all patrons queue for gravetender.

### DIFF
--- a/code/modules/jobs/job_types/peasants/gravedigger.dm
+++ b/code/modules/jobs/job_types/peasants/gravedigger.dm
@@ -17,14 +17,12 @@
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_PLAYER_NONHERETICAL
-	allowed_patrons = list(/datum/patron/divine/necra)
 
 	outfit = /datum/outfit/job/undertaker
 	give_bank_account = TRUE
 	cmode_music = 'sound/music/cmode/church/CombatGravekeeper.ogg'
 
 /datum/outfit/job/undertaker
-	allowed_patrons = list(/datum/patron/divine/necra)
 	job_bitflag = BITFLAG_CHURCH
 
 /datum/outfit/job/undertaker/pre_equip(mob/living/carbon/human/H)
@@ -38,6 +36,10 @@
 	beltl = /obj/item/storage/keyring/gravetender
 	beltr = /obj/item/storage/belt/pouch/coins/poor
 	backr = /obj/item/weapon/shovel
+
+	if(H.patron != /datum/patron/divine/necra)
+		H.set_patron(/datum/patron/divine/necra)
+
 	H.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE) // these are basically the acolyte skills with a bit of other stuff
 	H.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the allowed_patrons requirement from Gravetender, sets patron to Necra on pre_equip.

## Why It's Good For The Game

Brings the role to the standards set by other patron-locked roles. 

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
