### PR TITLE
Doubles Max Fiber in Bundle

### DIFF
--- a/code/game/objects/items/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/natural/clothfibersthorn.dm
@@ -312,7 +312,7 @@
 	possible_item_intents = list(/datum/intent/use)
 	force = 0
 	throwforce = 0
-	maxamount = 6
+	maxamount = 12
 	color = "#454032"
 	firefuel = 5 MINUTES
 	resistance_flags = FLAMMABLE


### PR DESCRIPTION
## About The Pull Request
Fiber bundles used to be able to hold 6 fiber this lets them hold 12

## Why It's Good For The Game
Takes tedium out of bundling fibers for some jobs.

## Changelog

:cl:
balance: fiber bundles can hold 12 fibers now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
