### PR TITLE
Leyline attunement rune

### DIFF
--- a/code/datums/rituals/ritual.dm
+++ b/code/datums/rituals/ritual.dm
@@ -246,6 +246,15 @@ GLOBAL_LIST_INIT(t2buffrunerituallist, generate_t2buff_rituallist())
 
 /datum/runerituals/knowledge/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	return TRUE
+/datum/runerituals/leyattunement
+	name = "leyline attunement"
+	tier = 1
+	blacklisted = FALSE
+	required_atoms = list(/obj/item/mana_battery/mana_crystal/small = 1,/obj/item/reagent_containers/food/snacks/produce/manabloom = 2,/obj/item/natural/leyline = 1)
+
+/datum/runerituals/leyattunement/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	return TRUE
+
 
 /datum/runerituals/buff/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	return TRUE

--- a/code/datums/rituals/ritual_runes.dm
+++ b/code/datums/rituals/ritual_runes.dm
@@ -374,6 +374,53 @@ GLOBAL_LIST(teleport_runes)
 			to_chat(living_invoker,  span_italics("[src] saps your strength!"))
 	do_invoke_glow()
 
+/obj/effect/decal/cleanable/roguerune/arcyne/leylines	//used for better quality of learning, grants temporary 2 minute INT bonus.
+	name = "leyline attunement matrix"
+	desc = "geometry shapes and lines on the ground resonate with power..."
+	icon = 'icons/effects/96x96.dmi'
+	icon_state = "empowerment"
+	runesize = 1
+	tier = 2
+	pixel_x = -32 //So the big ol' 96x96 sprite shows up right
+	pixel_y = -32
+	pixel_z = 0
+	//icon_state = "6"
+	invocation = "Thal’miren vek’laris un’vethar!"
+	color = "#a70808ce"
+	scribe_damage = 10
+	can_be_scribed = TRUE
+	associated_ritual = /datum/runerituals/leyattunement
+	var/buffed = FALSE
+
+/obj/effect/decal/cleanable/roguerune/arcyne/leylines/invoke(list/invokers, datum/runerituals/runeritual)
+	runeritual = associated_ritual
+	if(!..())	//VERY important. Calls parent and checks if it fails. parent/invoke has all the checks for ingredients
+		return
+	var/mob/living/user = usr
+	if (user.mana_pool.intrinsic_recharge_sources & MANA_SOULS) //unavailable to lich
+		to_chat(user, span_warning("I cannot attune to leylines now."))
+	else
+		if (user.mana_pool.intrinsic_recharge_sources & MANA_ALL_LEYLINES)
+			to_chat(user, span_warning("Already attuned to leylines!"))
+		else
+			user.mana_pool.set_intrinsic_recharge(MANA_ALL_LEYLINES)
+			playsound(user, 'sound/magic/blink.ogg', 80, FALSE)
+			to_chat(user, span_warning("Leylines fill me with power!"))
+			//	SEND_SIGNAL(user, COMSIG_BAPTISM_RECEIVED, user)  //for the baptism reference
+
+	if(ritual_result)
+		pickritual.cleanup_atoms(selected_atoms)
+
+	for(var/atom/invoker in invokers)
+		if(!isliving(invoker))
+			continue
+		var/mob/living/living_invoker = invoker
+		if(invocation)
+			living_invoker.say(invocation, language = /datum/language/common, ignore_spam = TRUE, forced = "cult invocation")
+		if(invoke_damage)
+			living_invoker.apply_damage(invoke_damage, BRUTE)
+			to_chat(living_invoker,  span_italics("[src] saps your strength!"))
+	do_invoke_glow()
 
 /obj/effect/decal/cleanable/roguerune/arcyne/empowerment	//used for better quality of learning, grants temporary 2 minute INT bonus.
 	name = "empowerment array"


### PR DESCRIPTION
About The Pull Request

Add leyline attunement rune and ritual for that rune, which uses one leyline shard, one small primordial crystal and two manabloom flowers.

Why It's Good For The Game

Mana fountain deleted, so baptism is unavailsble. Aspiring arcanists, orphans learning magic have no way to get leyline attunement

