### PR TITLE
prevent edge case where jaunting can end without removing its traits

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -54,6 +54,8 @@
 // Jaunt Spells
 /// Sent from datum/action/cooldown/spell/jaunt/enter_jaunt, to the mob jaunting: (obj/effect/dummy/phased_mob/jaunt, datum/action/cooldown/spell/spell)
 #define COMSIG_MOB_ENTER_JAUNT "spell_mob_enter_jaunt"
+/// Set from /obj/effect/dummy/phased_mob after the mob is ejected from its contents: (obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+#define COMSIG_MOB_EJECTED_FROM_JAUNT "spell_mob_eject_jaunt"
 /// Sent from datum/action/cooldown/spell/jaunt/exit_jaunt, after the mob exited jaunt: (datum/action/cooldown/spell/spell)
 #define COMSIG_MOB_AFTER_EXIT_JAUNT "spell_mob_after_exit_jaunt"
 

--- a/code/modules/spells/spell_types/undirected/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/undirected/jaunt/_jaunt.dm
@@ -56,9 +56,9 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
+	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, PROC_REF(on_jaunt_exited))
 	spell_requirements |= SPELL_CASTABLE_WHILE_PHASED
-	ADD_TRAIT(jaunter, TRAIT_MAGICALLY_PHASED, REF(src))
-	ADD_TRAIT(jaunter, TRAIT_RUNECHAT_HIDDEN, REF(src))
+	jaunter.add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
 	// Don't do the feedback until we have runechat hidden.
 	// Otherwise the text will follow the jaunt holder, which reveals where our caster is travelling.
 	spell_feedback()
@@ -88,14 +88,28 @@
 	if(loc_override)
 		jaunt.forceMove(loc_override)
 	jaunt.eject_jaunter()
-	spell_requirements &= ~SPELL_CASTABLE_WHILE_PHASED
-	REMOVE_TRAIT(unjaunter, TRAIT_MAGICALLY_PHASED, REF(src))
-	REMOVE_TRAIT(unjaunter, TRAIT_RUNECHAT_HIDDEN, REF(src))
 
-	// Ditto - this needs to happen at the end, after all the traits and stuff is handled
-	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)
 	return TRUE
+
+/**
+ * Called when a mob is ejected from the jaunt holder and goes back to normal.
+ * This is called both fom exit_jaunt() but also if the caster is ejected involuntarily for some reason.
+ * Use this to clear state data applied when jaunting, such as the trait TRAIT_MAGICALLY_PHASED.
+ * Arguments
+ * * jaunt - The mob holder effect the caster has just exited
+ * * unjaunter - The spellcaster who is no longer jaunting
+ */
+/datum/action/cooldown/spell/undirected/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
+	SHOULD_CALL_PARENT(TRUE)
+	check_flags &= ~AB_CHECK_PHASED
+	unjaunter.remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
+	// This needs to happen at the end, after all the traits and stuff is handled
+	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)
 
 /datum/action/cooldown/spell/undirected/jaunt/Remove(mob/living/remove_from)
 	exit_jaunt(remove_from)
+	if(!is_jaunting(remove_from)) // In case you have made exit_jaunt conditional, as in mirror walk
+		return ..()
+	var/obj/effect/dummy/phased_mob/jaunt = remove_from.loc
+	jaunt.eject_jaunter()
 	return ..()

--- a/code/modules/spells/spell_types/undirected/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/undirected/jaunt/_jaunt.dm
@@ -101,7 +101,7 @@
  */
 /datum/action/cooldown/spell/undirected/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	SHOULD_CALL_PARENT(TRUE)
-	check_flags &= ~AB_CHECK_PHASED
+	spell_requirements &= ~SPELL_CASTABLE_WHILE_PHASED
 	unjaunter.remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN, TRAIT_WEATHER_IMMUNE), REF(src))
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Somehow a court mage ended up leaving the jaunt without triggering the leave, this assures any method of leaving the jaunt dummy removes the traits granted by jaunting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
