### PR TITLE
Itinerant and Dark Knight migrant changes

### DIFF
--- a/code/datums/migrants/waves/dark_itinerant_knight_wave.dm
+++ b/code/datums/migrants/waves/dark_itinerant_knight_wave.dm
@@ -40,10 +40,14 @@
 		H.change_stat(STATKEY_CON, 2)
 		H.change_stat(STATKEY_END, 2)
 		H.change_stat(STATKEY_SPD, -1)
+		var/prev_real_name = H.real_name
+		var/prev_name = H.name
+		var/honorary = "Zizo Knight"
+		H.real_name = "[honorary] [prev_real_name]"
+		H.name = "[honorary] [prev_name]"
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	H.cmode_music = 'sound/music/cmode/antag/CombatThrall.ogg'
 
@@ -59,11 +63,11 @@
 /datum/outfit/job/dark_itinerant_squire/pre_equip(mob/living/carbon/human/H)
 	..()
 	shirt = /obj/item/clothing/shirt/dress/gen/colored/black
-	pants = /obj/item/clothing/pants/chainlegs/iron
+	pants = /obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather
 	beltr = /obj/item/ammo_holder/quiver/bolts
-	armor = /obj/item/clothing/armor/chainmail
+	armor = /obj/item/clothing/armor/leather/splint
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 	gloves = /obj/item/clothing/gloves/leather
 	wrists = /obj/item/clothing/wrists/bracers/leather

--- a/code/datums/migrants/waves/itinerant_knight_wave.dm
+++ b/code/datums/migrants/waves/itinerant_knight_wave.dm
@@ -20,6 +20,11 @@
 	backr = /obj/item/storage/backpack/satchel
 	backl = /obj/item/weapon/sword/long/greatsword
 	backpack_contents = list(/obj/item/clothing/neck/psycross/silver = 1, /obj/item/weapon/knife/dagger/steel = 1, /obj/item/storage/belt/pouch/coins/mid = 1)
+	var/prev_real_name = H.real_name
+	var/prev_name = H.name
+	var/honorary = "Itinerant Knight"
+	H.real_name = "[honorary] [prev_real_name]"
+	H.name = "[honorary] [prev_name]"
 
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
@@ -45,7 +50,6 @@
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	H.cmode_music = 'sound/music/cmode/nobility/CombatKnight.ogg'
 
@@ -61,11 +65,11 @@
 /datum/outfit/job/itinerant_squire/pre_equip(mob/living/carbon/human/H)
 	..()
 	shirt = /obj/item/clothing/shirt/dress/gen/colored/black
-	pants = /obj/item/clothing/pants/chainlegs/iron
+	pants =/obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots
 	belt = /obj/item/storage/belt/leather
 	beltr = /obj/item/ammo_holder/quiver/arrows
-	armor = /obj/item/clothing/armor/plate/full
+	armor = /obj/item/clothing/armor/leather/splint
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/short
 	gloves = /obj/item/clothing/gloves/leather
 	wrists = /obj/item/clothing/wrists/bracers/leather


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Removes Medium Armor Training from both knights(Heavy armor trait is already superior)

- Both Knights have Titles.

- Remove plate and iron chausess from the squires switching it for light armor so they can use their "Fast Reflex" Trait.

## Why It's Good For The Game

Squires had to sell their armor or steal one to use their trait, considering how low their combat skill are without the trait is basically certain death in close combat.

Both Hedge Knight and Dredge Black Knight got Titles, following that it only makes sense considering that both are knights to have a title.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Change Dark/Itinerant Knight squires plate armor to light armor.
add: Add titles for the Dark and Itinerant Knights
del: Remove Medium Armor Training from the Dark/Itinerant Knights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
