### PR TITLE
Triumph Shop: UI improvements, 2 new triumph buys

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -175,6 +175,11 @@ GLOBAL_LIST_EMPTY(job_respawn_delays)
 #define TRIUMPH_BUY_GRAGGAR_INFLUENCE "graggar_influence"
 #define TRIUMPH_BUY_MATTHIOS_INFLUENCE "matthios_influence"
 
+// Misc category and its buys
+#define TRIUMPH_CAT_MISC "MISC"
+
+#define TRIUMPH_BUY_PSYDON_FAVOURITE "psydon_favourite"
+
 // Bought triumph buys category
 #define TRIUMPH_CAT_ACTIVE_DATUMS "BOUGHT"
 

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -180,6 +180,11 @@ GLOBAL_LIST_EMPTY(job_respawn_delays)
 
 #define TRIUMPH_BUY_PSYDON_FAVOURITE "psydon_favourite"
 
+// Misc category and its buys
+#define TRIUMPH_CAT_COMMUNAL "COMMUNAL"
+
+#define TRIUMPH_BUY_PSYDON_RETIREMENT "psydon_retirement"
+
 // Bought triumph buys category
 #define TRIUMPH_CAT_ACTIVE_DATUMS "BOUGHT"
 

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -474,6 +474,8 @@ GLOBAL_LIST_INIT(featured_stats, list(
 ))
 
 // Chronicle statistics
+#define CHRONICLE_STATS_PSYDON_FAVOURITE "psydon_favourite"
+#define CHRONICLE_STATS_RANDOM_PASSERBY "random_passerby"
 #define CHRONICLE_STATS_MOST_SKILLS_PERSON "most_skills_person"
 #define CHRONICLE_STATS_LEAST_SKILLS_PERSON "least_skills_person"
 #define CHRONICLE_STATS_STRONGEST_PERSON "strongest_person"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -156,9 +156,7 @@
 
 	gamemode_report()
 
-	to_chat(world, personal_objectives_report())
-
-	sleep(5 SECONDS)
+	sleep(10 SECONDS)
 
 	players_report()
 
@@ -166,11 +164,9 @@
 	if(fund && SStriumphs.communal_pools[fund.type] > 0)
 		fund.on_activate()
 
-	sleep(5 SECONDS)
-
 	SSvote.initiate_vote("map", "Psydon")
 
-	CHECK_TICK
+	sleep(3 SECONDS)
 
 	SSgamemode.store_roundend_data()
 
@@ -287,8 +283,7 @@
 		if(last.show_in_roundend)
 			last.roundend_report_footer()
 
-
-	return
+	to_chat(world, personal_objectives_report())
 
 /datum/controller/subsystem/ticker/proc/standard_reboot()
 	if(ready_for_reboot)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -162,6 +162,14 @@
 
 	players_report()
 
+	CHECK_TICK
+
+	var/datum/triumph_buy/communal/psydon_retirement_fund/fund = locate() in SStriumphs.triumph_buy_datums
+	if(fund && SStriumphs.communal_pools[fund.type] > 0)
+		fund.on_activate()
+
+	CHECK_TICK
+
 	SSvote.initiate_vote("map", "Psydon")
 
 	CHECK_TICK

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -156,17 +156,19 @@
 
 	gamemode_report()
 
-	sleep(10 SECONDS)
-
-	players_report()
+	sleep(8 SECONDS)
 
 	var/datum/triumph_buy/communal/psydon_retirement_fund/fund = locate() in SStriumphs.triumph_buy_datums
 	if(fund && SStriumphs.communal_pools[fund.type] > 0)
 		fund.on_activate()
 
+	sleep(6 SECONDS)
+
+	players_report()
+
 	SSvote.initiate_vote("map", "Psydon")
 
-	sleep(3 SECONDS)
+	CHECK_TICK
 
 	SSgamemode.store_roundend_data()
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -158,17 +158,15 @@
 
 	to_chat(world, personal_objectives_report())
 
-	sleep(10 SECONDS)
+	sleep(5 SECONDS)
 
 	players_report()
-
-	CHECK_TICK
 
 	var/datum/triumph_buy/communal/psydon_retirement_fund/fund = locate() in SStriumphs.triumph_buy_datums
 	if(fund && SStriumphs.communal_pools[fund.type] > 0)
 		fund.on_activate()
 
-	CHECK_TICK
+	sleep(5 SECONDS)
 
 	SSvote.initiate_vote("map", "Psydon")
 

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1640,7 +1640,7 @@ SUBSYSTEM_DEF(gamemode)
 	if(length(current_valid_humans) >= 2 && valid_psydon_favourite)
 		var/list/potential_passers = current_valid_humans.Copy()
 		potential_passers -= valid_psydon_favourite
-		var/mob/living/carbon/human/random_passerby = pick(current_valid_humans)
+		var/mob/living/carbon/human/random_passerby = pick(potential_passers)
 
 		chosen_chronicle_stats[1] = CHRONICLE_STATS_PSYDON_FAVOURITE
 		set_chronicle_stat(CHRONICLE_STATS_PSYDON_FAVOURITE, valid_psydon_favourite, "PSYDON'S FAVOURITE", "#e6e6e6", "buying his way in")

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1433,6 +1433,10 @@ SUBSYSTEM_DEF(gamemode)
 	for(var/stat_name in statistics_to_clear)
 		force_set_round_statistic(stat_name, 0)
 
+	var/list/current_valid_humans = list()
+
+	var/mob/living/carbon/human/valid_psydon_favourite
+
 	var/highest_total_stats = -1
 	var/highest_strength = -1
 	var/highest_intelligence = -1
@@ -1471,6 +1475,7 @@ SUBSYSTEM_DEF(gamemode)
 			record_round_statistic(STATS_DEADITES_ALIVE)
 		if(ishuman(living))
 			var/mob/living/carbon/human/human_mob = client.mob
+			current_valid_humans += human_mob
 			record_round_statistic(STATS_TOTAL_POPULATION)
 			for(var/obj/item/clothing/neck/current_item in human_mob.get_equipped_items(TRUE))
 				if(current_item.type in list(/obj/item/clothing/neck/psycross, /obj/item/clothing/neck/psycross/silver, /obj/item/clothing/neck/psycross/g))
@@ -1561,6 +1566,9 @@ SUBSYSTEM_DEF(gamemode)
 
 			// Chronicle statistics
 
+			if(human_mob.client.has_triumph_buy(TRIUMPH_BUY_PSYDON_FAVOURITE))
+				valid_psydon_favourite = human_mob
+
 			var/total_stats = human_mob.STASTR + human_mob.STAINT + human_mob.STAEND + human_mob.STACON + human_mob.STAPER + human_mob.STASPD + human_mob.STALUC
 			if(total_stats > highest_total_stats)
 				highest_total_stats = total_stats
@@ -1628,6 +1636,22 @@ SUBSYSTEM_DEF(gamemode)
 			else if(wealth < lowest_wealth)
 				lowest_wealth = wealth
 				set_chronicle_stat(CHRONICLE_STATS_POOREST_PERSON, human_mob, "PAUPER", "#909c63", "[wealth] mammons")
+
+	if(length(current_valid_humans) >= 2 && valid_psydon_favourite)
+		var/list/potential_passers = current_valid_humans.Copy()
+		potential_passers -= valid_psydon_favourite
+		var/mob/living/carbon/human/random_passerby = pick(current_valid_humans)
+
+		chosen_chronicle_stats[1] = CHRONICLE_STATS_PSYDON_FAVOURITE
+		set_chronicle_stat(CHRONICLE_STATS_PSYDON_FAVOURITE, valid_psydon_favourite, "PSYDON'S FAVOURITE", "#e6e6e6", "buying his way in")
+
+		if(random_passerby)
+			chosen_chronicle_stats[2] = CHRONICLE_STATS_RANDOM_PASSERBY
+			set_chronicle_stat(CHRONICLE_STATS_RANDOM_PASSERBY, random_passerby, "RANDOM PASSERBY", "#888888", "just happening to be here")
+
+	else if(!isnull(GLOB.chronicle_stats[CHRONICLE_STATS_PSYDON_FAVOURITE]))
+		chosen_chronicle_stats = list()
+		pick_chronicle_stats()
 
 /// Returns total follower influence for the given storyteller
 /datum/controller/subsystem/gamemode/proc/get_follower_influence(datum/storyteller/chosen_storyteller)

--- a/code/controllers/subsystem/triumph/buy_datums/character/pick_all_jobs_as_any_race.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/character/pick_all_jobs_as_any_race.dm
@@ -6,3 +6,4 @@
 	category = TRIUMPH_CAT_CHARACTER
 	visible_on_active_menu = TRUE
 	manual_activation = TRUE
+	allow_multiple_buys = FALSE

--- a/code/controllers/subsystem/triumph/buy_datums/character/pick_all_jobs_as_any_race.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/character/pick_all_jobs_as_any_race.dm
@@ -1,6 +1,7 @@
 /datum/triumph_buy/race_all_jobs
+	name = "No Job Restrictions"
+	desc = "Any species can be in any job and advanced class! WARNING: Inhumen nobles may experience far more discrimination than their common counterparts."
 	triumph_buy_id = TRIUMPH_BUY_RACE_ALL
-	desc = "Any species can be in any job and class! WARNING: Inhumen Nobles may experience far more discrimination than their common counterparts."
 	triumph_cost = 30
 	category = TRIUMPH_CAT_CHARACTER
 	visible_on_active_menu = TRUE

--- a/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
@@ -1,6 +1,7 @@
 /datum/triumph_buy/pick_any_class
+	name = "No Advanced Class Restrictions"
+	desc = "Get a single run of of any advanced class on a job that has advanced classes to pick from! WARNING: PREPARE FOR UNFORESEEN CONSEQUENCES."
 	triumph_buy_id = TRIUMPH_BUY_ANY_CLASS
-	desc = "Get single run of a class that can pick any class BYPASSING CLASS RESTRICTIONS on any class selection! WARNING: PREPARE FOR UNFORESEEN CONSEQUENCES."
 	triumph_cost = 20
 	category = TRIUMPH_CAT_CHARACTER
 	visible_on_active_menu = TRUE

--- a/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
@@ -6,6 +6,7 @@
 	category = TRIUMPH_CAT_CHARACTER
 	visible_on_active_menu = TRUE
 	manual_activation = TRUE
+	allow_multiple_buys = FALSE
 
 /datum/triumph_buy/pick_any_class/on_buy()
 	. = ..()

--- a/code/controllers/subsystem/triumph/buy_datums/communal/_communal.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/_communal.dm
@@ -1,0 +1,15 @@
+/datum/triumph_buy/communal
+	name = "Communal Fund"
+	desc = "Contribute to a shared pool of triumphs for communal benefits."
+	category = TRIUMPH_CAT_COMMUNAL
+	visible_on_active_menu = TRUE
+	manual_activation = TRUE
+	/// Maximum triumphs this pool can hold (0 for unlimited)
+	var/maximum_pool = 0
+	/// Current progress towards goal (0-100)
+	var/progress = 0
+
+/datum/triumph_buy/communal/New()
+	. = ..()
+	SStriumphs.communal_pools[type] = 0
+	SStriumphs.communal_contributions[type] = list()

--- a/code/controllers/subsystem/triumph/buy_datums/communal/_communal.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/_communal.dm
@@ -4,7 +4,7 @@
 	category = TRIUMPH_CAT_COMMUNAL
 	visible_on_active_menu = TRUE
 	manual_activation = TRUE
-	/// Maximum triumphs this pool can hold (0 for unlimited)
+	/// Maximum number of triumphs this pool can hold (0 for unlimited)
 	var/maximum_pool = 0
 	/// Current progress towards goal (0-100)
 	var/progress = 0

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -11,8 +11,14 @@
 
 	var/list/eligible = list()
 	for(var/client/C in GLOB.clients)
-		if(C?.ckey)
-			eligible += C
+		if(!C?.ckey)
+			continue
+
+		if(!SStriumphs.triumph_amount_cache?.Find(C.ckey) || !isnum(SStriumphs.triumph_amount_cache[C.ckey]))
+			log_game("COMMUNAL: Psydon's Retirement Fund: Excluded [C.ckey] due corrupted/missing triumph data.")
+			continue
+
+		eligible += C
 
 	if(!length(eligible))
 		return

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -2,7 +2,7 @@
 	name = "Psydon's Retirement Fund"
 	desc = "Contribute to a fund that will be redistributed to the poorest players when its full or when the round ends."
 	triumph_buy_id = TRIUMPH_BUY_PSYDON_RETIREMENT
-	maximum_pool = 1000
+	maximum_pool = 500
 
 /datum/triumph_buy/communal/psydon_retirement_fund/on_activate()
 	var/total_pool = SStriumphs.communal_pools[type]
@@ -22,7 +22,7 @@
 		var/client/C = eligible[1]
 		adjust_triumphs(C, total_pool, FALSE, "Psydon's Retirement Fund")
 
-		to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
+		to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed to 1 beneficiary from the Psydon's Retirement Fund!"))
 		to_chat(world, "<br>")
 
 		SStriumphs.communal_pools[type] = 0
@@ -96,11 +96,13 @@
 
 		sortTim(client_data, GLOBAL_PROC_REF(cmp_client_triumphs))
 
+	var/number_of_beneficiaries = 0
 	for(var/client/C in distribution)
 		if(distribution[C] > 0)
+			number_of_beneficiaries++
 			adjust_triumphs(C, distribution[C], FALSE, "Psydon's Retirement Fund")
 
-	to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
+	to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed between [number_of_beneficiaries] beneficiaries from the Psydon's Retirement Fund!"))
 	to_chat(world, "<br>")
 
 	SStriumphs.communal_pools[type] = 0

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -20,10 +20,10 @@
 
 	if(length(eligible) == 1)
 		var/client/C = eligible[1]
-		to_chat(C, "<br>")
 		adjust_triumphs(C, total_pool, FALSE, "Psydon's Retirement Fund")
 
 		to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
+		to_chat(world, "<br>")
 
 		SStriumphs.communal_pools[type] = 0
 		SStriumphs.communal_contributions[type] = list()
@@ -101,6 +101,7 @@
 			adjust_triumphs(C, distribution[C], FALSE, "Psydon's Retirement Fund")
 
 	to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
+	to_chat(world, "<br>")
 
 	SStriumphs.communal_pools[type] = 0
 	SStriumphs.communal_contributions[type] = list()

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -13,11 +13,6 @@
 	for(var/client/C in GLOB.clients)
 		if(!C?.ckey)
 			continue
-
-		if(!SStriumphs.triumph_amount_cache?.Find(C.ckey) || !isnum(SStriumphs.triumph_amount_cache[C.ckey]))
-			log_game("COMMUNAL: Psydon's Retirement Fund: Excluded [C.ckey] due corrupted/missing triumph data.")
-			continue
-
 		eligible += C
 
 	if(!length(eligible))
@@ -38,7 +33,7 @@
 	for(var/client/C in eligible)
 		client_data += list(list(
 			"client" = C,
-			"triumphs" = SStriumphs.get_triumphs(C.ckey)
+			"triumphs" = SStriumphs.get_triumphs(C.ckey),
 		))
 
 	sortTim(client_data, GLOBAL_PROC_REF(cmp_client_triumphs))

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -22,9 +22,7 @@
 		to_chat(C, "<br>")
 		adjust_triumphs(C, total_pool, FALSE, "Psydon's Retirement Fund")
 
-		to_chat(world, "<br>")
 		to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
-		to_chat(world, "<br>")
 
 		SStriumphs.communal_pools[type] = 0
 		SStriumphs.communal_contributions[type] = list()
@@ -44,7 +42,7 @@
 		distribution[C] = 0
 
 	var/remaining = total_pool
-	var/safety_counter = 1000
+	var/safety_counter = 1500
 
 	while(remaining > 0 && safety_counter > 0)
 		safety_counter--
@@ -101,9 +99,7 @@
 		if(distribution[C] > 0)
 			adjust_triumphs(C, distribution[C], FALSE, "Psydon's Retirement Fund")
 
-	to_chat(world, "<br>")
 	to_chat(world, span_reallybig("A total of [total_pool] triumph[total_pool == 1 ? " has" : "s have"] been redistributed from the Psydon's Retirement Fund!"))
-	to_chat(world, "<br>")
 
 	SStriumphs.communal_pools[type] = 0
 	SStriumphs.communal_contributions[type] = list()

--- a/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/psydon_retirement_fund.dm
@@ -1,0 +1,88 @@
+/datum/triumph_buy/communal/psydon_retirement_fund
+	name = "Psydon's Retirement Fund"
+	desc = "Contribute to a fund that will be redistributed to the poorest players when its full or when the round ends."
+	triumph_buy_id = TRIUMPH_BUY_PSYDON_RETIREMENT
+	maximum_pool = 1000
+
+/datum/triumph_buy/communal/psydon_retirement_fund/on_activate()
+	var/total_pool = SStriumphs.communal_pools[type]
+	if(total_pool <= 0)
+		return
+
+	var/list/eligible = list()
+	for(var/client/C in GLOB.clients)
+		if(C?.ckey)
+			eligible += C
+
+	if(length(eligible) == 1)
+		var/client/C = eligible[1]
+		to_chat(C, "<br>")
+		adjust_triumphs(C, total_pool, FALSE, "Psydon's Retirement Fund")
+
+		to_chat(C, "<br>")
+		to_chat(C, span_reallybig("The total of [SStriumphs.communal_pools[type]] triumph\s have been redistributed from the Psydon's Retirement Fund!"))
+		to_chat(C, "<br>")
+
+		SStriumphs.communal_pools[type] = 0
+		SStriumphs.communal_contributions[type] = list()
+		return
+
+	var/list/client_data = list()
+	for(var/client/C in eligible)
+		client_data += list(list(
+			"client" = C,
+			"triumphs" = SStriumphs.get_triumphs(C.ckey)
+		))
+
+	sortTim(client_data, GLOBAL_PROC_REF(cmp_client_triumphs))
+
+	var/list/distribution = list()
+	var/remaining = total_pool
+	var/safety_counter = 1000
+	var/distribution_reason = "Psydon's Retirement Fund"
+
+	while(remaining > 0 && safety_counter > 0)
+		safety_counter--
+
+		var/current_min = client_data[1]["triumphs"]
+		var/list/current_group = list()
+
+		for(var/list/data in client_data)
+			if(data["triumphs"] == current_min)
+				current_group += data["client"]
+			else
+				break
+
+		if(!length(current_group))
+			break
+
+		var/per_player = max(1, FLOOR(remaining / length(current_group), 1))
+		for(var/client/C in current_group)
+			if(remaining <= 0)
+				break
+
+			var/give = min(per_player, remaining)
+			distribution[C] += give
+			remaining -= give
+
+			for(var/list/data in client_data)
+				if(data["client"] == C)
+					data["triumphs"] += give
+					break
+
+		sortTim(client_data, GLOBAL_PROC_REF(cmp_client_triumphs))
+
+	for(var/client/C in distribution)
+		if(distribution[C] > 0)
+			to_chat(C, "<br>")
+			adjust_triumphs(C, distribution[C], TRUE, distribution_reason)
+
+	to_chat(world, "<br>")
+	to_chat(world, span_reallybig("The total of [SStriumphs.communal_pools[type]] triumph\s have been redistributed from the Psydon's Retirement Fund!"))
+	to_chat(world, "<br>")
+
+	SStriumphs.communal_pools[type] = 0
+	SStriumphs.communal_contributions[type] = list()
+
+/proc/cmp_client_triumphs(list/a, list/b)
+	return a["triumphs"] - b["triumphs"]

--- a/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
@@ -7,6 +7,7 @@
 	visible_on_active_menu = TRUE
 	limited = TRUE
 	stock = 1
+	allow_multiple_buys = FALSE
 
 /datum/triumph_buy/psydon_favourite/on_activate()
 	. = ..()

--- a/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
@@ -1,6 +1,6 @@
 /datum/triumph_buy/psydon_favourite
 	name = "Psydon's Favourite"
-	desc = "Buy a place in the notables section!"
+	desc = "Have a guaranteed place as a notable person of the Realm if you make it through the week!"
 	triumph_buy_id = TRIUMPH_BUY_PSYDON_FAVOURITE
 	triumph_cost = 3
 	category = TRIUMPH_CAT_MISC
@@ -10,4 +10,4 @@
 
 /datum/triumph_buy/psydon_favourite/on_activate()
 	. = ..()
-
+	SSgamemode.refresh_alive_stats()

--- a/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
@@ -1,8 +1,13 @@
 /datum/triumph_buy/psydon_favourite
-	triumph_buy_id = TRIUMPH_BUY_PSYDON_FAVOURITE
+	name = "Psydon's Favourite"
 	desc = "Buy a place in the notables section!"
+	triumph_buy_id = TRIUMPH_BUY_PSYDON_FAVOURITE
 	triumph_cost = 3
 	category = TRIUMPH_CAT_MISC
 	visible_on_active_menu = TRUE
 	limited = TRUE
 	stock = 1
+
+/datum/triumph_buy/psydon_favourite/on_activate()
+	. = ..()
+

--- a/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/misc/psydon_favourite.dm
@@ -1,0 +1,8 @@
+/datum/triumph_buy/psydon_favourite
+	triumph_buy_id = TRIUMPH_BUY_PSYDON_FAVOURITE
+	desc = "Buy a place in the notables section!"
+	triumph_cost = 3
+	category = TRIUMPH_CAT_MISC
+	visible_on_active_menu = TRUE
+	limited = TRUE
+	stock = 1

--- a/code/controllers/subsystem/triumph/buy_datums/storyteller/bonus_influence.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/storyteller/bonus_influence.dm
@@ -6,6 +6,7 @@
 	visible_on_active_menu = TRUE
 	limited = TRUE
 	stock = 2
+	/// The name of the storyteller we are giving bonus influence to
 	var/storyteller_name
 
 /datum/triumph_buy/storyteller_influence_bonus/on_activate()

--- a/code/controllers/subsystem/triumph/buy_datums/storyteller/bonus_influence.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/storyteller/bonus_influence.dm
@@ -1,153 +1,98 @@
-/datum/triumph_buy/storyteller_influence_matthios
+/datum/triumph_buy/storyteller_influence_bonus
+	name = "Storyteller Influence Bonus"
+	desc = "Grants bonus influence to a storyteller."
+	triumph_cost = 3
+	category = TRIUMPH_CAT_STORYTELLER
+	visible_on_active_menu = TRUE
+	limited = TRUE
+	stock = 2
+	var/storyteller_name
+
+/datum/triumph_buy/storyteller_influence_bonus/on_activate()
+	. = ..()
+	if(storyteller_name)
+		adjust_storyteller_influence(storyteller_name, 25)
+
+/datum/triumph_buy/storyteller_influence_bonus/matthios
+	name = "Matthios' Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_MATTHIOS_INFLUENCE
-	desc = "FOR MATTHIOS! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = MATTHIOS
 
-/datum/triumph_buy/storyteller_influence_matthios/on_activate()
-	. = ..()
-	adjust_storyteller_influence(MATTHIOS, 25)
-
-/datum/triumph_buy/storyteller_influence_graggar
+/datum/triumph_buy/storyteller_influence_bonus/graggar
+	name = "Graggar's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_GRAGGAR_INFLUENCE
-	desc = "FOR GRAGGAR! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = GRAGGAR
 
-/datum/triumph_buy/storyteller_influence_graggar/on_activate()
-	. = ..()
-	adjust_storyteller_influence(GRAGGAR, 25)
-
-/datum/triumph_buy/storyteller_influence_baotha
+/datum/triumph_buy/storyteller_influence_bonus/baotha
+	name = "Baotha's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_BAOTHA_INFLUENCE
-	desc = "FOR BAOTHA! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = BAOTHA
 
-/datum/triumph_buy/storyteller_influence_baotha/on_activate()
-	. = ..()
-	adjust_storyteller_influence(BAOTHA, 25)
-
-/datum/triumph_buy/storyteller_influence_zizo
+/datum/triumph_buy/storyteller_influence_bonus/zizo
+	name = "Zizo's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_ZIZO_INFLUENCE
-	desc = "FOR ZIZO! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = ZIZO
 
-/datum/triumph_buy/storyteller_influence_zizo/on_activate()
-	. = ..()
-	adjust_storyteller_influence(ZIZO, 25)
-
-/datum/triumph_buy/storyteller_influence_dendor
+/datum/triumph_buy/storyteller_influence_bonus/dendor
+	name = "Dendor's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_DENDOR_INFLUENCE
-	desc = "FOR DENDOR! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = DENDOR
 
-/datum/triumph_buy/storyteller_influence_dendor/on_activate()
-	. = ..()
-	adjust_storyteller_influence(DENDOR, 25)
-
-/datum/triumph_buy/storyteller_influence_eora
+/datum/triumph_buy/storyteller_influence_bonus/eora
+	name = "Eora's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_EORA_INFLUENCE
-	desc = "FOR EORA! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = EORA
 
-/datum/triumph_buy/storyteller_influence_eora/on_activate()
-	. = ..()
-	adjust_storyteller_influence(EORA, 25)
-
-/datum/triumph_buy/storyteller_influence_malum
+/datum/triumph_buy/storyteller_influence_bonus/malum
+	name = "Malum's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_MALUM_INFLUENCE
-	desc = "FOR MALUM! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = MALUM
 
-/datum/triumph_buy/storyteller_influence_malum/on_activate()
-	. = ..()
-	adjust_storyteller_influence(MALUM, 25)
-
-/datum/triumph_buy/storyteller_influence_pestra
+/datum/triumph_buy/storyteller_influence_bonus/pestra
+	name = "Pestra's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_PESTRA_INFLUENCE
-	desc = "FOR PESTRA! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = PESTRA
 
-/datum/triumph_buy/storyteller_influence_pestra/on_activate()
-	. = ..()
-	adjust_storyteller_influence(PESTRA, 25)
-
-/datum/triumph_buy/storyteller_influence_necra
+/datum/triumph_buy/storyteller_influence_bonus/necra
+	name = "Necra's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_NECRA_INFLUENCE
-	desc = "FOR NECRA! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = NECRA
 
-/datum/triumph_buy/storyteller_influence_necra/on_activate()
-	. = ..()
-	adjust_storyteller_influence(NECRA, 25)
-
-/datum/triumph_buy/storyteller_influence_xylix
+/datum/triumph_buy/storyteller_influence_bonus/xylix
+	name = "Xylix's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_XYLIX_INFLUENCE
-	desc = "FOR XYLIX! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = XYLIX
 
-/datum/triumph_buy/storyteller_influence_xylix/on_activate()
-	. = ..()
-	adjust_storyteller_influence(XYLIX, 25)
-
-/datum/triumph_buy/storyteller_influence_abyssor
+/datum/triumph_buy/storyteller_influence_bonus/abyssor
+	name = "Abyssor's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_ABYSSOR_INFLUENCE
-	desc = "FOR ABYSSOR! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = ABYSSOR
 
-/datum/triumph_buy/storyteller_influence_abyssor/on_activate()
-	. = ..()
-	adjust_storyteller_influence(ABYSSOR, 25)
-
-/datum/triumph_buy/storyteller_influence_ravox
+/datum/triumph_buy/storyteller_influence_bonus/ravox
+	name = "Ravox's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_RAVOX_INFLUENCE
-	desc = "FOR RAVOX! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = RAVOX
 
-/datum/triumph_buy/storyteller_influence_ravox/on_activate()
-	. = ..()
-	adjust_storyteller_influence(RAVOX, 25)
-
-/datum/triumph_buy/storyteller_influence_noc
+/datum/triumph_buy/storyteller_influence_bonus/noc
+	name = "Noc's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_NOC_INFLUENCE
-	desc = "FOR NOC! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
+	storyteller_name = NOC
 
-/datum/triumph_buy/storyteller_influence_noc/on_activate()
-	. = ..()
-	adjust_storyteller_influence(NOC, 25)
-
-/datum/triumph_buy/storyteller_influence_astrata
+/datum/triumph_buy/storyteller_influence_bonus/astrata
+	name = "Astrata's Influence"
+	desc = "Buy an extra 25 influence for this god!"
 	triumph_buy_id = TRIUMPH_BUY_ASTRATA_INFLUENCE
-	desc = "FOR ASTRATA! Buy an extra 25 influence for this god!"
-	triumph_cost = 5
-	category = TRIUMPH_CAT_STORYTELLER
-	visible_on_active_menu = TRUE
-
-/datum/triumph_buy/storyteller_influence_astrata/on_activate()
-	. = ..()
-	adjust_storyteller_influence(ASTRATA, 25)
+	storyteller_name = ASTRATA

--- a/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
@@ -27,6 +27,8 @@
 	var/limited = FALSE
 	/// Number times the triumph buy can be bought if its limited
 	var/stock = 0
+	/// Whether the user is allowed to buy the triumph buy they already have
+	var/allow_multiple_buys = TRUE
 	/// List of things it can conflict with
 	var/list/conflicts_with = list()
 

--- a/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
@@ -3,14 +3,14 @@
 */
 
 /datum/triumph_buy
- 	/// This serves no purpose rn other than to stop duplicates in certain places
-	var/triumph_buy_id = "ERROR"
-	/// Key of the person who bought it.
-	var/key_of_buyer = null
-	/// Ckey of the person who bought it. I don't feel like dealing with the fact zeth used key for triumphs
-	var/ckey_of_buyer = null
-    /// Desc shown for it on the menu
-	var/desc = "ERROR"
+	/// Display name shown as a title above the description
+	var/name = "UNNAMED TRIUMPH BUY"
+	/// Desc shown for it on the menu
+	var/desc = "NO DESCRIPTION"
+ 	/// Unique ID of the triumph buy
+	var/triumph_buy_id
+	/// Ckey of the person who bought it
+	var/ckey_of_buyer
 	/// Cost in triumphs for something
 	var/triumph_cost = 500
 	/// Category we sort something into

--- a/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/triumph_buy_datums.dm
@@ -19,10 +19,14 @@
 	var/visible_on_active_menu = FALSE
 	/// Whether its pre-round only
 	var/pre_round_only = FALSE
-	/// Whatever the triumph buy effect must be manually activated somewhere else than on its buy
+	/// Whether the triumph buy effect must be manually activated somewhere else than on its buy
 	var/manual_activation = FALSE
-	/// Whatever the triumph buy effect was activated and therefore cannot be refunded
+	/// Whether the triumph buy effect was activated and therefore cannot be refunded
 	var/activated = FALSE
+	/// Whether the triumph buy has limited stock to buy
+	var/limited = FALSE
+	/// Number times the triumph buy can be bought if its limited
+	var/stock = 0
 	/// List of things it can conflict with
 	var/list/conflicts_with = list()
 

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -13,7 +13,7 @@
 		return
 
 	SStriumphs.triumph_adjust(amount, ckey)
-	SStriumphs.adjust_leaderboard(key)
+	SStriumphs.adjust_leaderboard(ckey)
 
 	var/adjustment_verb
 	if(amount > 0)

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -1,4 +1,4 @@
-/proc/adjust_triumphs(datum/key_holder, amount, counted = TRUE, reason)
+/proc/adjust_triumphs(datum/key_holder, amount, counted = TRUE, reason, silent = FALSE)
 	if(!key_holder)
 		return
 
@@ -29,17 +29,18 @@
 	if(reason)
 		final_text += " REASON: [reason]"
 
-	to_chat(key_holder, span_purple("[final_text]"))
+	if(!silent)
+		to_chat(key_holder, span_purple("[final_text]"))
 
-/datum/mind/proc/adjust_triumphs(amt, counted = TRUE, reason)
+/datum/mind/proc/adjust_triumphs(amt, counted = TRUE, reason, silent = FALSE)
 	if(!key)
 		return
-	global.adjust_triumphs(src, amt, counted, reason) //sorry
+	global.adjust_triumphs(src, amt, counted, reason, silent)
 
-/client/proc/adjust_triumphs(amt, counted = TRUE, reason)
-	global.adjust_triumphs(src, amt, counted, reason) //sorry
+/client/proc/adjust_triumphs(amt, counted = TRUE, reason, silent = FALSE)
+	global.adjust_triumphs(src, amt, counted, reason, silent)
 
-/mob/proc/adjust_triumphs(amt, counted = TRUE, reason)
+/mob/proc/adjust_triumphs(amt, counted = TRUE, reason, silent = FALSE)
 	if(!key)
 		return
-	global.adjust_triumphs(src, amt, counted, reason) //sorry
+	global.adjust_triumphs(src, amt, counted, reason, silent)

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -9,8 +9,7 @@
 		return
 	var/key = key_holder:key
 	var/ckey = ckey(key)
-	if(!key || !ckey)
-		log_game("TRIUMPHS: Unknown key/ckey called adjust_triumphs! Values: key:[key], ckey:[ckey]")
+	if(!key)
 		return
 
 	SStriumphs.triumph_adjust(amount, ckey)

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -13,7 +13,7 @@
 		return
 
 	SStriumphs.triumph_adjust(amount, ckey)
-	SStriumphs.adjust_leaderboard(ckey)
+	SStriumphs.adjust_leaderboard(key)
 
 	var/adjustment_verb
 	if(amount > 0)

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -7,9 +7,9 @@
 
 	if(!ismob(key_holder) && !ismind(key_holder) && !isclient(key_holder))
 		return
-	var/key = key_holder:key //sorry
+	var/key = key_holder:key
 	var/ckey = ckey(key)
-	if(!key)
+	if(!key || !ckey)
 		return
 
 	SStriumphs.triumph_adjust(amount, ckey)

--- a/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
+++ b/code/controllers/subsystem/triumph/triumph_adjust_procs.dm
@@ -10,6 +10,7 @@
 	var/key = key_holder:key
 	var/ckey = ckey(key)
 	if(!key || !ckey)
+		log_game("TRIUMPHS: Unknown key/ckey called adjust_triumphs! Values: key:[key], ckey:[ckey]")
 		return
 
 	SStriumphs.triumph_adjust(amount, ckey)

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -48,6 +48,19 @@
 					background-attachment: fixed;
 					background-size: 100% 100%;
 				}
+				.triumph_stock_wrapper {
+					font-family: "Pirata One", system-ui;
+					font-weight: 400;
+					font-style: normal;
+					font-size:24px;
+					color:#d4af37;
+					text-align: center;
+					padding: 0.1em 0.25em;
+					border-bottom: 1px solid rgb(128, 103, 81);
+					border-right: 1px solid rgb(106, 83, 65);
+					vertical-align: top;
+					white-space: nowrap;
+				}
 			</style>
 			<link rel='stylesheet' type='text/css' href='[SSassets.transport.get_asset_url("slop_menustyle3.css")]'>
 		</head>
@@ -80,6 +93,7 @@
 					<tr>
 						<th class=\"triumph_text_head\">Description</th>
 						<th class=\"triumph_text_head\">Cost</th>
+						[current_category != TRIUMPH_CAT_ACTIVE_DATUMS ? "<th class=\"triumph_text_head\">Stock</th>" : ""]
 						<th class=\"triumph_text_head_redeem\">Redeem</th>
 					</tr>
 				</thead>
@@ -124,10 +138,13 @@
 				<tr class='triumph_text_row'>
 					<td class='triumph_text_desc'>[current_check.desc]</td>
 					<td class='triumph_cost_wrapper'>[current_check.triumph_cost]</td>
+					<td class='triumph_stock_wrapper'>[current_check.limited ? SStriumphs.triumph_buy_stocks[current_check.type] : "∞"]</td>
 				"}
 
 			var/string = "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'>BUY</a></td>"
-			if(SSticker.HasRoundStarted() && current_check.pre_round_only)
+			if(current_check.limited && SStriumphs.triumph_buy_stocks[current_check.type] <= 0)
+				string = "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'><span class='strikethru_back'>OUT OF STOCK</span></a></td>"
+			else if(SSticker.HasRoundStarted() && current_check.pre_round_only)
 				string = "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'><span class='strikethru_back'>CONFLICT</span></a></td>"
 			else
 				for(var/datum/triumph_buy/conflict_check in SStriumphs.active_triumph_buy_queue)

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -1,5 +1,3 @@
-
-
 /datum/triumph_buy_menu
 	/// These are the menu datum vars
 	var/client/linked_client
@@ -17,15 +15,12 @@
 	linked_client = null
 	. = ..()
 
-
 /datum/triumph_buy_menu/proc/triumph_menu_startup_slop()
 	var/datum/asset/thicc_assets = get_asset_datum(/datum/asset/simple/stonekeep_triumph_buy_menu_slop_layout)
 	thicc_assets.send(linked_client)
 
 	show_menu()
 
-
-// TRIUMPH BUY MENU SIDED PROC
 /datum/triumph_buy_menu/proc/show_menu()
 	if(!linked_client)
 		return
@@ -48,18 +43,13 @@
 					background-attachment: fixed;
 					background-size: 100% 100%;
 				}
-				.triumph_stock_wrapper {
-					font-family: "Pirata One", system-ui;
+				.triumph_name {
+					font-family: "Aclonica", sans-serif;
 					font-weight: 400;
 					font-style: normal;
-					font-size:24px;
-					color:#d4af37;
-					text-align: center;
-					padding: 0.1em 0.25em;
-					border-bottom: 1px solid rgb(128, 103, 81);
-					border-right: 1px solid rgb(106, 83, 65);
-					vertical-align: top;
-					white-space: nowrap;
+					font-size: 20px;
+					color: #91E0F3;
+					padding-bottom: 2px;
 				}
 			</style>
 			<link rel='stylesheet' type='text/css' href='[SSassets.transport.get_asset_url("slop_menustyle3.css")]'>
@@ -72,11 +62,6 @@
 			</div>
 			<div style=\"width:100%;float:left\">
 	"}
-/*
-				<div id='triumph_close_div'>
-					<a id='triumph_close_button' href='byond://?src=\ref[src];close_menu=1'>CLOSE MENU</a>
-				</div>
-*/
 
 	data += "<hr class='fadeout_line'>"
 	for(var/cat_key in SStriumphs.central_state_data)
@@ -85,14 +70,14 @@
 		else
 			data += "<a class=\"triumph_categories_normal\" href=\"byond://?src=\ref[src];select_a_category=[cat_key]\">[cat_key]</a>"
 
-	data +={"
+	data += {"
 	<hr class=\"fadeout_line\">
 		</div>
 			<table>
 				<thead>
 					<tr>
 						<th class=\"triumph_text_head\">Description</th>
-						<th class=\"triumph_text_head\">Cost</th>
+						[current_category != TRIUMPH_CAT_ACTIVE_DATUMS ? "<th class=\"triumph_text_head\">Cost</th>" : ""]
 						[current_category != TRIUMPH_CAT_ACTIVE_DATUMS ? "<th class=\"triumph_text_head\">Stock</th>" : ""]
 						<th class=\"triumph_text_head_redeem\">Redeem</th>
 					</tr>
@@ -100,18 +85,18 @@
 				<tbody>
 	"}
 
-
 	if(current_category == TRIUMPH_CAT_ACTIVE_DATUMS)
-		// Mostly so we can stop the filler message from not being displayed if someone has a non-visible triumph buy, and theres nothing else in.
 		var/found_one = FALSE
 		if(SStriumphs.active_triumph_buy_queue.len)
 			for(var/datum/triumph_buy/found_triumph_buy in SStriumphs.active_triumph_buy_queue)
-				if(!found_triumph_buy.visible_on_active_menu || usr.ckey != found_triumph_buy.ckey_of_buyer) // If we aren't set to be able to be visible on the main menu
+				if(!found_triumph_buy.visible_on_active_menu || usr.ckey != found_triumph_buy.ckey_of_buyer)
 					continue
 				data += {"
 					<tr class='triumph_text_row'>
-						<td class='triumph_text_desc'>[found_triumph_buy.desc]</td>
-						<td class='triumph_cost_wrapper'>[found_triumph_buy.triumph_cost]</td>
+						<td class='triumph_text_desc'>
+							<div class='triumph_name'>[found_triumph_buy.name]</div>
+							[found_triumph_buy.desc]
+						</td>
 				"}
 				if(SSticker.HasRoundStarted() && found_triumph_buy.pre_round_only)
 					data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'><span class='strikethru_back'>ROUND STARTED</span></a></td>"
@@ -119,15 +104,12 @@
 					data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'>REFUND</a></td>"
 
 				data += "</tr>"
+				found_one = TRUE
 
-				found_one = TRUE // WE GOT ONE WOOHOO
-
-
-		if(!found_one) // We didn't find anything that could be visible, so cram in the mssage
+		if(!found_one)
 			data += {"
 				<tr class='triumph_text_row'>
 					<td class='triumph_text_desc'>NOTHING</td>
-					<td class='triumph_cost_wrapper'>ACTIVE</td>
 					<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];'>HERE</a></td>
 				</tr>
 			"}
@@ -136,10 +118,13 @@
 		for(var/datum/triumph_buy/current_check in SStriumphs.central_state_data[current_category]["[current_page]"])
 			data += {"
 				<tr class='triumph_text_row'>
-					<td class='triumph_text_desc'>[current_check.desc]</td>
+					<td class='triumph_text_desc'>
+						<div class='triumph_name'>[current_check.name]</div>
+						[current_check.desc]
+					</td>
 					<td class='triumph_cost_wrapper'>[current_check.triumph_cost]</td>
 					<td class='triumph_stock_wrapper'>[current_check.limited ? SStriumphs.triumph_buy_stocks[current_check.type] : "∞"]</td>
-				"}
+			"}
 
 			var/string = "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'>BUY</a></td>"
 			if(current_check.limited && SStriumphs.triumph_buy_stocks[current_check.type] <= 0)
@@ -148,13 +133,11 @@
 				string = "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'><span class='strikethru_back'>CONFLICT</span></a></td>"
 			else
 				for(var/datum/triumph_buy/conflict_check in SStriumphs.active_triumph_buy_queue)
-					if(current_check.type in conflict_check.conflicts_with) // We are in an active datum's conflicts with
+					if(current_check.type in conflict_check.conflicts_with)
 						string = "<td class='triumph_filler_cells'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[current_check];'><span class='strikethru_back'>CONFLICT</span></a></td>"
 
 			data += string
 			data += "</tr>"
-
-
 
 	data += {"
 				</tbody>
@@ -163,7 +146,6 @@
 	data += "<div class='triumph_footer'>"
 
 	for(var/i in 1 to SStriumphs.central_state_data[current_category].len)
-
 		if("[i]" == current_page)
 			data += "<a class='triumph_numbers_selected' href='byond://?src=\ref[src];select_a_page=[i]'><span class='num_bigunder_back'><span class='num_bigunder'></span>[i]</span></a>"
 		else
@@ -174,13 +156,8 @@
 		</body>
 	</html>
 	"}
-	data += {"
-		</head>
-	</html>
-	"}
-	linked_client << browse(data, "window=triumph_buy_window;size=615x715;can_close=1;can_minimize=0;can_maximize=0;can_resize=0;titlebar=1")
+	linked_client << browse(data, "window=triumph_buy_window;size=674x715;can_close=1;can_minimize=0;can_maximize=0;can_resize=0;titlebar=1")
 
-	// We setup the href_list "close" call if they hit the x on the top right
 	for(var/i in 1 to 10)
 		if(!linked_client)
 			break
@@ -188,7 +165,6 @@
 			winset(linked_client, "triumph_buy_window", "on-close=\".windowclose [REF(src)]\"")
 			break
 
-// TRIUMPH BUY MENU SIDED PROC
 /datum/triumph_buy_menu/Topic(href, list/href_list)
 	. = ..()
 
@@ -197,6 +173,7 @@
 		if(SStriumphs.central_state_data[sent_category])
 			if(sent_category != current_category)
 				current_category = sent_category
+				current_page = "1"
 				show_menu()
 
 	if(href_list["select_a_page"])

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -239,7 +239,7 @@
 				show_menu()
 
 	if(href_list["contribute"])
-		if(!linked_client)
+		if(!linked_client?.ckey)
 			return
 		if(SSticker.current_state == GAME_STATE_FINISHED)
 			to_chat(linked_client, span_warning("You cannot contribute after the round has ended!"))
@@ -251,7 +251,7 @@
 			var/max_possible = communal_buy.maximum_pool ? communal_buy.maximum_pool - SStriumphs.communal_pools[communal_buy.type] : INFINITY
 			var/amount = input(linked_client, "How much to contribute?", "Communal Contribution", 0) as num|null
 
-			if(!linked_client)
+			if(!linked_client?.ckey)
 				return
 			if(SSticker.current_state == GAME_STATE_FINISHED)
 				to_chat(linked_client, span_warning("You cannot contribute after the round has ended!"))
@@ -272,7 +272,7 @@
 			show_menu()
 
 	if(href_list["handle_buy_button"])
-		if(!linked_client)
+		if(!linked_client?.ckey)
 			return
 		if(SSticker.current_state == GAME_STATE_FINISHED)
 			to_chat(linked_client, span_warning("You cannot buy anything after the round has ended!"))

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -24,6 +24,7 @@
 /datum/triumph_buy_menu/proc/show_menu()
 	if(!linked_client)
 		return
+
 	var/data = {"
 	<html>
 		<head>
@@ -51,6 +52,16 @@
 					color: #91E0F3;
 					padding-bottom: 2px;
 				}
+				.nothing_bought {
+					font-family: "Aclonica", sans-serif;
+					font-weight: 400;
+					font-style: normal;
+					font-size: 24px;
+					color: #FDF7D2;
+					text-align: center;
+					width: 100%;
+					padding-top: 200px;
+				}
 			</style>
 			<link rel='stylesheet' type='text/css' href='[SSassets.transport.get_asset_url("slop_menustyle3.css")]'>
 		</head>
@@ -73,24 +84,26 @@
 	data += {"
 	<hr class=\"fadeout_line\">
 		</div>
-			<table>
-				<thead>
-					<tr>
-						<th class=\"triumph_text_head\">Description</th>
-						[current_category != TRIUMPH_CAT_ACTIVE_DATUMS ? "<th class=\"triumph_text_head\">Cost</th>" : ""]
-						[current_category != TRIUMPH_CAT_ACTIVE_DATUMS ? "<th class=\"triumph_text_head\">Stock</th>" : ""]
-						<th class=\"triumph_text_head_redeem\">Redeem</th>
-					</tr>
-				</thead>
-				<tbody>
 	"}
 
 	if(current_category == TRIUMPH_CAT_ACTIVE_DATUMS)
 		var/found_one = FALSE
 		if(SStriumphs.active_triumph_buy_queue.len)
+			data += {"
+				<table>
+					<thead>
+						<tr>
+							<th class=\"triumph_text_head\">Description</th>
+							<th class=\"triumph_text_head_redeem\">Redeem</th>
+						</tr>
+					</thead>
+					<tbody>
+			"}
+
 			for(var/datum/triumph_buy/found_triumph_buy in SStriumphs.active_triumph_buy_queue)
 				if(!found_triumph_buy.visible_on_active_menu || usr.ckey != found_triumph_buy.ckey_of_buyer)
 					continue
+
 				data += {"
 					<tr class='triumph_text_row'>
 						<td class='triumph_text_desc'>
@@ -98,6 +111,7 @@
 							[found_triumph_buy.desc]
 						</td>
 				"}
+
 				if(SSticker.HasRoundStarted() && found_triumph_buy.pre_round_only)
 					data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'><span class='strikethru_back'>ROUND STARTED</span></a></td>"
 				else
@@ -106,15 +120,29 @@
 				data += "</tr>"
 				found_one = TRUE
 
-		if(!found_one)
 			data += {"
-				<tr class='triumph_text_row'>
-					<td class='triumph_text_desc'>NOTHING</td>
-					<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];'>HERE</a></td>
-				</tr>
+					</tbody>
+				</table>
 			"}
 
+		if(!found_one)
+			data += {"
+				<div class='nothing_bought'>YOU HAVE NOTHING</div>
+			"}
 	else
+		data += {"
+			<table>
+				<thead>
+					<tr>
+						<th class=\"triumph_text_head\">Description</th>
+						<th class=\"triumph_text_head\">Cost</th>
+						<th class=\"triumph_text_head\">Stock</th>
+						<th class=\"triumph_text_head_redeem\">Redeem</th>
+					</tr>
+				</thead>
+				<tbody>
+		"}
+
 		for(var/datum/triumph_buy/current_check in SStriumphs.central_state_data[current_category]["[current_page]"])
 			data += {"
 				<tr class='triumph_text_row'>
@@ -139,10 +167,11 @@
 			data += string
 			data += "</tr>"
 
-	data += {"
+		data += {"
 				</tbody>
 			</table>
-			"}
+		"}
+
 	data += "<div class='triumph_footer'>"
 
 	for(var/i in 1 to SStriumphs.central_state_data[current_category].len)

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -239,21 +239,32 @@
 				show_menu()
 
 	if(href_list["contribute"])
+		if(!linked_client)
+			return
+		if(SSticker.current_state == GAME_STATE_FINISHED)
+			to_chat(linked_client, span_warning("You cannot contribute after the round has ended!"))
+			return
+
 		var/datum/triumph_buy/communal/communal_buy = locate(href_list["contribute"])
 		if(communal_buy && istype(communal_buy))
 			var/available = SStriumphs.get_triumphs(linked_client.ckey)
 			var/max_possible = communal_buy.maximum_pool ? communal_buy.maximum_pool - SStriumphs.communal_pools[communal_buy.type] : INFINITY
 			var/amount = input(linked_client, "How much to contribute?", "Communal Contribution", 0) as num|null
 
+			if(!linked_client)
+				return
+			if(SSticker.current_state == GAME_STATE_FINISHED)
+				to_chat(linked_client, span_warning("You cannot contribute after the round has ended!"))
+				return
 			if(!amount || amount <= 0)
 				return
 
 			amount = min(amount, available, max_possible)
 			if(amount > 0)
-				SStriumphs.triumph_adjust(-amount, linked_client.ckey)
+				linked_client.adjust_triumphs(-amount, counted = FALSE, silent = TRUE)
 				SStriumphs.communal_pools[communal_buy.type] += amount
 				LAZYADD(SStriumphs.communal_contributions[communal_buy.type][linked_client.ckey], amount)
-				to_chat(linked_client, span_notice("You have contributed [amount] triumph\s to \the [communal_buy.name]."))
+				to_chat(linked_client, span_notice("You have contributed [amount] triumph\s to the [communal_buy.name]."))
 
 				if(communal_buy.maximum_pool && SStriumphs.communal_pools[communal_buy.type] >= communal_buy.maximum_pool)
 					communal_buy.on_activate()
@@ -261,6 +272,12 @@
 			show_menu()
 
 	if(href_list["handle_buy_button"])
+		if(!linked_client)
+			return
+		if(SSticker.current_state == GAME_STATE_FINISHED)
+			to_chat(linked_client, span_warning("You cannot buy anything after the round has ended!"))
+			return
+
 		var/datum/triumph_buy/target_datum = locate(href_list["handle_buy_button"])
 		if(target_datum)
 			var/conflicting = FALSE

--- a/code/controllers/subsystem/triumph/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/triumph/triumph_buy_menu.dm
@@ -88,48 +88,48 @@
 
 	if(current_category == TRIUMPH_CAT_ACTIVE_DATUMS)
 		var/found_one = FALSE
-		var/built_header = FALSE
+		var/list/active_items = list()
 
 		for(var/datum/triumph_buy/found_triumph_buy in SStriumphs.active_triumph_buy_queue)
 			if(!found_triumph_buy.visible_on_active_menu || usr.ckey != found_triumph_buy.ckey_of_buyer)
 				continue
 
-			if(!built_header)
-				data += {"
-					<table>
-						<thead>
-							<tr>
-								<th class=\"triumph_text_head\">Description</th>
-								<th class=\"triumph_text_head_redeem\">Redeem</th>
-							</tr>
-						</thead>
-						<tbody>
-				"}
-				built_header = TRUE
-
-			data += {"
-				<tr class='triumph_text_row'>
-					<td class='triumph_text_desc'>
-						<div class='triumph_name'>[found_triumph_buy.name]</div>
-						[found_triumph_buy.desc]
-					</td>
-			"}
-
-			if(SSticker.HasRoundStarted() && found_triumph_buy.pre_round_only)
-				data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'><span class='strikethru_back'>ROUND STARTED</span></a></td>"
-			else
-				data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'>REFUND</a></td>"
-
-			data += "</tr>"
+			active_items += found_triumph_buy
 			found_one = TRUE
 
-			if(built_header)
+		if(found_one)
+			data += {"
+				<table>
+					<thead>
+						<tr>
+							<th class=\"triumph_text_head\">Description</th>
+							<th class=\"triumph_text_head_redeem\">Redeem</th>
+						</tr>
+					</thead>
+					<tbody>
+			"}
+
+			for(var/datum/triumph_buy/found_triumph_buy in active_items)
 				data += {"
-						</tbody>
-					</table>
+					<tr class='triumph_text_row'>
+						<td class='triumph_text_desc'>
+							<div class='triumph_name'>[found_triumph_buy.name]</div>
+							[found_triumph_buy.desc]
+						</td>
 				"}
 
-		if(!found_one)
+				if(SSticker.HasRoundStarted() && found_triumph_buy.pre_round_only)
+					data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'><span class='strikethru_back'>ROUND STARTED</span></a></td>"
+				else
+					data += "<td class='triumph_buy_wrapper'><a class='triumph_text_buy' href='byond://?src=\ref[src];handle_buy_button=\ref[found_triumph_buy];'>REFUND</a></td>"
+
+				data += "</tr>"
+
+			data += {"
+					</tbody>
+				</table>
+			"}
+		else
 			data += {"
 				<div class='nothing_bought'>YOU HAVE NOTHING</div>
 			"}

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -253,7 +253,7 @@ SUBSYSTEM_DEF(triumphs)
 
 	if(target_ckey in triumph_amount_cache)
 		triumph_amount_cache[target_ckey] += amt
-		log_game("TRIUMPHS: [target_ckey] received [amt] triumph\s. They now have a total of [triumph_amount_cache[target_ckey]] triumph\s. Checked with cache.")
+		log_game("TRIUMPHS: [target_ckey] received [amt] triumph\s. They have a total of [triumph_amount_cache[target_ckey]] triumph\s now. Checked with cache.")
 		var/list/saving_data = list()
 		var/target_file = file("data/player_saves/[target_ckey[1]]/[target_ckey]/triumphs.json")
 		if(fexists(target_file))
@@ -269,7 +269,7 @@ SUBSYSTEM_DEF(triumphs)
 			var/cur_client_triumph_count = not_new_guy["triumph_count"]
 			triumph_amount_cache[target_ckey] = cur_client_triumph_count + amt
 
-			log_game("TRIUMPHS: [target_ckey] received [amt] triumph\s. They now have a total of [triumph_amount_cache[target_ckey]] triumph\s. Checked with player save.")
+			log_game("TRIUMPHS: [target_ckey] received [amt] triumph\s. They have a total of [triumph_amount_cache[target_ckey]] triumph\s now. Checked with player save.")
 			var/list/saving_data = list()
 			saving_data["triumph_wipe_season"] = GLOB.triumph_wipe_season
 			saving_data["triumph_count"] = triumph_amount_cache[target_ckey]

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -173,10 +173,10 @@ SUBSYSTEM_DEF(triumphs)
 			to_chat(C, span_warning("You can't refund a triumph buy that was already activated!"))
 		return FALSE
 	var/refund_amount = triumph_buy.triumph_cost
-	if(C)
+	if(C?.ckey)
 		C.adjust_triumphs(refund_amount, counted = FALSE, silent = TRUE)
 		to_chat(C, span_redtext("You were refunded [refund_amount] triumph\s due to \a [reason]."))
-	else
+	else if(previous_owner_ckey)
 		triumph_adjust(refund_amount, previous_owner_ckey)
 	if(triumph_buy.limited)
 		triumph_buy_stocks[triumph_buy.type]++

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -351,27 +351,20 @@ SUBSYSTEM_DEF(triumphs)
 
 	sort_leaderboard()
 
-// Adjust leaderboard
-// I want a key here so it looks pretty
-/datum/controller/subsystem/triumphs/proc/adjust_leaderboard(CLIENT_KEY_not_CKEY)
-	var/user_key = CLIENT_KEY_not_CKEY
-	var/triumph_total = triumph_amount_cache[ckey(CLIENT_KEY_not_CKEY)]
+/datum/controller/subsystem/triumphs/proc/adjust_leaderboard(ckey)
+	var/triumph_total = triumph_amount_cache[ckey]
 
-	if(5 > triumph_total) // You aren't tracked at all unless you got at least 5, no iterating a bunch of losers repeatedly
+	if(5 > triumph_total)
 		return
 
-	// You automatically get added in if we haven't filled in all the crap
 	if(triumph_leaderboard_positions_tracked > triumph_leaderboard.len)
-		triumph_leaderboard[user_key] = triumph_total
-
-	// Guy in last place is still greater than this guy
-	if(triumph_leaderboard[triumph_leaderboard[triumph_leaderboard.len]] > triumph_total)
+		triumph_leaderboard[ckey] = triumph_total
+	else if(triumph_leaderboard[triumph_leaderboard[triumph_leaderboard.len]] > triumph_total)
 		return
 
-	triumph_leaderboard.Cut(triumph_leaderboard.len) // Cut the end
-	triumph_leaderboard[user_key] = triumph_total // Add our guy to the end
-
-	sort_leaderboard() // Now sort it, sort it NOW!
+	triumph_leaderboard.Cut(triumph_leaderboard.len)
+	triumph_leaderboard[ckey] = triumph_total
+	sort_leaderboard()
 
 // Sort what we got
 /datum/controller/subsystem/triumphs/proc/sort_leaderboard()

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -266,7 +266,7 @@ SUBSYSTEM_DEF(triumphs)
 		saving_data["triumph_count"] = triumph_amount_cache["[target_ckey]"]
 		WRITE_FILE(target_file, json_encode(saving_data))
 	else
-		triumph_amount_cache["[target_ckey]"] = 0
+		// triumph_amount_cache["[target_ckey]"] = 0
 		log_game("TRIUMPHS: Ckey [target_ckey] was not found in the triumph cache, setting him there with 0 triumphs")
 
 /// Wipe the triumphs of one person

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -62,7 +62,7 @@ SUBSYSTEM_DEF(triumphs)
 	var/list/active_triumph_menus = list()
 
 	// display limit per page in a category on the user menu
-	var/page_display_limit = 14
+	var/page_display_limit = 11
 
 	// This represents the triumph buy organization on the main SS for triumphs
 	// Each key is a category name
@@ -96,9 +96,11 @@ SUBSYSTEM_DEF(triumphs)
 	prep_the_triumphs_leaderboard()
 
 	for(var/cur_path in subtypesof(/datum/triumph_buy))
-		var/datum/triumph_buy/cur_datum = new cur_path // We will do this
+		var/datum/triumph_buy/cur_datum = new cur_path
+		if(isnull(cur_datum.triumph_buy_id))
+			continue
 		triumph_buy_datums += cur_datum
-		central_state_data[cur_datum.category] += 1 // Tally up the totals here to save on a total of one loop
+		central_state_data[cur_datum.category] += 1
 
 	for(var/datum/triumph_buy/cur_datum in triumph_buy_datums)
 		if(cur_datum.limited)
@@ -139,7 +141,6 @@ SUBSYSTEM_DEF(triumphs)
 
 		var/datum/triumph_buy/triumph_buy = new ref_datum.type
 
-		triumph_buy.key_of_buyer = C.key
 		triumph_buy.ckey_of_buyer = C.ckey
 
 		if(!triumph_buy_owners[C.ckey])

--- a/code/controllers/subsystem/triumph/triumphs.dm
+++ b/code/controllers/subsystem/triumph/triumphs.dm
@@ -266,8 +266,7 @@ SUBSYSTEM_DEF(triumphs)
 		saving_data["triumph_count"] = triumph_amount_cache["[target_ckey]"]
 		WRITE_FILE(target_file, json_encode(saving_data))
 	else
-		// triumph_amount_cache["[target_ckey]"] = 0
-		log_game("TRIUMPHS: Ckey [target_ckey] was not found in the triumph cache, setting him there with 0 triumphs")
+		log_game("TRIUMPHS: Ckey [target_ckey] was not found in the triumph cache, he would receive [amt]")
 
 /// Wipe the triumphs of one person
 /datum/controller/subsystem/triumphs/proc/wipe_target_triumphs(target_ckey)

--- a/code/game/gamemodes/personal_objectives/abyssor/abyssoid_creation.dm
+++ b/code/game/gamemodes/personal_objectives/abyssor/abyssoid_creation.dm
@@ -1,5 +1,6 @@
 /datum/objective/create_abyssoids
 	name = "Create Abyssoids"
+	triumph_count = 2
 	var/abyssoids_created = 0
 	var/abyssoids_required = 5
 

--- a/code/game/gamemodes/personal_objectives/abyssor/fish_release.dm
+++ b/code/game/gamemodes/personal_objectives/abyssor/fish_release.dm
@@ -1,5 +1,6 @@
 /datum/objective/release_fish
 	name = "Release Rare Fish"
+	triumph_count = 2
 	var/released_count = 0
 	var/required_count = 1
 	var/required_rarity_rank = 1

--- a/code/game/gamemodes/personal_objectives/abyssor/splash_water.dm
+++ b/code/game/gamemodes/personal_objectives/abyssor/splash_water.dm
@@ -1,5 +1,6 @@
 /datum/objective/abyssor_splash
 	name = "Splash Water"
+	triumph_count = 2
 
 /datum/objective/abyssor_splash/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/abyssor/take_bath.dm
+++ b/code/game/gamemodes/personal_objectives/abyssor/take_bath.dm
@@ -1,5 +1,6 @@
 /datum/objective/abyssor_bath
 	name = "Take Bath"
+	triumph_count = 2
 
 /datum/objective/abyssor_bath/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/astrata/become_noble.dm
+++ b/code/game/gamemodes/personal_objectives/astrata/become_noble.dm
@@ -1,6 +1,6 @@
 /datum/objective/nobility
 	name = "Become Noble"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/nobility/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/astrata/recruit_retainer.dm
+++ b/code/game/gamemodes/personal_objectives/astrata/recruit_retainer.dm
@@ -1,5 +1,6 @@
 /datum/objective/retainer
 	name = "Recruit Retainer"
+	triumph_count = 2
 	var/retainers_recruited = 0
 
 /datum/objective/retainer/on_creation()

--- a/code/game/gamemodes/personal_objectives/astrata/scorn_inhumen.dm
+++ b/code/game/gamemodes/personal_objectives/astrata/scorn_inhumen.dm
@@ -1,5 +1,6 @@
 /datum/objective/inhumen_scorn
 	name = "Scorn Inhumen"
+	triumph_count = 2
 	var/spits_done = 0
 	var/spits_required = 2
 

--- a/code/game/gamemodes/personal_objectives/baotha/exploit_flaws.dm
+++ b/code/game/gamemodes/personal_objectives/baotha/exploit_flaws.dm
@@ -1,5 +1,6 @@
 /datum/objective/find_flaws
 	name = "Exploit Flaws"
+	triumph_count = 2
 	var/flaws_found = 0
 	var/flaws_required = 10
 	var/list/known_targets = list()

--- a/code/game/gamemodes/personal_objectives/baotha/sniff_drugs.dm
+++ b/code/game/gamemodes/personal_objectives/baotha/sniff_drugs.dm
@@ -1,5 +1,6 @@
 /datum/objective/sniff_drugs
 	name = "Sniff Drugs"
+	triumph_count = 2
 	var/sniff_count = 0
 	var/required_count = 2
 

--- a/code/game/gamemodes/personal_objectives/baotha/taste_lux.dm
+++ b/code/game/gamemodes/personal_objectives/baotha/taste_lux.dm
@@ -1,6 +1,6 @@
 /datum/objective/taste_lux
 	name = "Taste Divine Essence"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/taste_lux/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/dendor/butcher_animals.dm
+++ b/code/game/gamemodes/personal_objectives/dendor/butcher_animals.dm
@@ -1,5 +1,6 @@
 /datum/objective/butcher_animals
 	name = "Butcher Animals"
+	triumph_count = 2
 	var/animals_butchered = 0
 	var/animals_required = 2
 

--- a/code/game/gamemodes/personal_objectives/dendor/make_wise_trees.dm
+++ b/code/game/gamemodes/personal_objectives/dendor/make_wise_trees.dm
@@ -1,5 +1,6 @@
 /datum/objective/wise_trees
 	name = "Create Wise Trees"
+	triumph_count = 2
 	var/trees_transformed = 0
 	var/trees_required = 3
 

--- a/code/game/gamemodes/personal_objectives/dendor/tame_animals.dm
+++ b/code/game/gamemodes/personal_objectives/dendor/tame_animals.dm
@@ -1,5 +1,6 @@
 /datum/objective/tame_animal
 	name = "Tame an Animal"
+	triumph_count = 2
 	var/tamed_count = 0
 	var/required_tames = 1
 

--- a/code/game/gamemodes/personal_objectives/eora/adopt_orphan.dm
+++ b/code/game/gamemodes/personal_objectives/eora/adopt_orphan.dm
@@ -1,6 +1,6 @@
 /datum/objective/adopt_orphan
 	name = "Adopt Orphan"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/adopt_orphan/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/eora/hug.dm
+++ b/code/game/gamemodes/personal_objectives/eora/hug.dm
@@ -1,5 +1,6 @@
 /datum/objective/hug_beggar
 	name = "Hug a Beggar"
+	triumph_count = 2
 
 /datum/objective/hug_beggar/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/eora/matchmake.dm
+++ b/code/game/gamemodes/personal_objectives/eora/matchmake.dm
@@ -1,5 +1,6 @@
 /datum/objective/marriage_broker
 	name = "Arrange Marriage"
+	triumph_count = 2
 
 /datum/objective/marriage_broker/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/graggar/eat_organs.dm
+++ b/code/game/gamemodes/personal_objectives/graggar/eat_organs.dm
@@ -1,5 +1,6 @@
 /datum/objective/consume_organs
 	name = "Consume Organs"
+	triumph_count = 2
 	var/organs_consumed = 0
 	var/hearts_consumed = 0
 	var/organs_required = 3

--- a/code/game/gamemodes/personal_objectives/graggar/punch_targets.dm
+++ b/code/game/gamemodes/personal_objectives/graggar/punch_targets.dm
@@ -1,5 +1,6 @@
 /datum/objective/punch_women
 	name = "Punch Women"
+	triumph_count = 2
 	var/punches_done = 0
 	var/punches_required = 3
 

--- a/code/game/gamemodes/personal_objectives/graggar/splash_blood.dm
+++ b/code/game/gamemodes/personal_objectives/graggar/splash_blood.dm
@@ -1,5 +1,6 @@
 /datum/objective/blood_splash
 	name = "Splash Blood"
+	triumph_count = 2
 
 /datum/objective/blood_splash/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/malum/craft_shrine.dm
+++ b/code/game/gamemodes/personal_objectives/malum/craft_shrine.dm
@@ -1,5 +1,6 @@
 /datum/objective/craft_shrine
 	name = "Build Shrines"
+	triumph_count = 2
 	var/target_type = /obj/structure/fluff/psycross/crafted
 	var/target_count = 2
 	var/current_count = 0

--- a/code/game/gamemodes/personal_objectives/malum/improve_craft.dm
+++ b/code/game/gamemodes/personal_objectives/malum/improve_craft.dm
@@ -1,5 +1,6 @@
 /datum/objective/improve_craft
 	name = "Improve Craft Skills"
+	triumph_count = 2
 	var/levels_gained = 0
 	var/required_levels = 2
 

--- a/code/game/gamemodes/personal_objectives/malum/spend_energy.dm
+++ b/code/game/gamemodes/personal_objectives/malum/spend_energy.dm
@@ -1,5 +1,6 @@
 /datum/objective/energy_expenditure
 	name = "Spend Energy"
+	triumph_count = 2
 	var/energy_spent = 0
 	var/energy_required = 1000
 

--- a/code/game/gamemodes/personal_objectives/matthios/hoard_mammons.dm
+++ b/code/game/gamemodes/personal_objectives/matthios/hoard_mammons.dm
@@ -1,5 +1,6 @@
 /datum/objective/hoard_mammons
 	name = "Hoard Mammons"
+	triumph_count = 2
 	var/target_mammons = 400
 	var/current_amount = 0
 	var/check_cooldown = 20 SECONDS

--- a/code/game/gamemodes/personal_objectives/matthios/rob_graves.dm
+++ b/code/game/gamemodes/personal_objectives/matthios/rob_graves.dm
@@ -1,5 +1,6 @@
 /datum/objective/grave_robbery
 	name = "Rob Graves"
+	triumph_count = 2
 	var/graves_robbed = 0
 	var/graves_required = 2
 

--- a/code/game/gamemodes/personal_objectives/matthios/theft.dm
+++ b/code/game/gamemodes/personal_objectives/matthios/theft.dm
@@ -1,5 +1,6 @@
 /datum/objective/steal_items
 	name = "Steal Items"
+	triumph_count = 2
 	var/stolen_count = 0
 	var/required_count = 3
 

--- a/code/game/gamemodes/personal_objectives/necra/bury.dm
+++ b/code/game/gamemodes/personal_objectives/necra/bury.dm
@@ -1,5 +1,6 @@
 /datum/objective/proper_burial
 	name = "Consecrate Graves"
+	triumph_count = 2
 	var/burials_completed = 0
 	var/required_burials = 1
 

--- a/code/game/gamemodes/personal_objectives/necra/embrace_death.dm
+++ b/code/game/gamemodes/personal_objectives/necra/embrace_death.dm
@@ -1,6 +1,6 @@
 /datum/objective/embrace_death
 	name = "Embrace Death"
-	triumph_count = 3
+	triumph_count = 4
 
 /datum/objective/embrace_death/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/necra/hear_cries.dm
+++ b/code/game/gamemodes/personal_objectives/necra/hear_cries.dm
@@ -1,5 +1,6 @@
 /datum/objective/listen_whispers
 	name = "Listen to Whispers"
+	triumph_count = 2
 	var/time_required = 5 MINUTES
 	var/time_spent = 0
 	var/last_check = 0
@@ -45,7 +46,7 @@
 		var/message = pick(GLOB.last_words - heard_messages)
 		to_chat(user, span_red("[message]"))
 		heard_messages += message
-		if(prob(25))
+		if(prob(33))
 			user.playsound_local(user, 'sound/effects/ghost.ogg', 40)
 
 	if(time_spent >= time_required && !completed)

--- a/code/game/gamemodes/personal_objectives/noc/baptism.dm
+++ b/code/game/gamemodes/personal_objectives/noc/baptism.dm
@@ -1,6 +1,6 @@
 /datum/objective/baptism
 	name = "Receive Baptism"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/baptism/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/noc/get_apprentice.dm
+++ b/code/game/gamemodes/personal_objectives/noc/get_apprentice.dm
@@ -1,6 +1,6 @@
 /datum/objective/get_apprentice
 	name = "Get Apprentice"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/get_apprentice/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/noc/get_literate.dm
+++ b/code/game/gamemodes/personal_objectives/noc/get_literate.dm
@@ -1,5 +1,6 @@
 /datum/objective/literacy
 	name = "Get Literate"
+	triumph_count = 2
 
 /datum/objective/literacy/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/pestra/eat_rotten_food.dm
+++ b/code/game/gamemodes/personal_objectives/pestra/eat_rotten_food.dm
@@ -1,5 +1,6 @@
 /datum/objective/rotten_feast
 	name = "Rotten Feast"
+	triumph_count = 2
 	var/meals_eaten = 0
 	var/meals_required = 2
 

--- a/code/game/gamemodes/personal_objectives/pestra/lux_extraction.dm
+++ b/code/game/gamemodes/personal_objectives/pestra/lux_extraction.dm
@@ -1,5 +1,6 @@
 /datum/objective/lux_extraction
 	name = "Extract Lux"
+	triumph_count = 2
 
 /datum/objective/lux_extraction/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/pestra/take_pain.dm
+++ b/code/game/gamemodes/personal_objectives/pestra/take_pain.dm
@@ -1,6 +1,6 @@
 /datum/objective/take_pain
 	name = "Take Pain"
-	triumph_count = 2
+	triumph_count = 3
 	var/total_pain_taken = 0
 	var/target_pain = 1000
 

--- a/code/game/gamemodes/personal_objectives/ravox/duel.dm
+++ b/code/game/gamemodes/personal_objectives/ravox/duel.dm
@@ -1,11 +1,11 @@
 /datum/objective/ravox_duel
 	name = "Honor Duels"
+	triumph_count = 2
 	var/duels_won = 0
-	var/duels_required = 2
+	var/duels_required = 1
 
 /datum/objective/ravox_duel/on_creation()
 	. = ..()
-	duels_required = prob(66) ? 1 : 2
 	var/datum/action/innate/ravox_challenge/challenge = new(src)
 	challenge.Grant(owner.current)
 	update_explanation_text()

--- a/code/game/gamemodes/personal_objectives/ravox/improve_combat.dm
+++ b/code/game/gamemodes/personal_objectives/ravox/improve_combat.dm
@@ -1,5 +1,6 @@
 /datum/objective/improve_combat
 	name = "Improve Combat Skills"
+	triumph_count = 2
 	var/levels_gained = 0
 	var/required_levels = 2
 

--- a/code/game/gamemodes/personal_objectives/ravox/ultimate_sacrifice.dm
+++ b/code/game/gamemodes/personal_objectives/ravox/ultimate_sacrifice.dm
@@ -1,6 +1,6 @@
 /datum/objective/ultimate_sacrifice
 	name = "Ultimate Sacrifice"
-	triumph_count = 2
+	triumph_count = 3
 
 /datum/objective/ultimate_sacrifice/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/xylix/coin_flip.dm
+++ b/code/game/gamemodes/personal_objectives/xylix/coin_flip.dm
@@ -1,5 +1,6 @@
 /datum/objective/coin_flip
 	name = "Flip Coin"
+	triumph_count = 2
 	var/obj/item/coin/required_coin_type = /obj/item/coin/gold
 	var/winning_side
 

--- a/code/game/gamemodes/personal_objectives/xylix/mock.dm
+++ b/code/game/gamemodes/personal_objectives/xylix/mock.dm
@@ -1,5 +1,6 @@
 /datum/objective/mock
 	name = "Mock"
+	triumph_count = 2
 
 /datum/objective/mock/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/zizo/kick_man.dm
+++ b/code/game/gamemodes/personal_objectives/zizo/kick_man.dm
@@ -1,5 +1,6 @@
 /datum/objective/kick_groin
 	name = "Kick Groin"
+	triumph_count = 2
 
 /datum/objective/kick_groin/on_creation()
 	. = ..()

--- a/code/game/gamemodes/personal_objectives/zizo/profane_shrines.dm
+++ b/code/game/gamemodes/personal_objectives/zizo/profane_shrines.dm
@@ -1,5 +1,6 @@
 /datum/objective/build_zizo_shrine
 	name = "Construct Profane Shrines"
+	triumph_count = 2
 	var/target_type = /obj/structure/fluff/psycross/zizocross
 	var/target_count = 2
 	var/current_count = 0

--- a/code/game/gamemodes/personal_objectives/zizo/torture.dm
+++ b/code/game/gamemodes/personal_objectives/zizo/torture.dm
@@ -1,6 +1,6 @@
 /datum/objective/torture
 	name = "Extract Truth Through Pain"
-	triumph_count = 2
+	triumph_count = 3
 	var/torture_count = 0
 	var/required_count = 1
 

--- a/code/modules/events/personal/necra/hear_cries.dm
+++ b/code/modules/events/personal/necra/hear_cries.dm
@@ -16,7 +16,7 @@
 	if(!.)
 		return FALSE
 
-	if(length(GLOB.last_words) < 8)
+	if(length(GLOB.last_words) < 7)
 		return FALSE
 
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
@@ -29,7 +29,7 @@
 	return FALSE
 
 /datum/round_event/dead_whispers/start()
-	if(length(GLOB.last_words) < 8)
+	if(length(GLOB.last_words) < 7)
 		return FALSE
 
 	var/list/valid_targets = list()

--- a/code/modules/spells/spell_types/pointed/ultimate_sacrifice.dm
+++ b/code/modules/spells/spell_types/pointed/ultimate_sacrifice.dm
@@ -65,3 +65,5 @@
 			owner.adjust_triumphs(objective.triumph_count)
 			adjust_storyteller_influence(RAVOX, 20)
 			objective.escalate_objective()
+
+	qdel(src)

--- a/html/browser/slop_menustyle3.css
+++ b/html/browser/slop_menustyle3.css
@@ -103,7 +103,21 @@ a#triumph_close_button:hover{
 	padding: 0.1em 0.25em;
 	border-bottom: 1px solid rgb(128, 103, 81);
 	border-right: 1px solid rgb(106, 83, 65);
-	vertical-align: top;
+	vertical-align: middle;
+	white-space: nowrap;
+}
+
+.triumph_stock_wrapper {
+	font-family: "Pirata One", system-ui;
+	font-weight: 400;
+	font-style: normal;
+	font-size:24px;
+	color:#d4af37;
+	text-align: center;
+	padding: 0.1em 0.25em;
+	border-bottom: 1px solid rgb(128, 103, 81);
+	border-right: 1px solid rgb(106, 83, 65);
+	vertical-align: middle;
 	white-space: nowrap;
 }
 
@@ -111,7 +125,7 @@ a#triumph_close_button:hover{
 	text-align: center;
 	padding: 0.1em 0.25em;
 	border-bottom: 1px solid rgb(128, 103, 81);
-	vertical-align: top;
+	vertical-align: middle;
 	white-space: nowrap;
 }
 

--- a/html/browser/slop_menustyle3.css
+++ b/html/browser/slop_menustyle3.css
@@ -267,3 +267,78 @@ a.triumph_numbers_selected, a.triumph_numbers_selected:link, a.triumph_numbers_s
     /* position of strike through from top */
     top:90%;
 }
+
+.communal_header {
+	font-family: 'Aclonica', sans-serif;
+	font-size: 24px;
+	color: #91E0F3;
+	text-align: center;
+	margin: 20px 0;
+}
+
+.communal_container {
+	display: grid;
+	gap: 15px;
+	padding: 10px;
+}
+
+.communal_item {
+	background: rgba(40, 40, 60, 0.7);
+	border: 1px solid #4a4a6a;
+	padding: 15px;
+	border-radius: 5px;
+}
+
+.communal_name {
+	font-weight: bold;
+	color: #FDF7D2;
+	font-size: 18px;
+	margin-bottom: 5px;
+}
+.communal_desc {
+	color: #b0b0b0;
+	margin-bottom: 10px;
+}
+
+.progress_container {
+	background: #2a2a3a;
+	height: 20px;
+	border-radius: 10px;
+	position: relative;
+	margin: 10px 0;
+	overflow: hidden;
+}
+
+.progress_bar {
+	background: linear-gradient(90deg, #4CAF50, #8BC34A);
+	height: 100%;
+	border-radius: 10px;
+	transition: width 0.3s;
+}
+
+.progress_text {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	text-align: center;
+	color: white;
+	line-height: 20px;
+	font-size: 12px;
+}
+
+.communal_contribute {
+    display: inline-block;
+    background: #4a6ea9;
+    color: white;
+    text-align: center;
+    padding: 4px 30px;
+    border-radius: 3px;
+    font-size: 16px;
+    min-width: 80px;
+    text-decoration: none;
+}
+
+.communal_contribute:hover {
+    background: #5a7eb9;
+}

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -477,6 +477,7 @@
 #include "code\controllers\subsystem\triumph\buy_datums\triumph_buy_datums.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\character\pick_all_jobs_as_any_race.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\character\pick_any_class.dm"
+#include "code\controllers\subsystem\triumph\buy_datums\communal\_communal.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\communal\psydon_retirement_fund.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\misc\psydon_favourite.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\storyteller\bonus_influence.dm"

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -477,6 +477,8 @@
 #include "code\controllers\subsystem\triumph\buy_datums\triumph_buy_datums.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\character\pick_all_jobs_as_any_race.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\character\pick_any_class.dm"
+#include "code\controllers\subsystem\triumph\buy_datums\communal\psydon_retirement_fund.dm"
+#include "code\controllers\subsystem\triumph\buy_datums\misc\psydon_favourite.dm"
 #include "code\controllers\subsystem\triumph\buy_datums\storyteller\bonus_influence.dm"
 #include "code\datums\_verb_callback.dm"
 #include "code\datums\antag_retainer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**Changes:**

- Added a new triumph buy - Psydon's Favourite. Limited to one per round. Owner of this triumph buy will have a special spot in the notable people section, if he manages to get through the round in one piece.
- Added a new triumph buy - Psydon's Retirement Fund. The first of the new type of triumph buys - communal. Communal triumph buys are shared between all players and all of them can contribute triumphs towards activating it. Psydon's Retirement Fund is even little more unique - it will also activate at round end if it did not reach its maximum pool of 1000 triumphs before that. Psydon's Retirement fund will redistribute all its pooled triumphs to the poorest players present, aka the one with least triumphs.
- Storyteller bonus influence triumph buys are now limited to 2 per round and their price has decreased from 5 to 3.
- General improvements to triumph shop menu code, formatting, layout, pagination and texts.
- Triumph changes are now logged.
- Triumph leaderboard now shows 20 players and is based on browser datum.
- All personal god objectives now give 1 extra triumph, as they are not given or completed that often and now there are more various uses for triumphs in general.

**Example image:**

<img width="682" height="347" alt="GlowUP" src="https://github.com/user-attachments/assets/373c8341-6376-40b1-9156-598ff49ce47b" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Better and saner triumph shop, new interesting triumph buys.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Arkatos
add: Added a new triumph buy - Psydon's Favourite.
add: Added a new triumph buy - Psydon's Retirement Fund.
add: Storyteller bonus influence triumph buys are now limited to 2 per round and their price has decreased from 5 to 3.
add: All personal god objectives now award 1 extra triumph upon completion.
qol: Improved Triumph Leaderboard menu.
qol: Improved Triumph Shop menu formatting, layout, pagination and texts.
admin: Triumph changes are now logged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
