### PR TITLE
Cleric changes

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -60,6 +60,7 @@
 				beltl = /obj/item/weapon/mace/elvenclub
 			else
 				beltl = /obj/item/weapon/mace
+			beltr = /obj/item/weapon/shovel/small //so they can burry the dead
 			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		if(/datum/patron/divine/eora)
@@ -102,7 +103,7 @@
 			cloak = /obj/item/clothing/cloak/tabard/crusader
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 			backr = /obj/item/weapon/polearm/spear //think fishing spear
-			beltl = /obj/item/fishingrod //no attachements, cleric can either discard it or embrace abyssor and fish like mans hould
+			beltl = /obj/item/fishingrod //no attachements, cleric can either discard it or embrace abyssor and fish like man was made to do
 			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
 		if(/datum/patron/divine/malum)

--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -1,7 +1,9 @@
 //shield
 /datum/advclass/combat/cleric
 	name = "Cleric"
-	tutorial = "Clerics are wandering warriors of the Gods, drawn from the ranks of temple acolytes who demonstrated martial talent. Protected by armor and zeal, they are a force to be reckoned with."
+	tutorial = "Clerics are wandering warriors of the Gods, \
+	drawn from the ranks of temple acolytes who demonstrated martial talent. \
+	Protected by armor and zeal, they are a force to be reckoned with."
 	allowed_races = RACES_PLAYER_NONHERETICAL
 	vampcompat = FALSE
 	outfit = /datum/outfit/job/adventurer/cleric
@@ -16,103 +18,132 @@
 /datum/outfit/job/adventurer/cleric/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.virginity = TRUE
+	H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+
 	head = /obj/item/clothing/head/helmet/ironpot
 	armor = /obj/item/clothing/armor/cuirass/iron // Adventurers are not supposed to have fricking steel, at all
-	shirt = /obj/item/clothing/armor/gambeson/light
+	shirt = /obj/item/clothing/armor/gambeson
+	gloves = /obj/item/clothing/gloves/leather
 	pants = /obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots/leather
 	neck = /obj/item/clothing/neck/chaincoif/iron // Everyone gets iron coif, instead of variable neck armor
 	belt = /obj/item/storage/belt/leather
-	backr = /obj/item/weapon/shield/heater
-	if(ispath(H.patron?.type, /datum/patron/divine/necra))
-		backl = /obj/item/weapon/shovel
-	if(ispath(H.patron?.type, /datum/patron/divine/abyssor))
-		backl = /obj/item/weapon/polearm/woodstaff/quarterstaff
-	else
-		if(iself(H) || ishalfelf(H))
-			beltl = /obj/item/weapon/mace/elvenclub
-		else
-			beltl = /obj/item/weapon/mace
-	beltr = /obj/item/storage/belt/pouch/coins/poor
+	backl = /obj/item/storage/backpack/satchel
+	//I assume they were given something for the journey by another parish, or the one they departed from
+	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1, /obj/item/reagent_containers/food/snacks/hardtack = 1)
 
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
 			wrists = /obj/item/clothing/neck/psycross/silver/astrata
 			cloak = /obj/item/clothing/cloak/stabard/templar/astrata
 			H.cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
+			backr = /obj/item/weapon/shield/heater
+			if(iself(H) || ishalfelf(H))
+				beltl = /obj/item/weapon/mace/elvenclub
+			else
+				beltl = /obj/item/weapon/mace
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		if(/datum/patron/divine/dendor)
 			wrists = /obj/item/clothing/neck/psycross/silver/dendor
 			cloak = /obj/item/clothing/cloak/stabard/templar/dendor
 			H.cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
+			backr = /obj/item/weapon/polearm/halberd/bardiche
+			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		if(/datum/patron/divine/necra)
 			wrists = /obj/item/clothing/neck/psycross/silver/necra
 			cloak = /obj/item/clothing/cloak/stabard/templar/necra
 			H.cmode_music = 'sound/music/cmode/church/CombatGravekeeper.ogg'
+			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)//accustomed to death
+			backr = /obj/item/weapon/shield/heater
+			if(iself(H) || ishalfelf(H))
+				beltl = /obj/item/weapon/mace/elvenclub
+			else
+				beltl = /obj/item/weapon/mace
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		if(/datum/patron/divine/eora)
 			wrists = /obj/item/clothing/neck/psycross/silver/eora
 			cloak = /obj/item/clothing/cloak/stabard/templar/eora
 			H.cmode_music = 'sound/music/cmode/church/CombatEora.ogg'
-			H.virginity = FALSE // this is hilarious lol
+			H.virginity = FALSE
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+			beltl = /obj/item/ammo_holder/quiver/bolts
+			beltr = /obj/item/weapon/knife/dagger //meant as a backup weapon
+			H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		if(/datum/patron/divine/ravox)
 			wrists = /obj/item/clothing/neck/psycross/silver/ravox
 			cloak =  /obj/item/clothing/cloak/stabard/templar/ravox
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
+			backr = /obj/item/weapon/polearm/woodstaff/quarterstaff/iron
+			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 		if(/datum/patron/divine/noc)
 			wrists = /obj/item/clothing/neck/psycross/noc
 			cloak = /obj/item/clothing/cloak/stabard/templar/noc
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+			backr = /obj/item/weapon/shield/heater
+			beltl = /obj/item/weapon/whip/chain
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 		if(/datum/patron/divine/pestra)
 			wrists = /obj/item/clothing/neck/psycross/silver/pestra
 			cloak = /obj/item/clothing/cloak/stabard/templar/pestra
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+			backr = /obj/item/weapon/shield/heater
+			beltl = /obj/item/weapon/sword/short
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 		if(/datum/patron/divine/abyssor)
 			wrists = /obj/item/clothing/neck/psycross/silver/abyssor
 			cloak = /obj/item/clothing/cloak/tabard/crusader
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+			backr = /obj/item/weapon/polearm/spear //think fishing spear
+			beltl = /obj/item/fishingrod //no attachements, cleric can either discard it or embrace abyssor and fish like mans hould
+			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
 		if(/datum/patron/divine/malum)
 			wrists = /obj/item/clothing/neck/psycross/silver/malum
 			cloak = /obj/item/clothing/cloak/stabard/templar/malum
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'
+			beltl = /obj/item/weapon/hammer/sledgehammer
+			H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
 		if(/datum/patron/divine/xylix)
 			wrists = /obj/item/clothing/neck/psycross/silver/xylix
 			cloak = /obj/item/clothing/cloak/stabard/templar/xylix
 			H.cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
+			backr = /obj/item/weapon/shield/heater
+			beltl = /obj/item/weapon/flail
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 		else // Failsafe
 			cloak = /obj/item/clothing/cloak/tabard/crusader // Give us a generic crusade tabard
 			wrists = /obj/item/clothing/neck/psycross/silver // Give us a silver psycross for protection against lickers
 			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
 
-
-	if(H.mind)
-		H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
+	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
-		if(ispath(H.patron?.type, /datum/patron/divine/necra))
-			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-		var/datum/skill/to_add = /datum/skill/combat/axesmaces
-		if(ispath(H.patron?.type, /datum/patron/divine/abyssor))
-			to_add = /datum/skill/combat/polearms
-			H.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
-		H.adjust_skillrank(to_add, 3, TRUE)
-		if(H.age == AGE_OLD)
-			H.adjust_skillrank(to_add, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.change_stat(STATKEY_STR, 1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_CON, 1)
-		H.change_stat(STATKEY_END, 2)
-		H.change_stat(STATKEY_SPD, -1)
-		if(!H.has_language(/datum/language/celestial)) // For discussing church matters with the other Clergy
-			H.grant_language(/datum/language/celestial)
-			to_chat(H, "<span class='info'>I can speak Celestial with ,c before my speech.</span>")
+	H.change_stat(STATKEY_STR, 1)
+	H.change_stat(STATKEY_INT, 1)
+	H.change_stat(STATKEY_CON, 1)
+	H.change_stat(STATKEY_END, 2)
+	H.change_stat(STATKEY_SPD, -1)
+	if(!H.has_language(/datum/language/celestial)) // For discussing church matters with the other Clergy
+		H.grant_language(/datum/language/celestial)
+		to_chat(H, "<span class='info'>I can speak Celestial with ,c before my speech.</span>")
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC) // Even if it has limited slots, it is a common drifter role available to anyone. Their armor also is not heavy, so medium armor training is enough
 	var/datum/devotion/cleric_holder/C = new /datum/devotion/cleric_holder(H, H.patron)
 	C.grant_spells_cleric(H)

--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -48,7 +48,7 @@
 			wrists = /obj/item/clothing/neck/psycross/silver/dendor
 			cloak = /obj/item/clothing/cloak/stabard/templar/dendor
 			H.cmode_music = 'sound/music/cmode/garrison/CombatForestGarrison.ogg'
-			backr = /obj/item/weapon/polearm/halberd/bardiche
+			backr = /obj/item/weapon/polearm/halberd/bardiche/woodcutter
 			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		if(/datum/patron/divine/necra)
 			wrists = /obj/item/clothing/neck/psycross/silver/necra

--- a/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/cleric.dm
@@ -68,6 +68,7 @@
 			H.cmode_music = 'sound/music/cmode/church/CombatEora.ogg'
 			H.virginity = FALSE
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+			//its a cupid joke, but in this case with a crossbow
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			beltl = /obj/item/ammo_holder/quiver/bolts
 			beltr = /obj/item/weapon/knife/dagger //meant as a backup weapon

--- a/code/modules/jobs/job_types/adventurer/types/combat/clericinhumen.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/clericinhumen.dm
@@ -1,7 +1,8 @@
 //shield
 /datum/advclass/combat/inhumencleric
 	name = "Inhumen Cleric"
-	tutorial = "Those Clerics are wandering warriors of the Inhumens"
+	tutorial = "Clerics are wandering warriors of the Inhumen Gods, zealots whom demonstrated martial talent.\
+	Protected by stolen armor and unholy zeal, they are a force to be reckoned with."
 	allowed_races = RACES_PLAYER_ALL
 	vampcompat = FALSE
 	outfit = /datum/outfit/job/adventurer/inhumencleric
@@ -17,78 +18,77 @@
 	..()
 	head = /obj/item/clothing/head/helmet/ironpot
 	armor = /obj/item/clothing/armor/cuirass/iron // Adventurers are not supposed to have fricking steel, at all
-	shirt = /obj/item/clothing/armor/gambeson/light
+	shirt = /obj/item/clothing/armor/gambeson
+	gloves = /obj/item/clothing/gloves/leather
 	pants = /obj/item/clothing/pants/trou/leather
 	shoes = /obj/item/clothing/shoes/boots/leather
 	neck = /obj/item/clothing/neck/chaincoif/iron // Everyone gets iron coif, instead of variable neck armor
 	belt = /obj/item/storage/belt/leather
-	backr = /obj/item/weapon/shield/heater
-	if(ispath(H.patron?.type, /datum/patron/inhumen/graggar))
-		beltl = /obj/item/weapon/axe/iron
-	else if(ispath(H.patron?.type, /datum/patron/inhumen/matthios))
-		backl = /obj/item/weapon/polearm/woodstaff/quarterstaff
-	else if(ispath(H.patron?.type, /datum/patron/inhumen/baotha))
-		beltl = /obj/item/weapon/knife/dagger/steel
-		backl = /obj/item/storage/backpack/satchel
-		backpack_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 2, /obj/item/weapon/knife/dagger/steel = 1) //Poison
-	else
-		if(iself(H) || ishalfelf(H))
-			beltl = /obj/item/weapon/mace/elvenclub
-		else
-			beltl = /obj/item/weapon/mace
-	beltr = /obj/item/storage/belt/pouch/coins/poor
+	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor = 1)
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/graggar)
 			cloak = /obj/item/clothing/cloak/raincloak/colored/mortus
+			head = /obj/item/clothing/head/helmet/horned	//barbarian adventurer reference
+			beltl = /obj/item/weapon/axe/boneaxe
+			beltr = /obj/item/weapon/axe/boneaxe
+			H.adjust_skillrank(/datum/skill/combat/axesmaces, 3, TRUE)
+			ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
-		if(/datum/patron/inhumen/graggar_zizo)
+		if(/datum/patron/inhumen/graggar_zizo)	//I assume this can only happen if a maniac rolls cleric
 			cloak = /obj/item/clothing/cloak/raincloak/colored/mortus
 			H.cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		if(/datum/patron/inhumen/zizo)
 			cloak = /obj/item/clothing/cloak/raincloak/colored/mortus
 			head = /obj/item/clothing/head/helmet/skullcap/cult
 			H.cmode_music = 'sound/music/cmode/antag/combat_cult.ogg'
+			backr = /obj/item/weapon/shield/heater
+			beltl = /obj/item/weapon/sword/short
+			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 		if(/datum/patron/inhumen/matthios)
 			cloak = /obj/item/clothing/cloak/raincloak/colored/mortus
 			H.cmode_music = 'sound/music/cmode/antag/CombatBandit1.ogg'
+			backr = /obj/item/weapon/pitchfork //weapon of the peasantry
+			H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
 		if(/datum/patron/inhumen/baotha)
 			head = /obj/item/clothing/head/crown/circlet
 			mask = /obj/item/clothing/face/spectacles/sglasses
 			cloak = /obj/item/clothing/cloak/raincloak/colored/purple
-			ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
+			backpack_contents = list(/obj/item/reagent_containers/glass/bottle/poison = 1, /obj/item/reagent_containers/glass/bottle/stampoison = 1) //Poison
+			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+			beltl = /obj/item/ammo_holder/quiver/bolts
+			beltr = /obj/item/weapon/knife/dagger/steel //meant as a backup weapon
+			H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
 			H.cmode_music = 'sound/music/cmode/antag/CombatBaotha.ogg'
 		else // Failsafe
 			cloak = /obj/item/clothing/cloak/tabard/crusader // Give us a generic crusade tabard
 			wrists = /obj/item/clothing/neck/psycross/silver // Give us a silver psycross for protection against lickers
 			H.cmode_music = 'sound/music/cmode/church/CombatInquisitor.ogg'
 
-
-	if(H.mind)
-		H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
+	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/mathematics, 2, TRUE)
-		var/datum/skill/to_add = /datum/skill/combat/axesmaces
-		if(ispath(H.patron?.type, /datum/patron/inhumen/matthios))
-			to_add = /datum/skill/combat/polearms
-		if(ispath(H.patron?.type, /datum/patron/inhumen/baotha))
-			to_add = /datum/skill/combat/knives
-			H.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
-		H.adjust_skillrank(to_add, 3, TRUE)
-		if(H.age == AGE_OLD)
-			H.adjust_skillrank(to_add, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.change_stat(STATKEY_STR, 1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_CON, 1)
-		H.change_stat(STATKEY_END, 2)
-		H.change_stat(STATKEY_SPD, -1)
+	H.change_stat(STATKEY_STR, 1)
+	H.change_stat(STATKEY_INT, 1)
+	H.change_stat(STATKEY_CON, 1)
+	H.change_stat(STATKEY_END, 2)
+	H.change_stat(STATKEY_SPD, -1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC) // Even if it has limited slots, it is a common drifter role available to anyone. Their armor also is not heavy, so medium armor training is enough
 	var/datum/devotion/cleric_holder/C = new /datum/devotion/cleric_holder(H, H.patron)
 	C.grant_spells_cleric(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Each cleric (both of the ten and the inhumen) get a weapon associated with their respective god, and the needed skills
Also makes the code cleaner

## Why It's Good For The Game

Clean code doesn't make me want to rip out my hairs.
Variation to cleric equipment makes things cooler I believe, Malumites get a sledgehammer, Dendorites get a woodcutter axe, etc.
Nothing too strong, something that I imagine they would be equipped with when they were leaving to travel to Vanderlin.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Clerics, both Ten and Inhumen, had their loadouts overhauled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
