### PR TITLE
Removes the Artificer Key from Pilgrims

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/rare/Lcarp.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/rare/Lcarp.dm
@@ -45,7 +45,7 @@
 	beltl = /obj/item/weapon/hammer/steel
 	backl = /obj/item/storage/backpack/backpack
 	backr = /obj/item/weapon/polearm/halberd/bardiche/woodcutter // A specialist in cutting trees would carry an impressive axe
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/weapon/knife/hunting = 1, /obj/item/key/artificer = 1)
+	backpack_contents = list(/obj/item/flint = 1, /obj/item/weapon/knife/hunting = 1)
 	H.change_stat(STATKEY_STR, 2)
 	H.change_stat(STATKEY_END, 2)
 	H.change_stat(STATKEY_INT, 1)

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/woodcutter.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/woodcutter.dm
@@ -33,6 +33,6 @@
 	armor = /obj/item/clothing/armor/gambeson/light/striped
 	beltr = /obj/item/weapon/axe/iron
 	beltl = /obj/item/weapon/knife/villager
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/key/artificer = 1)
+	backpack_contents = list(/obj/item/flint = 1)
 	H.change_stat(STATKEY_STR, 1)
 	H.change_stat(STATKEY_END, 1) // Tree chopping builds endurance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title

## Why It's Good For The Game

Why did they had in the first place? They come from outside Vanderlin and none of those has a lore pointing to being part of the maker guild, even the Supreme Aritifcer in the Heartfelt Migration don't got Vanderlin Artificer keys.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Remove Artificer Keys from pilgrims.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
