### PR TITLE
Noble Boot types storing

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -60,6 +60,7 @@
 	var/screen_start_y = 2
 	//End
 
+	/// prevents storage interactions while it is equipped. Think backpacks.
 	var/not_while_equipped = FALSE
 
 /datum/component/storage/Initialize(datum/component/storage/concrete/master)

--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -33,7 +33,7 @@
 		var/atom/boots = parent
 		if(istype(attacking_item, /obj/item/weapon/knife) && istype(boots?.loc, /mob/living/carbon/human))
 			var/mob/living/carbon/human/unlucky = boots.loc
-			if(unlucky.shoes == parent && prob(40 - (unlucky.STALUC * 4)))
+			if(unlucky.shoes == parent && prob(40 - max((unlucky.STALUC * 4), 0)))
 				var/cached_aim = user.zone_selected
 				user.zone_selected = pick(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
 				unlucky.attackby(attacking_item, user, params)

--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -14,3 +14,36 @@
 /datum/component/storage/concrete/scabbard/sword/New(list/raw_args)
 	. = ..()
 	set_holdable(list(/obj/item/weapon/sword), list(/obj/item/weapon/sword/long/exe, /obj/item/weapon/sword/long/greatsword))
+
+/datum/component/storage/concrete/boots
+	max_items = 1
+	rustle_sound = 'sound/foley/equip/scabbard_holster.ogg'
+	max_w_class = WEIGHT_CLASS_SMALL
+	quickdraw = TRUE
+	allow_look_inside = FALSE
+	insert_verb = "slide"
+	insert_preposition = "in"
+
+/datum/component/storage/concrete/boots/New(list/raw_args)
+	. = ..()
+	set_holdable(list(/obj/item/weapon/knife, /obj/item/coin, /obj/item/key))
+
+/datum/component/storage/concrete/boots/attackby(datum/source, obj/item/attacking_item, mob/user, params, storage_click)
+	if(isatom(parent) && can_be_inserted(obj/item/attacking_item, stop_messages = TRUE, mob/user))
+		var/atom/boots = parent
+		if(istype(attacking_item, /obj/item/weapon/knife) && istype(boots?.loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/unlucky = boots.loc
+			if(unlucky.shoes == parent && prob(40 - (unlucky.STALUC * 4)))
+				var/cached_aim = user.zone_selected
+				user.zone_selected = pick(BODY_ZONE_PRECISE_R_FOOT, BODY_ZONE_PRECISE_L_FOOT)
+				unlucky.attackby(attacking_item, user, params)
+				unlucky.to_chat("<span class='danger'>UNLUCKY! I've stabbed myself with the [attacking_item]!</span>")
+				user.zone_selected = cached_aim
+
+	return ..()
+
+/datum/component/storage/concrete/boots/handle_item_insertion(obj/item/I, prevent_warning, mob/M, datum/component/storage/remote, params, storage_click)
+	. = ..()
+
+	if(!.)
+		return

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -121,6 +121,10 @@
 	stressadd = 1
 //	desc = "<span class='red'>I fell. I'm a fool.</span>"
 
+/datum/stressevent/fullshoe
+	stressadd = 1
+	desc = "<span class='red'>There is something in my shoe.</span>"
+
 /datum/stressevent/uncookedfood
 	timer = 2 MINUTES
 	stressadd = 2

--- a/code/modules/clothing/shoes/misc.dm
+++ b/code/modules/clothing/shoes/misc.dm
@@ -11,6 +11,10 @@
 	salvage_result = /obj/item/natural/hide/cured
 	salvage_amount = 1
 
+/obj/item/clothing/shoes/nobleboot/apply_components()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/boots)
+
 /obj/item/clothing/shoes/nobleboot/thighboots
 	name = "thigh boots"
 	icon_state = "thighboot"

--- a/code/modules/clothing/shoes/misc.dm
+++ b/code/modules/clothing/shoes/misc.dm
@@ -15,6 +15,35 @@
 	. = ..()
 	AddComponent(/datum/component/storage/concrete/boots)
 
+/obj/item/clothing/shoes/nobleboot/Destroy()
+	if(istype(src.loc, /mob/living/carbon))
+		var/mob/living/carbon/wearer = src.loc
+		wearer.remove_stress(/datum/stressevent/fullshoe)
+	return ..()
+
+/obj/item/clothing/shoes/nobleboot/equipped(mob/user, slot)
+	. = ..()
+
+	if(slot != ITEM_SLOT_SHOES)
+		return
+
+	var/datum/component/storage/concrete/boots/myboots = src.GetComponent(/datum/component/storage/concrete/boots)
+	var/atom/real_location = myboots.real_location()
+	if(length(real_location.contents))
+		var/list/irritants = list()
+		for(var/obj/item/I in real_location.contents)
+			if(!istype(I, /obj/item/weapon/knife))
+				irritants |= I
+		if(length(irritants) && istype(src.loc, /mob/living/carbon))
+			var/mob/living/carbon/wearer = user
+			wearer.add_stress(/datum/stressevent/fullshoe)
+
+/obj/item/clothing/shoes/nobleboot/dropped(mob/user)
+	if(istype(user, /mob/living/carbon))
+		var/mob/living/carbon/wearer = user
+		wearer.remove_stress(/datum/stressevent/fullshoe)
+	return ..()
+
 /obj/item/clothing/shoes/nobleboot/thighboots
 	name = "thigh boots"
 	icon_state = "thighboot"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

https://github.com/user-attachments/assets/14a7cc78-cb9a-42a1-901b-2e005f673466


This adds the ability for noble boots and its subtypes to store single keys, coins, or small knives. It has only a single slot and anything but the knife will give you a stress debuff if you are wearing your shoes with an item stored in them.

For those that find themselves unlucky they will randomly cut themselves in the foot when storing a knife into their boots starting at less than 10 luck. A potential maximum of 40% chance to cut yourself if you have 0 luck. Should also apply any potential poisons if the blade was coated with one.

## Why It's Good For The Game

Just another minor storage place for small very limited items. I honestly would think assassins would store a blade in their boots as a hold out item to sneak in with. But these boots are visually tall and I think adds to the feel of the game. Small blade a few mammons or a key honestly think would be things you would find in some soilsons shoe. If they could have these boots that is.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:Siro
add: Noble boot variants can store small knives, coins, or key. Only one storage space. 
add: Storing anything but a knife in your boots will add a stress.
add: Maximum 40% chance to cut yourself storing a knife in your boots at less than 10 luck.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
