### PR TITLE
Retrigger pointed spells with a cooldown less than 1 minute if no spell is reselected

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_action.dm
+++ b/code/__DEFINES/dcs/signals/signals_action.dm
@@ -23,16 +23,12 @@
 	#define COMPONENT_BLOCK_ABILITY_START (1<<0)
 /// From base of /datum/action/cooldown/proc/PreActivate(), sent to the action owner: (datum/action/cooldown/finished)
 #define COMSIG_MOB_ABILITY_FINISHED "mob_ability_base_finished"
+/// From base of /datum/action/cooldown/proc/CooldownEnded()
+#define COMSIG_ACTION_COOLDOWN_ENDED "mob_action_cooldown_ended"
 
 // Specific cooldown action signals
 
-/// From base of /datum/action/cooldown/mob_cooldown/blood_warp/proc/blood_warp(): ()
-#define COMSIG_BLOOD_WARP "mob_ability_blood_warp"
 /// From base of /datum/action/cooldown/mob_cooldown/charge/proc/do_charge(): ()
 #define COMSIG_STARTED_CHARGE "mob_ability_charge_started"
 /// From base of /datum/action/cooldown/mob_cooldown/charge/proc/do_charge(): ()
 #define COMSIG_FINISHED_CHARGE "mob_ability_charge_finished"
-/// From base of /datum/action/cooldown/mob_cooldown/lava_swoop/proc/swoop_attack(): ()
-#define COMSIG_SWOOP_INVULNERABILITY_STARTED "mob_swoop_invulnerability_started"
-/// From base of /datum/action/cooldown/mob_cooldown/lava_swoop/proc/swoop_attack(): ()
-#define COMSIG_LAVA_ARENA_FAILED "mob_lava_arena_failed"

--- a/code/datums/actions/action_cooldown.dm
+++ b/code/datums/actions/action_cooldown.dm
@@ -131,8 +131,8 @@
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 	START_PROCESSING(SSfastprocess, src)
 
-/// Callback proc for when the cooldown of the spell would naturally end may not actually end at this time,
-/// Or may have already ended.
+/// Callback proc for when the cooldown of the spell would naturally end,
+/// may not actually end at this time or may have already ended.
 /datum/action/cooldown/proc/CooldownEnded()
 	if(QDELETED(src) || QDELETED(owner))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Trigger a timer when spells start a cooldown which sends a signal for *natural* cooldown ending which if possible retriggers the last spell used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mirror previous behaviour.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
