### PR TITLE
Non-Discriminated Inhumen (Triton, Harpies, Medicators) may now be town elder.

### DIFF
--- a/code/modules/jobs/job_types/garrison/town_elder.dm
+++ b/code/modules/jobs/job_types/garrison/town_elder.dm
@@ -78,7 +78,7 @@
 
 /datum/advclass/town_elder/mayor
 	name = "Mayor"
-	allowed_races=(RACES_PLAYER_NONDISCRIMINATED) // Due to the inherent nobility coming from being a mayor, non-humen species are barred.
+	allowed_races = RACES_PLAYER_NONDISCRIMINATED // Due to the inherent nobility coming from being a mayor, non-humen species are barred.
 	tutorial = "Before politics, you were a bard, your voice stirred hearts, your tales traveled farther than your feet ever could. You carved your name in history not with steel, but with stories that moved kings and commoners alike. In time, your charisma became counsel, your songs gave way to speeches. Decades later, your skill in diplomacy and trade earned you nobility, and with it, the title of Mayor. Now, you lead not from a stage, but from the heart of the people you once sang for."
 	outfit = /datum/outfit/job/town_elder/mayor
 


### PR DESCRIPTION


## About The Pull Request

As the title says, Triton, Harpies and Medicators are now able to roll town Elder. They however lose access to the "Mayor" subclass, since it's upposed to be a noble.

## Why It's Good For The Game

Inhumen species are cool because they're actually weird fantasy species and not "human with funny ears / size" (Aasimars are forgiven, they're cool). However, you get shafted hard for playing them, all leadership positions being completely barred from you. This seeks to give more RP opportunities for inhumen players without breaking canon.

<img width="463" height="83" alt="image" src="https://github.com/user-attachments/assets/24fee331-853f-474e-a9ab-0bd29ab1dbf5" />

<img width="844" height="451" alt="image" src="https://github.com/user-attachments/assets/93aabd04-d8f5-464f-9af6-38b2e1ece86b" />

<img width="336" height="435" alt="image" src="https://github.com/user-attachments/assets/970fc4f0-e442-4970-9744-620a666a2c52" />

<img width="515" height="39" alt="image" src="https://github.com/user-attachments/assets/03130d7c-44cf-4289-a5d7-765052c1e11b" />


## Changelog

:cl:
add: The town elder role is now accessible to Medicators, Tritons, and Harpies, these species do not have access to the Mayor subclass, however, as it is reserved for nobles.
/:cl:


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
