### PR TITLE
Roundstart event fix

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -73,7 +73,7 @@
 		if(string)
 			string += ","
 		string += "Cap Reached"
-	if(earliest_start >= world.time-SSticker.round_start_time)
+	if(earliest_start > max(world.time - SSticker.round_start_time, 0))
 		if(string)
 			string += ","
 		string +="Too Soon"
@@ -109,7 +109,7 @@
 	if(occurrences >= max_occurrences)
 		return FALSE
 
-	if(earliest_start >= world.time-SSticker.round_start_time)
+	if(earliest_start > max(world.time - SSticker.round_start_time, 0))
 		return FALSE
 
 	if(wizardevent != SSevents.wizardmode)

--- a/code/modules/events/raids/goblin.dm
+++ b/code/modules/events/raids/goblin.dm
@@ -11,13 +11,6 @@
 
 	raid_text = "The goblin horde approaches."
 
-/datum/round_event_control/worldsiege/goblin/canSpawnEvent(players_amt, gamemode, fake_check)
-	if(earliest_start >= world.time-SSticker.round_start_time)
-		return FALSE
-	if(players_amt < min_players)
-		return FALSE
-	. = ..()
-
 /datum/round_event/worldsiege/goblin/start()
 	SSmapping.add_world_trait(/datum/world_trait/goblin_siege, rand(4 MINUTES, 8 MINUTES))
 	for(var/mob/dead/observer/O in GLOB.player_list)

--- a/code/modules/events/raids/rousman.dm
+++ b/code/modules/events/raids/rousman.dm
@@ -11,13 +11,6 @@
 
 	raid_text = "The rousman horde approaches."
 
-/datum/round_event_control/worldsiege/rousman/canSpawnEvent(players_amt, gamemode, fake_check)
-	if(earliest_start >= world.time-SSticker.round_start_time)
-		return FALSE
-	if(players_amt < min_players)
-		return FALSE
-	. = ..()
-
 /datum/round_event/worldsiege/rousman/start()
 	SSmapping.add_world_trait(/datum/world_trait/rousman_siege, rand(4 MINUTES, 8 MINUTES))
 	for(var/mob/dead/observer/O in GLOB.player_list)

--- a/code/modules/events/raids/skeleton.dm
+++ b/code/modules/events/raids/skeleton.dm
@@ -10,13 +10,6 @@
 	var/last_siege
 	var/raid_text = "The skeleton horde approaches."
 
-/datum/round_event_control/worldsiege/canSpawnEvent(players_amt, gamemode, fake_check)
-	if(earliest_start >= world.time-SSticker.round_start_time)
-		return FALSE
-	if(players_amt < min_players)
-		return FALSE
-	. = ..()
-
 /datum/round_event_control/worldsiege/preRunEvent()
 	. = ..()
 	if(. == EVENT_READY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes an issue where the roundstart event sometimes failed to trigger due to failing the earliest start check, even when it was supposed to pass. And also cleans up canSpawnEvent for raids, as they had a superfluous checks, even when the exact same checks are in the parent.

## Why It's Good For The Game

Bugfix.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Arkatos
fix: Fixed a rare issue where a roundstart event failed to trigger due to wrong timing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
