### PR TITLE
Torch Buffs/Fix

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -227,7 +227,7 @@
 
 		if (should_self_destruct)  // check if self-destruct
 			times_used += 1
-			if (times_used >= 8) //amount used before burning out
+			if (times_used >= 12) //amount used before burning out
 				user.visible_message("<span class='warning'>[src] has burnt out and falls apart!</span>")
 				qdel(src)
 
@@ -253,9 +253,9 @@
 	metalizer_result = null
 
 /obj/item/flashlight/flare/torch/metal/afterattack(atom/movable/A, mob/user, proximity)
-	. = ..()
 	if(!proximity)
 		return
+
 	if(on && (prob(50) || (user.used_intent.type == /datum/intent/use)))
 		if(ismob(A))
 			A.spark_act()
@@ -264,7 +264,7 @@
 
 		if (should_self_destruct)  // check if self-destruct
 			times_used += 1
-			if (times_used >= 13) //amount used before burning out
+			if (times_used >= 60) //amount used before burning out
 				user.visible_message("<span class='warning'>[src] has burnt out and falls apart!</span>")
 				qdel(src)
 


### PR DESCRIPTION
## About The Pull Request

Standard Torch uses up from 8 to 12

Metal Torch uses up from 13 to 60

Fixed metal torch was logging two uses per use so it was actually worse than normal torch.

## Why It's Good For The Game

It's annoying to craft torches when lighting other torches in sconces, or setting things on fire.

I thought about making it so metal torches can't even self destruct, but figured they probably should. They technically cost 1/5 iron ingot and 1/5 coal to smith.  I doubt anyone will ever ask the smith to make them a metal torch even with these changes, but this could be good to give to towns people we don't want to give lampterns.

## Changelog

:cl:
balance: Torches can be used slightly more
fix: Metal torches last longer
/:cl:


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
