### PR TITLE
Hollow Ranger Fixes

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/hollowranger.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/hollowranger.dm
@@ -4,12 +4,15 @@
 	Acting mostly as scouts for groups of 'supply liberation' militia around their home, \
 	stealth is a virtue for a Hollow Ranger."
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list("Hollow-Kin",
-	"Harpy",
-	"Humen")
+	allowed_races = list(\
+		SPEC_ID_HOLLOWKIN,\
+		SPEC_ID_HUMEN,\
+		SPEC_ID_HARPY,\
+	)
 	outfit = /datum/outfit/job/adventurer/hollowranger
 	min_pq = 0
 	category_tags = list(CTAG_ADVENTURER)
+	cmode_music = 'sound/music/cmode/adventurer/CombatIntense.ogg'
 
 /datum/outfit/job/adventurer/hollowranger/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

Updates hollowranger.dm's allowed_races to be in line with the other adventurer classes so it can actually spawn without triumph buying, also gives it some combat music because it didn't have any specified. This is my first time messing around with github so yell at me if I did something wrong.

## Why It's Good For The Game

An interesting adventurer class was completely unable to spawn because of the way the species restrictions were entered.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.