### PR TITLE
Craftable Potter's Lathe and Clay. Changes Pottery Crafting Chances.

### DIFF
--- a/code/datums/pottery_recipes/_base.dm
+++ b/code/datums/pottery_recipes/_base.dm
@@ -37,13 +37,15 @@
 	return TRUE
 
 /datum/pottery_recipe/proc/update_step(mob/living/user, rotations_per_minute)
-	var/skill_level = max(1, user?.get_skill_level(/datum/skill/craft/masonry))
-	var/fail_chance = (25 * difficulty) + (skill_level * 25)
+	var/skill_level = max(0, user?.get_skill_level(/datum/skill/craft/masonry))
+	var/success_chance = 25 * ((skill_level - difficulty) + 1)
+	success_chance = clamp(success_chance, 5, 95) // No reason to block pottery with lower masonry skills, just make it not worth the time.
+
 	if(rotations_per_minute > speed_sweetspot)
-		fail_chance += (rotations_per_minute - speed_sweetspot) * 2
-	if(prob(fail_chance))
+		success_chance -= (rotations_per_minute - speed_sweetspot) * 2
+	if(!prob(success_chance))
 		if(user.client?.prefs.showrolls)
-			to_chat(user, "<span class='danger'>I've messed up \the [name]. (Success chance: [max(0, 100 - fail_chance)]%)</span>")
+			to_chat(user, "<span class='danger'>I've messed up \the [name]. (Success chance: [success_chance]%)</span>")
 			return
 		to_chat(user, "<span class='danger'>I've messed up \the [name].</span>")
 		return

--- a/code/modules/crafting/quality_of_crafting/natural_items.dm
+++ b/code/modules/crafting/quality_of_crafting/natural_items.dm
@@ -444,3 +444,15 @@
 	output = /obj/item/weapon/axe/boneaxe
 	craftdiff = 2
 
+/datum/repeatable_crafting_recipe/survival/clay
+	name = "clay lump"
+	requirements = list(
+		/obj/item/natural/dirtclod= 3,
+	)
+	reagent_requirements = list(
+		/datum/reagent/water = 10
+	)
+	attacked_atom = /obj/item/natural/dirtclod
+	starting_atom = /obj/item/natural/dirtclod
+	output = /obj/item/natural/clay
+	craftdiff = 0

--- a/code/modules/crafting/structure.dm
+++ b/code/modules/crafting/structure.dm
@@ -101,6 +101,15 @@
 	craftsound = null
 	skillcraft = /datum/skill/craft/masonry
 
+/datum/crafting_recipe/structure/pottery_lathe
+	name = "potter's lathe"
+	result = /obj/structure/pottery_lathe
+	reqs = list(/obj/item/natural/stone = 2,
+				/obj/item/grown/log/tree/small = 1)
+	verbage = "mason"
+	verbage_tp = "masons"
+	skillcraft = /datum/skill/craft/masonry
+
 /datum/crafting_recipe/structure/torchholder
 	name = "sconce"
 	result = /obj/machinery/light/fueled/torchholder


### PR DESCRIPTION
## About The Pull Request
Adds potter's lathe masonry recipe (craft menu), craftdiff =1 masonry two stone, one small log.
Adds  clay slapcraft craftdiff = 0 crafting, three dirtclod 10u water. Dirtclod slap dirtclod.

Also it looked like there was a problem with the way success was calculated for pottery crafts. I tested it and think I fixed it. Pottery crafts are all either craftdiff 0 or 1, but I clamped crafts at a minimum of 5%. 

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/83b76fa6-9282-4e65-921a-2c605bb6c036" />


## Why It's Good For The Game
Clay shouldn't be a limited resource, and people shouldn't have to go to the smith's bedroom to do pottery. Now people can make pottery.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
