### PR TITLE
Influences tweaks, best and worst gods receive influence modifiers

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -868,7 +868,7 @@ SUBSYSTEM_DEF(gamemode)
 /// Loads config values from game_options.txt
 /datum/controller/subsystem/gamemode/proc/load_config_vars()
 	point_gain_multipliers[EVENT_TRACK_MUNDANE] = CONFIG_GET(number/mundane_point_gain_multiplier)
-	point_gain_multipliers[EVENT_TRACK_PERSONAL] = CONFIG_GET(number/moderate_point_gain_multiplier) * 1.2
+	point_gain_multipliers[EVENT_TRACK_PERSONAL] = CONFIG_GET(number/moderate_point_gain_multiplier) * 1.25
 	point_gain_multipliers[EVENT_TRACK_MODERATE] = CONFIG_GET(number/moderate_point_gain_multiplier)
 	point_gain_multipliers[EVENT_TRACK_INTERVENTION] = CONFIG_GET(number/major_point_gain_multiplier)
 	point_gain_multipliers[EVENT_TRACK_CHARACTER_INJECTION] = CONFIG_GET(number/roleset_point_gain_multiplier)
@@ -1656,20 +1656,20 @@ SUBSYSTEM_DEF(gamemode)
 
 /// Returns influence value for a given storyteller for his given statistic
 /datum/controller/subsystem/gamemode/proc/calculate_specific_influence(datum/storyteller/chosen_storyteller, statistic)
-	var/datum/storyteller/initalized_storyteller = storytellers[chosen_storyteller]
-	if(!initalized_storyteller)
+	var/datum/storyteller/initialized_storyteller = storytellers[chosen_storyteller]
+	if(!initialized_storyteller)
 		return
 
-	if(!(statistic in initalized_storyteller.influence_factors))
+	if(!(statistic in initialized_storyteller.influence_factors))
 		return
 
 	var/influence = 0
 	var/stat_value = GLOB.vanderlin_round_stats[statistic]
-	var/list/factors = initalized_storyteller.influence_factors[statistic]
+	var/list/factors = initialized_storyteller.influence_factors[statistic]
 	var/modifier = factors["points"]
 	var/capacity = factors["capacity"]
 
-	var/raw_contribution = stat_value * modifier
+	var/raw_contribution = (stat_value * modifier) * initialized_storyteller.influence_modifier
 	influence = (modifier < 0) ? max(raw_contribution, capacity) : min(raw_contribution, capacity)
 
 	return influence

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1352,7 +1352,7 @@ SUBSYSTEM_DEF(gamemode)
 	if(!highest)
 		return
 
-	var/adjustment = min(2.5, 1 + (0.3 * FLOOR(max(0, highest.times_chosen - 5) / 5, 1)))
+	var/adjustment = min(3, 1 + (0.4 * FLOOR(max(0, highest.times_chosen - 5) / 5, 1)))
 
 	if(storytellers_with_influence[highest] > adjustment)
 		highest.bonus_points -= adjustment

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -72,6 +72,8 @@
 	var/list/influence_sets = list()
 	/// Chosen influence factors, which are used to calculate storyteller influence. List of lists, which looks like RELEVANT_STATS = list(point gain, max capacity)
 	var/influence_factors = list()
+	/// Modifier to the calcualted value of the chosen influence factors, default is 1 (100%)
+	var/influence_modifier = 1
 	/// How many influence points storyteller gets for each follower
 	var/follower_modifier = STANDARD_FOLLOWER_MODIFIER
 	/// Thematic color of the storyteller, used in statistics menu

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -155,7 +155,7 @@
 
 	influence_sets = list(
 		"Set 1" = list(
-			STATS_LAUGHS_MADE = list("name" = "Laughs had:", "points" = 0.24, "capacity" = 85),
+			STATS_LAUGHS_MADE = list("name" = "Laughs had:", "points" = 0.23, "capacity" = 85),
 		),
 		"Set 2" = list(
 			STATS_GAMES_RIGGED = list("name" = "Games rigged:", "points" = 3.5, "capacity" = 40),
@@ -490,17 +490,17 @@
 			STATS_ASSASSINATIONS = list("name" = "Successful assasinations:", "points" = 17.5, "capacity" = 80),
 		),
 		"Set 2" = list(
-			STATS_BLOOD_SPILT = list("name" = "Blood spilt:", "points" = 0.0285, "capacity" = 90),
+			STATS_BLOOD_SPILT = list("name" = "Blood spilt:", "points" = 0.02825, "capacity" = 90),
 		),
 		"Set 3" = list(
-			STATS_ORGANS_EATEN = list("name" = "Organs eaten:", "points" = 4.5, "capacity" = 70),
+			STATS_ORGANS_EATEN = list("name" = "Organs eaten:", "points" = 4.25, "capacity" = 70),
 		),
 		"Set 4" = list(
-			STATS_LIMBS_BITTEN = list("name" = "Limbs bitten:", "points" = 1, "capacity" = 70),
+			STATS_LIMBS_BITTEN = list("name" = "Limbs bitten:", "points" = 0.9, "capacity" = 70),
 			STATS_ALIVE_HALF_ORCS = list("name" = "Number of half-orcs:", "points" = 6.25, "capacity" = 65),
 		),
 		"Set 5" = list(
-			STATS_PEOPLE_GIBBED = list("name" = "People gibbed:", "points" = 3.25, "capacity" = 55),
+			STATS_PEOPLE_GIBBED = list("name" = "People gibbed:", "points" = 3, "capacity" = 55),
 		)
 	)
 
@@ -543,7 +543,7 @@
 			STATS_KLEPTOMANIACS = list("name" = "Number of kleptomaniacs:", "points" = 12, "capacity" = 70),
 		),
 		"Set 4" = list(
-			STATS_DODGES = list("name" = "Dodges made:", "points" = 0.09, "capacity" = 100),
+			STATS_DODGES = list("name" = "Dodges made:", "points" = 0.085, "capacity" = 100),
 		),
 		"Set 5" = list(
 			STATS_LOCKS_PICKED = list("name" = "Locks picked:", "points" = 3.5, "capacity" = 80),

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -14,15 +14,15 @@
 			STATS_ALIVE_NOBLES = list("name" = "Number of nobles:", "points" = 2.5, "capacity" = 60),
 		),
 		"Set 3" = list(
-			STATS_NOBLE_DEATHS = list("name" = "Noble deaths:", "points" = -3.75, "capacity" = -60),
+			STATS_NOBLE_DEATHS = list("name" = "Noble deaths:", "points" = -3.5, "capacity" = -60),
 			STATS_PEOPLE_SMITTEN = list("name" = "People smitten:", "points" = 4.5, "capacity" = 40),
 		),
 		"Set 4" = list(
 			STATS_ASTRATA_REVIVALS = list("name" = "Holy revivals:", "points" = 6.25, "capacity" = 75),
-			STATS_PRAYERS_MADE = list("name" = "Prayers made:", "points" = 1.75, "capacity" = 65),
+			STATS_PRAYERS_MADE = list("name" = "Prayers made:", "points" = 1.8, "capacity" = 65),
 		),
 		"Set 5" = list(
-			STATS_TAXES_COLLECTED = list("name" = "Taxes collected:", "points" = 0.2, "capacity" = 80),
+			STATS_TAXES_COLLECTED = list("name" = "Taxes collected:", "points" = 0.21, "capacity" = 80),
 			STATS_SLURS_SPOKEN = list("name" = "Slurs spoken:", "points" = 1.65, "capacity" = 80),
 		)
 	)
@@ -53,7 +53,7 @@
 			STATS_ILLITERATES = list("name" = "Number of illiterates:", "points" = -2, "capacity" = -40),
 		),
 		"Set 4" = list(
-			STATS_SKILLS_DREAMED = list("name" = "Skills dreamed:", "points" = 0.33, "capacity" = 100),
+			STATS_SKILLS_DREAMED = list("name" = "Skills dreamed:", "points" = 0.335, "capacity" = 100),
 		),
 		"Set 5" = list(
 			STATS_MANA_SPENT = list("name" = "Mana spent:", "points" = 0.0165, "capacity" = 90),
@@ -84,16 +84,16 @@
 
 	influence_sets = list(
 		"Set 1" = list(
-			STATS_COMBAT_SKILLS = list("name" = "Combat skills learned:", "points" = 1.15, "capacity" = 100),
+			STATS_COMBAT_SKILLS = list("name" = "Combat skills learned:", "points" = 1.075, "capacity" = 90),
 		),
 		"Set 2" = list(
-			STATS_PARRIES = list("name" = "Parries made:", "points" = 0.0525, "capacity" = 100),
+			STATS_PARRIES = list("name" = "Parries made:", "points" = 0.052, "capacity" = 100),
 		),
 		"Set 3" = list(
 			STATS_WARCRIES = list("name" = "Warcries made:", "points" = 0.375, "capacity" = 50),
 		),
 		"Set 4" = list(
-			STATS_YIELDS = list("name" = "Yields made:", "points" = -4, "capacity" = -40),
+			STATS_YIELDS = list("name" = "Yields made:", "points" = -4.25, "capacity" = -40),
 		),
 		"Set 5" = list(
 			STATS_UNDERWORLD_DUELS = list("name" = "Underworld duels:", "points" = 6, "capacity" = 70),
@@ -116,10 +116,10 @@
 	influence_sets = list(
 		"Set 1" = list(
 			STATS_FISH_CAUGHT = list("name" = "Fish caught:", "points" = 1.6, "capacity" = 85),
-			STATS_ALIVE_TRITONS = list("name" = "Number of tritons:", "points" = 9, "capacity" = 85),
+			STATS_ALIVE_TRITONS = list("name" = "Number of tritons:", "points" = 8.5, "capacity" = 80),
 		),
 		"Set 2" = list(
-			STATS_WATER_CONSUMED = list("name" = "Water consumed:", "points" = 0.0125, "capacity" = 90),
+			STATS_WATER_CONSUMED = list("name" = "Water consumed:", "points" = 0.013, "capacity" = 90),
 		),
 		"Set 3" = list(
 			STATS_ABYSSOR_REMEMBERED = list("name" = "Abyssor remembered:", "points" = 0.85, "capacity" = 40),
@@ -155,20 +155,20 @@
 
 	influence_sets = list(
 		"Set 1" = list(
-			STATS_LAUGHS_MADE = list("name" = "Laughs had:", "points" = 0.25, "capacity" = 85),
+			STATS_LAUGHS_MADE = list("name" = "Laughs had:", "points" = 0.24, "capacity" = 85),
 		),
 		"Set 2" = list(
-			STATS_GAMES_RIGGED = list("name" = "Games rigged:", "points" = 3.75, "capacity" = 40),
-			STATS_MOAT_FALLERS = list("name" = "Moat fallers:", "points" = 4, "capacity" = 45),
+			STATS_GAMES_RIGGED = list("name" = "Games rigged:", "points" = 3.5, "capacity" = 40),
 		),
 		"Set 3" = list(
-			STATS_PEOPLE_MOCKED = list("name" = "People mocked:", "points" = 6, "capacity" = 60),
+			STATS_PEOPLE_MOCKED = list("name" = "People mocked:", "points" = 5, "capacity" = 60),
 		),
 		"Set 4" = list(
-			STATS_CRITS_MADE = list("name" = "Crits made:", "points" = 0.275, "capacity" = 90),
+			STATS_CRITS_MADE = list("name" = "Crits made:", "points" = 0.27, "capacity" = 90),
 		),
 		"Set 5" = list(
-			STATS_SONGS_PLAYED = list("name" = "Songs played:", "points" = 0.725, "capacity" = 70),
+			STATS_SONGS_PLAYED = list("name" = "Songs played:", "points" = 0.7, "capacity" = 70),
+			STATS_MOAT_FALLERS = list("name" = "Moat fallers:", "points" = 4, "capacity" = 50),
 		)
 	)
 
@@ -241,7 +241,7 @@
 			STATS_ANIMALS_BRED = list("name" = "Animals bred:", "points" = 5.75, "capacity" = 65),
 		),
 		"Set 5" = list(
-			STATS_FOOD_ROTTED = list("name" = "Food rotted:", "points" = 0.175, "capacity" = 80),
+			STATS_FOOD_ROTTED = list("name" = "Food rotted:", "points" = 0.2, "capacity" = 80),
 		)
 	)
 
@@ -322,7 +322,7 @@
 		),
 		"Set 5" = list(
 			STATS_CLINGY_PEOPLE = list("name" = "Clingy people:", "points" = 6.75, "capacity" = 75),
-			STATS_ALIVE_HARPIES = list("name" = "Number of harpies:", "points" = 7.25, "capacity" = 65),
+			STATS_ALIVE_HARPIES = list("name" = "Number of harpies:", "points" = 7.5, "capacity" = 70),
 		)
 	)
 
@@ -350,20 +350,20 @@
 
 	influence_sets = list(
 		"Set 1" = list(
-			STATS_TREES_CUT = list("name" = "Trees felled:", "points" = -0.375, "capacity" = -50),
-			STATS_WEREVOLVES = list("name" = "Number of werevolves:", "points" = 17.5, "capacity" = 70),
+			STATS_TREES_CUT = list("name" = "Trees felled:", "points" = -0.35, "capacity" = -45),
+			STATS_WEREVOLVES = list("name" = "Number of werevolves:", "points" = 15, "capacity" = 65),
 		),
 		"Set 2" = list(
-			STATS_PLANTS_HARVESTED = list("name" = "Plants harvested:", "points" = 0.825, "capacity" = 110),
+			STATS_PLANTS_HARVESTED = list("name" = "Plants harvested:", "points" = 0.825, "capacity" = 100),
 		),
 		"Set 3" = list(
 			STATS_FOREST_DEATHS = list("name" = "Forest deaths:", "points" = 6.5, "capacity" = 90),
 		),
 		"Set 4" = list(
-			STATS_DENDOR_SACRIFICES = list("name" = "Sacrifices to Dendor:", "points" = 15, "capacity" = 80),
+			STATS_DENDOR_SACRIFICES = list("name" = "Sacrifices to Dendor:", "points" = 15, "capacity" = 75),
 		),
 		"Set 5" = list(
-			STATS_ANIMALS_TAMED = list("name" = "Animals tamed:", "points" = 7, "capacity" = 65),
+			STATS_ANIMALS_TAMED = list("name" = "Animals tamed:", "points" = 6.5, "capacity" = 65),
 		)
 	)
 
@@ -397,17 +397,17 @@
 
 	influence_sets = list(
 		"Set 1" = list(
-			STATS_ZIZO_PRAISED = list("name" = "Zizo praised:", "points" = 0.825, "capacity" = 40),
+			STATS_ZIZO_PRAISED = list("name" = "Zizo praised:", "points" = 0.9, "capacity" = 40),
+			STATS_ALIVE_DARK_ELVES = list("name" = "Number of dark elves:", "points" = 6, "capacity" = 60),
 		),
 		"Set 2" = list(
-			STATS_NOBLE_DEATHS = list("name" = "Nobles killed:", "points" = 5, "capacity" = 80),
-			STATS_ALIVE_DARK_ELVES = list("name" = "Number of dark elves:", "points" = 6, "capacity" = 65),
+			STATS_NOBLE_DEATHS = list("name" = "Nobles killed:", "points" = 5.25, "capacity" = 80),
 		),
 		"Set 3" = list(
-			STATS_DEADITES_WOKEN_UP = list("name" = "Deadites woken up:", "points" = 3, "capacity" = 90),
+			STATS_DEADITES_WOKEN_UP = list("name" = "Deadites woken up:", "points" = 4, "capacity" = 85),
 		),
 		"Set 4" = list(
-			STATS_CLERGY_DEATHS = list("name" = "Clergy killed:", "points" = 9, "capacity" = 80),
+			STATS_CLERGY_DEATHS = list("name" = "Clergy killed:", "points" = 10, "capacity" = 70),
 		),
 		"Set 5" = list(
 			STATS_TORTURES = list("name" = "Tortures performed:", "points" = 5, "capacity" = 70),
@@ -445,17 +445,17 @@
 			STATS_DRUGS_SNORTED = list("name" = "Drugs snorted:", "points" = 4.25, "capacity" = 85),
 		),
 		"Set 2" = list(
-			STATS_ALCOHOL_CONSUMED = list("name" = "Alcohol consumed:", "points" = 0.045, "capacity" = 90),
+			STATS_ALCOHOL_CONSUMED = list("name" = "Alcohol consumed:", "points" = 0.0425, "capacity" = 90),
 		),
 		"Set 3" = list(
-			STATS_ALCOHOLICS = list("name" = "Number of alcoholics:", "points" = 3.5, "capacity" = 60),
+			STATS_ALCOHOLICS = list("name" = "Number of alcoholics:", "points" = 3.25, "capacity" = 60),
 		),
 		"Set 4" = list(
 			STATS_JUNKIES = list("name" = "Number of junkies:", "points" = 9, "capacity" = 70),
 			STATS_ALIVE_TIEFLINGS = list("name" = "Number of tieflings:", "points" = 6, "capacity" = 60),
 		),
 		"Set 5" = list(
-			STATS_LUXURIOUS_FOOD_EATEN = list("name" = "Luxurious food eaten:", "points" = 0.9, "capacity" = 85),
+			STATS_LUXURIOUS_FOOD_EATEN = list("name" = "Luxurious food eaten:", "points" = 0.85, "capacity" = 85),
 		)
 	)
 
@@ -490,17 +490,17 @@
 			STATS_ASSASSINATIONS = list("name" = "Successful assasinations:", "points" = 17.5, "capacity" = 80),
 		),
 		"Set 2" = list(
-			STATS_BLOOD_SPILT = list("name" = "Blood spilt:", "points" = 0.028, "capacity" = 90),
+			STATS_BLOOD_SPILT = list("name" = "Blood spilt:", "points" = 0.0285, "capacity" = 90),
 		),
 		"Set 3" = list(
-			STATS_ORGANS_EATEN = list("name" = "Organs eaten:", "points" = 4.25, "capacity" = 75),
+			STATS_ORGANS_EATEN = list("name" = "Organs eaten:", "points" = 4.5, "capacity" = 70),
 		),
 		"Set 4" = list(
 			STATS_LIMBS_BITTEN = list("name" = "Limbs bitten:", "points" = 1, "capacity" = 70),
 			STATS_ALIVE_HALF_ORCS = list("name" = "Number of half-orcs:", "points" = 6.25, "capacity" = 65),
 		),
 		"Set 5" = list(
-			STATS_PEOPLE_GIBBED = list("name" = "People gibbed:", "points" = 3, "capacity" = 55),
+			STATS_PEOPLE_GIBBED = list("name" = "People gibbed:", "points" = 3.25, "capacity" = 55),
 		)
 	)
 
@@ -512,6 +512,7 @@
 	welcome_text = "Fortune favors the cunning."
 	weight = 4
 	always_votable = TRUE
+	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#8B4513"
 
 	tag_multipliers = list(
@@ -535,7 +536,7 @@
 			STATS_ITEMS_PICKPOCKETED = list("name" = "Items pickpocketed:", "points" = 4.75, "capacity" = 80),
 		),
 		"Set 2" = list(
-			STATS_SHRINE_VALUE = list("name" = "Value offered to his idol:", "points" = 0.085, "capacity" = 70),
+			STATS_SHRINE_VALUE = list("name" = "Value offered to his idol:", "points" = 0.0825, "capacity" = 70),
 		),
 		"Set 3" = list(
 			STATS_GREEDY_PEOPLE = list("name" = "Number of greedy people:", "points" = 7, "capacity" = 70),

--- a/code/modules/client/gods_rankings.dm
+++ b/code/modules/client/gods_rankings.dm
@@ -14,7 +14,7 @@
 
 	sortTim(storytellers, GLOBAL_PROC_REF(cmp_storyteller_ranking))
 
-	for(var/i in 1 to storytellers.len)
+	for(var/i in 1 to length(storytellers))
 		var/datum/storyteller/initialized_storyteller = storytellers[i]
 
 		// Top 3 penalties

--- a/code/modules/client/gods_rankings.dm
+++ b/code/modules/client/gods_rankings.dm
@@ -26,11 +26,11 @@
 			initialized_storyteller.influence_modifier = 0.975
 
 		// Bottom 3 bonuses
-		else if(i == storytellers.len)
+		else if(i == length(storytellers))
 			initialized_storyteller.influence_modifier = 1.1
-		else if(i == storytellers.len - 1)
+		else if(i == length(storytellers) - 1)
 			initialized_storyteller.influence_modifier = 1.05
-		else if(i == storytellers.len - 2)
+		else if(i == length(storytellers) - 2)
 			initialized_storyteller.influence_modifier = 1.025
 
 		// Handle ascension

--- a/code/modules/client/gods_rankings.dm
+++ b/code/modules/client/gods_rankings.dm
@@ -28,9 +28,9 @@
 		// Bottom 3 bonuses
 		else if(i == length(storytellers))
 			initialized_storyteller.influence_modifier = 1.1
-		else if(i == length(storytellers) - 1)
+		else if(i == (length(storytellers) - 1))
 			initialized_storyteller.influence_modifier = 1.05
-		else if(i == length(storytellers) - 2)
+		else if(i == (length(storytellers) - 2))
 			initialized_storyteller.influence_modifier = 1.025
 
 		// Handle ascension

--- a/code/modules/client/gods_rankings.dm
+++ b/code/modules/client/gods_rankings.dm
@@ -6,16 +6,40 @@
 	var/list/json = json_decode(file2text(json_file))
 	var/modified = FALSE
 
-	for(var/god_name in json)
-		if(json[god_name] >= 100)
-			json[god_name] = 0
+	var/list/storytellers = list()
+	for(var/storyteller_name in SSgamemode.storytellers)
+		var/datum/storyteller/initialized_storyteller = SSgamemode.storytellers[storyteller_name]
+		if(initialized_storyteller)
+			storytellers += initialized_storyteller
+
+	sortTim(storytellers, GLOBAL_PROC_REF(cmp_storyteller_ranking))
+
+	for(var/i in 1 to storytellers.len)
+		var/datum/storyteller/initialized_storyteller = storytellers[i]
+
+		// Top 3 penalties
+		if(i == 1)
+			initialized_storyteller.influence_modifier = 0.9
+		else if(i == 2)
+			initialized_storyteller.influence_modifier = 0.95
+		else if(i == 3)
+			initialized_storyteller.influence_modifier = 0.975
+
+		// Bottom 3 bonuses
+		else if(i == storytellers.len)
+			initialized_storyteller.influence_modifier = 1.1
+		else if(i == storytellers.len - 1)
+			initialized_storyteller.influence_modifier = 1.05
+		else if(i == storytellers.len - 2)
+			initialized_storyteller.influence_modifier = 1.025
+
+		// Handle ascension
+		var/points = json[initialized_storyteller.name] || 0
+		if(points >= 100)
+			json[initialized_storyteller.name] = 0
 			modified = TRUE
-			for(var/storyteller_name in SSgamemode.storytellers)
-				var/datum/storyteller/initialized_storyteller = SSgamemode.storytellers[storyteller_name]
-				if(initialized_storyteller?.name == god_name)
-					initialized_storyteller.ascendant = TRUE
-					adjust_storyteller_influence(initialized_storyteller.name, 400)
-					break
+			initialized_storyteller.ascendant = TRUE
+			adjust_storyteller_influence(initialized_storyteller.name, 500)
 
 	if(modified)
 		fdel(json_file)
@@ -74,6 +98,10 @@
 
 /proc/cmp_god_ranking(list/a, list/b)
 	return b["points"] - a["points"]
+
+/proc/cmp_storyteller_ranking(datum/storyteller/a, datum/storyteller/b)
+	var/list/json = get_god_rankings()
+	return (json[b.name] || 0) - (json[a.name] || 0)
 
 /proc/create_god_ranking_entry(god_name, points, color_theme)
 	var/percentage = min(points, 100)

--- a/code/modules/client/gods_rankings.dm
+++ b/code/modules/client/gods_rankings.dm
@@ -59,6 +59,7 @@
 	var/most_frequent
 	var/highest_influence = -1
 	var/highest_chosen = -1
+	var/ascendant_round = FALSE
 
 	for(var/storyteller_name in SSgamemode.storytellers)
 		var/datum/storyteller/initialized_storyteller = SSgamemode.storytellers[storyteller_name]
@@ -66,7 +67,7 @@
 			continue
 
 		if(initialized_storyteller.ascendant)
-			continue
+			ascendant_round = TRUE
 
 		var/influence = SSgamemode.calculate_storyteller_influence(initialized_storyteller.type)
 		if(influence > highest_influence)
@@ -77,7 +78,7 @@
 			highest_chosen = initialized_storyteller.times_chosen
 			most_frequent = initialized_storyteller.name
 
-	if(!most_influential || !most_frequent)
+	if(!most_influential || !most_frequent || ascendant_round)
 		return
 
 	var/json_file = file("data/gods_rankings.json")

--- a/code/modules/client/round_end_panel.dm
+++ b/code/modules/client/round_end_panel.dm
@@ -58,11 +58,6 @@
 		if(initialized_storyteller.times_chosen > max_chosen)
 			max_chosen = initialized_storyteller.times_chosen
 			most_frequent = initialized_storyteller
-		else if(initialized_storyteller.times_chosen == max_chosen)
-			if(!most_frequent || influence > SSgamemode.calculate_storyteller_influence(most_frequent.type))
-				most_frequent = initialized_storyteller
-			else if(influence == SSgamemode.calculate_storyteller_influence(most_frequent.type) && prob(50))
-				most_frequent = initialized_storyteller
 
 	// Gods display
 	data += "<div style='text-align: center; margin: 25px auto; width: 80%; max-width: 800px;'>"
@@ -936,7 +931,7 @@
 			for(var/stat in current_set)
 				var/list/stat_data = current_set[stat]
 				var/stat_value = GLOB.vanderlin_round_stats[stat] || 0
-				var/influence_value = stat_value * stat_data["points"]
+				var/influence_value = (stat_value * stat_data["points"]) * initialized_storyteller.influence_modifier
 				var/is_active = (stat in initialized_storyteller.influence_factors)
 
 				dynamic_content += "<span style='color: [is_active ? "#88f088" : "#f79090"];'>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Small gods' influences patch.

- Minor influences balancing and set changes
- Minor round end panel cleanup
- Max influence adjustment is now capped at 3 instead of 2.5, and it now grows by 0.4 every 5 storyteller reigns (was 0.3)
- Very small boost point gain for the personal storyteller track
- Ascendant rounds don't update rankings
- Adds influence modifier to each storyteller, default is 1 (100%), which modifies gain from the storytellers' specific influences
- Top 3 ranking gods now receive small influence modifier malus, and worst 3 ranking gods receive small influence modifier bonus

## Why It's Good For The Game

Better influences balancing

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
