### PR TITLE
Soap changes

### DIFF
--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -51,7 +51,7 @@
 /datum/stressevent/blessed
 	timer = 60 MINUTES
 	stressadd = -5
-	desc = span_green("I feel a soothing.")
+	desc = span_green("I feel soothed.")
 
 /datum/stressevent/triumph
 	timer = 60 MINUTES
@@ -99,13 +99,13 @@
 	desc = span_green("Down with the tyranny!")
 
 /datum/stressevent/clean
-	timer = 15 MINUTES
+	timer = 20 MINUTES
 	stressadd = -1
 	desc = span_green("I cleaned myself recently.")
 
 /datum/stressevent/clean_plus
-	timer = 20 MINUTES
-	stressadd = -2
+	timer = 30 MINUTES
+	stressadd = -1
 	desc = span_green("That was an amazing bath.")
 
 /datum/stressevent/music

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -165,7 +165,7 @@
 		reagents.add_reagent(/datum/reagent/soap, amt2Add)
 		reagents.trans_to(O, reagents.total_volume, transfered_by = user, method = TOUCH)
 		to_chat(user, span_info("I dissolve some of \the [name] in the water."))
-		decreaseUses(1)//meant to consume less uses than it does on on_clean_success
+		decreaseUses(5)//meant to consume less uses than it does on on_clean_success
 
 /obj/item/soap/proc/scrub_scrub(mob/living/carbon/human/target, mob/living/carbon/user)
 	target.wash(clean_strength)

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -165,7 +165,7 @@
 		reagents.add_reagent(/datum/reagent/soap, amt2Add)
 		reagents.trans_to(O, reagents.total_volume, transfered_by = user, method = TOUCH)
 		to_chat(user, span_info("I dissolve some of \the [name] in the water."))
-		decreaseUses(5)//meant to consume less uses than it does on on_clean_success
+		decreaseUses(5)
 
 /obj/item/soap/proc/scrub_scrub(mob/living/carbon/human/target, mob/living/carbon/user)
 	target.wash(clean_strength)

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -165,11 +165,13 @@
 		reagents.add_reagent(/datum/reagent/soap, amt2Add)
 		reagents.trans_to(O, reagents.total_volume, transfered_by = user, method = TOUCH)
 		to_chat(user, span_info("I dissolve some of \the [name] in the water."))
+		decreaseUses(1)//meant to consume less uses than it does on on_clean_success
 
 /obj/item/soap/proc/scrub_scrub(mob/living/carbon/human/target, mob/living/carbon/user)
 	target.wash(clean_strength)
 	user.visible_message(span_info("[user] scrubs [target] with [src]."), span_info("I scrub [target] with [src]."))
 	decreaseUses(5)
+	target.add_stress(/datum/stressevent/clean)
 
 /obj/item/soap/bath
 	name = "herbal soap"
@@ -182,6 +184,8 @@
 	. = ..()
 	to_chat(target, span_green("I feel so relaxed and clean!"))
 	if(user != target)
+		//Someone else washing you applies the buff, otherwise just the stress event
+		//btw, the buff applies the clean_plus stressevent, keep that in mind
 		target.apply_status_effect(/datum/status_effect/buff/clean_plus)
 	else
-		user.add_stress(/datum/stressevent/clean)
+		user.add_stress(/datum/stressevent/clean_plus)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

There's a minor change to the description of the blessed mood, but that's unrelated. "I feel a soothing." doesn't make sense in english I think.
The clean and clean plus mood effects were increased to 20 and 30 minutes respectively
Their stress reduction however is both at -1, this is because clean and clean_plus are both applied in the case of using the herbal soap, for a total of -2 stress reduction.
Cleaning yourself in normal soap will give you the normal clean mood effect.
Made it so soap is consumed when dilluted in a bucket of water.

## Why It's Good For The Game

Firstly, the mood length was buffed to encourage people to clean themselves
The normal soap was also made to give out the clean effect as to, again encourage people to clean themselves, but also to allow horcs to clean themselves, which is what prevents their stink to radiate out of them.
I found it a bit silly that soap wasn't consumed at all when dilluted in a bucket of water

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cleaning people with normal soap applies the clean mood effect, which will remove the stink of horcs. Cleaning yourself with herbal soap applies a greater effect, and being cleaned by someone with herbal soap will apply the clean buff
balance: Soaps now lose a bit of use when dilluted in a bucket of water, it is still way better than using it to clean floors directly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
