### PR TITLE
Churchlings now have Celestial.

### DIFF
--- a/code/modules/jobs/job_types/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/youngfolk/churchling.dm
@@ -77,6 +77,9 @@
 
 	H.change_stat(STATKEY_PER, 1)
 	H.change_stat(STATKEY_SPD, 2)
+	if(!H.has_language(/datum/language/celestial)) // For discussing church matters with the other Clergy
+		H.grant_language(/datum/language/celestial)
+		to_chat(H, "<span class='info'>I can speak Celestial with ,c before my speech.</span>")
 
 	var/datum/devotion/cleric_holder/C = new /datum/devotion/cleric_holder(H, H.patron)
 	C.grant_spells_churchling(H)


### PR DESCRIPTION
## About The Pull Request

Right what it says on the tin. Churchlings can speak and understand celestial now. 

## Why It's Good For The Game

They're a church role, presumably taken in and taken care of, possibly raised, by the church. It's a bit odd they aren't taught the language of the clergy.

Aberra also said they probably should be able to speak it. 

<img width="514" height="68" alt="Discord_YSfxu2nTLb" src="https://github.com/user-attachments/assets/3563a937-8d7b-424b-a556-82380fc0032c" />


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
