### PR TITLE
Lock unlock animations

### DIFF
--- a/_maps/map_files/debug/roguetest.dmm
+++ b/_maps/map_files/debug/roguetest.dmm
@@ -1258,6 +1258,14 @@
 /obj/structure/hotspring/border/five,
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/mountains/decap)
+"hh" = (
+/obj/effect/landmark/start/adventurerlate,
+/obj/effect/landmark/latejoin,
+/obj/effect/landmark/start/lord{
+	dir = 8
+	},
+/turf/open/floor/grass/yel,
+/area/rogue/outdoors)
 "hi" = (
 /obj/structure/table/wood/treestump/shroomstump,
 /turf/open/floor/dirt,
@@ -2297,6 +2305,7 @@
 /area/rogue/indoors/town/manor)
 "zZ" = (
 /obj/structure/throne,
+/obj/structure/fake_machine/titan,
 /turf/open/floor/cobble,
 /area/rogue/indoors)
 "Ab" = (
@@ -2705,9 +2714,7 @@
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "GO" = (
-/obj/effect/landmark/start/adventurerlate,
 /obj/machinery/light/fueled/wallfire/candle,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/ruinedwood,
 /area/rogue/outdoors)
 "GU" = (
@@ -2773,9 +2780,6 @@
 /obj/effect/decal/carpet/square{
 	pixel_y = -17;
 	pixel_x = -16
-	},
-/obj/effect/landmark/start/lord{
-	dir = 8
 	},
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -15455,7 +15459,7 @@ QN
 QN
 qc
 QN
-QN
+hh
 QN
 al
 al

--- a/_maps/map_files/debug/roguetest.dmm
+++ b/_maps/map_files/debug/roguetest.dmm
@@ -1509,14 +1509,6 @@
 	},
 /turf/open/floor/dirt,
 /area/rogue/outdoors/mountains/decap)
-"mz" = (
-/obj/structure/door/fancy{
-	name = "Lord's Apartment"
-	},
-/obj/effect/mapping_helpers/access/keyset/manor/lord,
-/obj/effect/mapping_helpers/access/locker,
-/turf/open/floor/hexstone,
-/area/rogue/outdoors)
 "mE" = (
 /obj/machinery/light/fueled/torchholder/r,
 /turf/open/floor/churchbrick,
@@ -2591,10 +2583,6 @@
 	},
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
-"Eq" = (
-/obj/item/key/lord,
-/turf/open/floor/grass/yel,
-/area/rogue/outdoors)
 "Ev" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -14957,7 +14945,7 @@ ji
 VG
 jC
 VG
-mz
+QN
 LA
 QN
 jC
@@ -15214,7 +15202,7 @@ ky
 QN
 ae
 QN
-Eq
+QN
 QN
 QN
 Wr

--- a/_maps/map_files/debug/roguetest.dmm
+++ b/_maps/map_files/debug/roguetest.dmm
@@ -1258,14 +1258,6 @@
 /obj/structure/hotspring/border/five,
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"hh" = (
-/obj/effect/landmark/start/adventurerlate,
-/obj/effect/landmark/latejoin,
-/obj/effect/landmark/start/lord{
-	dir = 8
-	},
-/turf/open/floor/grass/yel,
-/area/rogue/outdoors)
 "hi" = (
 /obj/structure/table/wood/treestump/shroomstump,
 /turf/open/floor/dirt,
@@ -2132,16 +2124,6 @@
 /obj/structure/hotspring/border/nine,
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/mountains/decap)
-"wx" = (
-/obj/effect/landmark/house_spot{
-	template_z = 2;
-	template_x = 6;
-	template_y = 6;
-	link_id = "test";
-	house_id = "test"
-	},
-/turf/open/floor/grass/yel,
-/area/rogue/outdoors)
 "wD" = (
 /obj/structure/bridge_stakes{
 	dir = 8
@@ -2305,7 +2287,6 @@
 /area/rogue/indoors/town/manor)
 "zZ" = (
 /obj/structure/throne,
-/obj/structure/fake_machine/titan,
 /turf/open/floor/cobble,
 /area/rogue/indoors)
 "Ab" = (
@@ -2714,7 +2695,9 @@
 /turf/open/floor/wood,
 /area/rogue/indoors/town/manor)
 "GO" = (
+/obj/effect/landmark/start/adventurerlate,
 /obj/machinery/light/fueled/wallfire/candle,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/ruinedwood,
 /area/rogue/outdoors)
 "GU" = (
@@ -2780,6 +2763,9 @@
 /obj/effect/decal/carpet/square{
 	pixel_y = -17;
 	pixel_x = -16
+	},
+/obj/effect/landmark/start/lord{
+	dir = 8
 	},
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
@@ -3116,12 +3102,6 @@
 	},
 /turf/open/floor/dirt/road,
 /area/rogue/outdoors)
-"SN" = (
-/obj/structure/sign/property_claim{
-	link_id = "test"
-	},
-/turf/closed/wall/mineral/stone,
-/area/rogue/indoors/town/manor)
 "SS" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -15459,7 +15439,7 @@ QN
 QN
 qc
 QN
-hh
+QN
 QN
 al
 al
@@ -16736,7 +16716,7 @@ jN
 jN
 hA
 jN
-wx
+QN
 aF
 pD
 zF
@@ -16993,7 +16973,7 @@ iC
 sE
 jq
 ZT
-SN
+jN
 ai
 Wr
 pD

--- a/_maps/map_files/debug/roguetest.dmm
+++ b/_maps/map_files/debug/roguetest.dmm
@@ -1509,6 +1509,14 @@
 	},
 /turf/open/floor/dirt,
 /area/rogue/outdoors/mountains/decap)
+"mz" = (
+/obj/structure/door/fancy{
+	name = "Lord's Apartment"
+	},
+/obj/effect/mapping_helpers/access/keyset/manor/lord,
+/obj/effect/mapping_helpers/access/locker,
+/turf/open/floor/hexstone,
+/area/rogue/outdoors)
 "mE" = (
 /obj/machinery/light/fueled/torchholder/r,
 /turf/open/floor/churchbrick,
@@ -2583,6 +2591,10 @@
 	},
 /turf/open/floor/churchbrick,
 /area/rogue/indoors/town/manor)
+"Eq" = (
+/obj/item/key/lord,
+/turf/open/floor/grass/yel,
+/area/rogue/outdoors)
 "Ev" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -14945,7 +14957,7 @@ ji
 VG
 jC
 VG
-QN
+mz
 LA
 QN
 jC
@@ -15202,7 +15214,7 @@ ky
 QN
 ae
 QN
-QN
+Eq
 QN
 QN
 Wr

--- a/code/datums/locks/_lock.dm
+++ b/code/datums/locks/_lock.dm
@@ -21,25 +21,25 @@
 	src.holder = null
 	return ..()
 
-/datum/lock/proc/toggle(mob/user, silent = FALSE)
+/datum/lock/proc/toggle(mob/user, obj/item, silent = FALSE)
 	if(!silent && user)
 		silent = user?.m_intent == MOVE_INTENT_SNEAK
 	if(locked)
-		unlock(user, silent)
+		unlock(user, item, silent)
 	else
-		lock(user, silent)
+		lock(user, item, silent)
 
-/datum/lock/proc/lock(user, silent = FALSE)
+/datum/lock/proc/lock(user, obj/item, silent = FALSE)
 	tampered = FALSE
 	locked = TRUE
 	if(user)
-		holder?.on_lock(user, silent)
+		holder?.on_lock(user, item, silent)
 
-/datum/lock/proc/unlock(user, silent = FALSE)
+/datum/lock/proc/unlock(user, obj/item, silent = FALSE)
 	tampered = FALSE
 	locked = FALSE
 	if(user)
-		holder?.on_unlock(user, silent)
+		holder?.on_unlock(user, item, silent)
 
 /// A keylock
 /datum/lock/key
@@ -117,7 +117,7 @@
 		if(!locked && !is_right)
 			holder?.lock_failed(user, silent, "It won't turn this way, try turning it to the right.")
 			return
-	toggle(user, silent)
+	toggle(user, I, silent)
 
 /datum/lock/key/proc/set_pick_difficulty(difficulty)
 	src.difficulty = CLAMP(difficulty, 1, 6)

--- a/code/datums/locks/_lock.dm
+++ b/code/datums/locks/_lock.dm
@@ -21,25 +21,25 @@
 	src.holder = null
 	return ..()
 
-/datum/lock/proc/toggle(mob/user, obj/item, silent = FALSE)
+/datum/lock/proc/toggle(mob/user, silent = FALSE)
 	if(!silent && user)
 		silent = user?.m_intent == MOVE_INTENT_SNEAK
 	if(locked)
-		unlock(user, item, silent)
+		unlock(user, silent)
 	else
-		lock(user, item, silent)
+		lock(user, silent)
 
-/datum/lock/proc/lock(user, obj/item, silent = FALSE)
+/datum/lock/proc/lock(user, silent = FALSE)
 	tampered = FALSE
 	locked = TRUE
 	if(user)
-		holder?.on_lock(user, item, silent)
+		holder?.on_lock(user, silent)
 
-/datum/lock/proc/unlock(user, obj/item, silent = FALSE)
+/datum/lock/proc/unlock(user, silent = FALSE)
 	tampered = FALSE
 	locked = FALSE
 	if(user)
-		holder?.on_unlock(user, item, silent)
+		holder?.on_unlock(user, silent)
 
 /// A keylock
 /datum/lock/key
@@ -117,7 +117,7 @@
 		if(!locked && !is_right)
 			holder?.lock_failed(user, silent, "It won't turn this way, try turning it to the right.")
 			return
-	toggle(user, I, silent)
+	toggle(user, silent)
 
 /datum/lock/key/proc/set_pick_difficulty(difficulty)
 	src.difficulty = CLAMP(difficulty, 1, 6)

--- a/code/datums/locks/lock_access.dm
+++ b/code/datums/locks/lock_access.dm
@@ -57,22 +57,26 @@
 		return
 	to_chat(user, span_notice("I lock \the [src]."))
 
+/mob
+	var/angleee = 180
+
 /mob/proc/lock_unlock_animation(obj/door, obj/item)
 	animate(src, time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * 5), pixel_z = ((door.y - src.y) * 5), easing = SINE_EASING, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 	animate(time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * -5), pixel_z = ((door.y - src.y) * -5), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-	var/mutable_appearance/key = mutable_appearance(item.icon, item.icon_state, src.layer, src.plane, alpha = 0)
-	key.appearance = item.appearance // yeah.
+	var/obj/effect/key = new(get_turf(src))
+	key.appearance = item.appearance
 
-	key.loc = door
+	var/direction = get_dir(src, door)
 
-	key.pixel_w = (door.x - src.x) * -16
-	key.pixel_z = (door.y - src.y) * -16
+	var/angle = dir2angle(direction)
 
-	key.transform.Turn(dir2angle(get_dir(src, door)))
+	var/new_transform = key.transform.Turn(angleee + angle)
+	new_transform = matrix(new_transform) * 0.6
+	key.transform = new_transform
+	key.alpha = 0
 
-	animate(key, time = 0.5 SECONDS, alpha = 255, easing = SINE_EASING)
-	animate(time = 1 SECONDS, pixel_w = ((door.x - src.x) * 10), pixel_z = ((door.y - src.y) * 10), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-	animate(time = 0.5 SECONDS, alpha = 0, easing = SINE_EASING)
+	animate(key, time = 0.5 SECONDS, alpha = 170, pixel_w = ((door.x - src.x) * 14), pixel_z = ((door.y - src.y) * 14), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+	animate(time = 0.4 SECONDS, alpha = 0, easing = SINE_EASING)
 
 /// Called when unlocked
 /obj/proc/on_unlock(mob/user, obj/item, silent = FALSE)

--- a/code/datums/locks/lock_access.dm
+++ b/code/datums/locks/lock_access.dm
@@ -49,34 +49,21 @@
 	animate(pixel_x = oldx, time = 0.5)
 
 /// Called when locked
-/obj/proc/on_lock(mob/user, obj/item, silent = FALSE)
-	user.lock_unlock_animation(src, item)
+/obj/proc/on_lock(mob/user, silent = FALSE)
+	user.lock_unlock_animation(src)
 	if(!silent && lock_sound)
 		playsound(get_turf(src), lock_sound, 50)
 		user.visible_message(span_notice("[user] locks \the [src]."), span_notice("I lock \the [src]."), span_notice("I hear a click."))
 		return
 	to_chat(user, span_notice("I lock \the [src]."))
 
-/mob/proc/lock_unlock_animation(obj/door, obj/item)
+/mob/proc/lock_unlock_animation(obj/door)
 	animate(src, time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * 5), pixel_z = ((door.y - src.y) * 5), easing = SINE_EASING, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 	animate(time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * -5), pixel_z = ((door.y - src.y) * -5), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-	var/mutable_appearance/key = mutable_appearance(item.icon, item.icon_state, src.layer, src.plane, alpha = 0)
-	key.appearance = item.appearance // yeah.
-
-	key.loc = door
-
-	key.pixel_w = (door.x - src.x) * -16
-	key.pixel_z = (door.y - src.y) * -16
-
-	key.transform.Turn(dir2angle(get_dir(src, door)))
-
-	animate(key, time = 0.5 SECONDS, alpha = 255, easing = SINE_EASING)
-	animate(time = 1 SECONDS, pixel_w = ((door.x - src.x) * 10), pixel_z = ((door.y - src.y) * 10), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
-	animate(time = 0.5 SECONDS, alpha = 0, easing = SINE_EASING)
 
 /// Called when unlocked
-/obj/proc/on_unlock(mob/user, obj/item, silent = FALSE)
-	user.lock_unlock_animation(src, item)
+/obj/proc/on_unlock(mob/user, silent = FALSE)
+	user.lock_unlock_animation(src)
 	if(!silent && unlock_sound)
 		playsound(get_turf(src), unlock_sound, 50)
 		user.visible_message(span_notice("[user] unlocks \the [src]."), span_notice("I unlock \the [src]."), span_notice("I hear a click."))

--- a/code/datums/locks/lock_access.dm
+++ b/code/datums/locks/lock_access.dm
@@ -50,14 +50,20 @@
 
 /// Called when locked
 /obj/proc/on_lock(mob/user, silent = FALSE)
+	user.lock_unlock_animation(src)
 	if(!silent && lock_sound)
 		playsound(get_turf(src), lock_sound, 50)
 		user.visible_message(span_notice("[user] locks \the [src]."), span_notice("I lock \the [src]."), span_notice("I hear a click."))
 		return
 	to_chat(user, span_notice("I lock \the [src]."))
 
+/mob/proc/lock_unlock_animation(obj/door)
+	animate(src, time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * 5), pixel_z = ((door.y - src.y) * 5), easing = SINE_EASING, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
+	animate(time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * -5), pixel_z = ((door.y - src.y) * -5), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+
 /// Called when unlocked
 /obj/proc/on_unlock(mob/user, silent = FALSE)
+	user.lock_unlock_animation(src)
 	if(!silent && unlock_sound)
 		playsound(get_turf(src), unlock_sound, 50)
 		user.visible_message(span_notice("[user] unlocks \the [src]."), span_notice("I unlock \the [src]."), span_notice("I hear a click."))

--- a/code/datums/locks/lock_access.dm
+++ b/code/datums/locks/lock_access.dm
@@ -57,9 +57,6 @@
 		return
 	to_chat(user, span_notice("I lock \the [src]."))
 
-/mob
-	var/angleee = 180
-
 /mob/proc/lock_unlock_animation(obj/door, obj/item)
 	animate(src, time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * 5), pixel_z = ((door.y - src.y) * 5), easing = SINE_EASING, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 	animate(time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * -5), pixel_z = ((door.y - src.y) * -5), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
@@ -70,13 +67,15 @@
 
 	var/angle = dir2angle(direction)
 
-	var/new_transform = key.transform.Turn(angleee + angle)
+	var/new_transform = key.transform.Turn(180 + angle)
 	new_transform = matrix(new_transform) * 0.6
 	key.transform = new_transform
 	key.alpha = 0
 
 	animate(key, time = 0.5 SECONDS, alpha = 170, pixel_w = ((door.x - src.x) * 14), pixel_z = ((door.y - src.y) * 14), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
 	animate(time = 0.4 SECONDS, alpha = 0, easing = SINE_EASING)
+
+	qdel(key)
 
 /// Called when unlocked
 /obj/proc/on_unlock(mob/user, obj/item, silent = FALSE)

--- a/code/datums/locks/lock_access.dm
+++ b/code/datums/locks/lock_access.dm
@@ -49,21 +49,34 @@
 	animate(pixel_x = oldx, time = 0.5)
 
 /// Called when locked
-/obj/proc/on_lock(mob/user, silent = FALSE)
-	user.lock_unlock_animation(src)
+/obj/proc/on_lock(mob/user, obj/item, silent = FALSE)
+	user.lock_unlock_animation(src, item)
 	if(!silent && lock_sound)
 		playsound(get_turf(src), lock_sound, 50)
 		user.visible_message(span_notice("[user] locks \the [src]."), span_notice("I lock \the [src]."), span_notice("I hear a click."))
 		return
 	to_chat(user, span_notice("I lock \the [src]."))
 
-/mob/proc/lock_unlock_animation(obj/door)
+/mob/proc/lock_unlock_animation(obj/door, obj/item)
 	animate(src, time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * 5), pixel_z = ((door.y - src.y) * 5), easing = SINE_EASING, flags = ANIMATION_RELATIVE|ANIMATION_PARALLEL)
 	animate(time = 0.3 SECONDS, pixel_w = ((door.x - src.x) * -5), pixel_z = ((door.y - src.y) * -5), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+	var/mutable_appearance/key = mutable_appearance(item.icon, item.icon_state, src.layer, src.plane, alpha = 0)
+	key.appearance = item.appearance // yeah.
+
+	key.loc = door
+
+	key.pixel_w = (door.x - src.x) * -16
+	key.pixel_z = (door.y - src.y) * -16
+
+	key.transform.Turn(dir2angle(get_dir(src, door)))
+
+	animate(key, time = 0.5 SECONDS, alpha = 255, easing = SINE_EASING)
+	animate(time = 1 SECONDS, pixel_w = ((door.x - src.x) * 10), pixel_z = ((door.y - src.y) * 10), easing = SINE_EASING, flags = ANIMATION_RELATIVE)
+	animate(time = 0.5 SECONDS, alpha = 0, easing = SINE_EASING)
 
 /// Called when unlocked
-/obj/proc/on_unlock(mob/user, silent = FALSE)
-	user.lock_unlock_animation(src)
+/obj/proc/on_unlock(mob/user, obj/item, silent = FALSE)
+	user.lock_unlock_animation(src, item)
 	if(!silent && unlock_sound)
 		playsound(get_turf(src), unlock_sound, 50)
 		user.visible_message(span_notice("[user] unlocks \the [src]."), span_notice("I unlock \the [src]."), span_notice("I hear a click."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

https://github.com/user-attachments/assets/2ad6c7ab-367b-4ef9-88c5-71d944308954


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
looks nice
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: lock unlock now has a nice animation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
