### PR TITLE
Fixes a migrant wave crash on the debug map

### DIFF
--- a/_maps/map_files/debug/roguetest.dmm
+++ b/_maps/map_files/debug/roguetest.dmm
@@ -2773,6 +2773,10 @@
 /mob/living/simple_animal/hostile/retaliate/cow,
 /turf/open/floor/grass/yel,
 /area/rogue/outdoors)
+"XG" = (
+/obj/effect/landmark/start/adventurerlate,
+/turf/open/floor/grass/yel,
+/area/rogue/outdoors)
 "XL" = (
 /obj/structure/hotspring/border/twelve,
 /turf/open/floor/dirt/road,
@@ -15124,7 +15128,7 @@ qi
 RC
 QN
 Wg
-QN
+XG
 qc
 jC
 fS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Forcing and joining as part of a migrant wave crashes the game while on the roguetest map, because most migrants use the Pilgrim landmark to spawn, which the debug  map doesn't have/destroys after roundstart
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
