### PR TITLE
Door changes

### DIFF
--- a/code/__DEFINES/dcs/signals_atoms/signals_obj.dm
+++ b/code/__DEFINES/dcs/signals_atoms/signals_obj.dm
@@ -17,7 +17,6 @@
 #define COMSIG_ITEM_ATTACK_SECONDARY "item_attack_secondary"
 /// From base of obj/item/attack_obj(): (/obj, /mob)
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
-	#define COMPONENT_NO_ATTACK_OBJ 1
 
 /// From base of [obj/item/afterattack()]: (atom/target, mob/user, params)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -386,7 +386,7 @@
 
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for non-mob targets. Return TRUE to end the attack chain.
 /obj/item/proc/attack_atom(atom/attacked_atom, mob/living/user)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_OBJ, attacked_atom, user) & COMPONENT_NO_ATTACK_OBJ)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_OBJ, attacked_atom, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	if(item_flags & NOBLUDGEON)
 		return TRUE

--- a/code/datums/elements/bed_tuckable.dm
+++ b/code/datums/elements/bed_tuckable.dm
@@ -50,7 +50,7 @@
 		tucked.transform = turn(tucked.transform, rotation_degree)
 		RegisterSignal(tucked, COMSIG_ITEM_PICKUP, PROC_REF(untuck))
 
-	return COMPONENT_NO_AFTERATTACK
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /**
  * If we rotate our object, then we need to un-rotate it when it's picked up

--- a/code/datums/elements/tipped_item.dm
+++ b/code/datums/elements/tipped_item.dm
@@ -43,7 +43,7 @@
 		return
 
 	INVOKE_ASYNC(src, PROC_REF(start_dipping), dipper, attacked_container, attacker)
-	return COMPONENT_NO_ATTACK | COMPONENT_NO_ATTACK_OBJ
+	return COMPONENT_NO_ATTACK | COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/element/tipped_item/proc/start_dipping(obj/item/dipper, obj/item/reagent_containers/attacked_container, mob/living/attacker, params)
 	if(!do_after(attacker, 2 SECONDS, attacked_container))

--- a/code/game/objects/structures/doors.dm
+++ b/code/game/objects/structures/doors.dm
@@ -183,10 +183,10 @@
 	return ..()
 
 /obj/structure/door/attackby(obj/item/I, mob/user)
-	if(I.has_access())
-		return (..() || attack_hand(user))
 	if(switching_states)
 		return
+	if(I.has_access())
+		return (..() || attack_hand(user))
 	return ..()
 
 /obj/structure/door/attack_hand_secondary(mob/user, params)

--- a/code/game/objects/structures/doors.dm
+++ b/code/game/objects/structures/doors.dm
@@ -159,7 +159,7 @@
 		to_chat(user, span_warning("I claw at [src]"))
 		take_damage(40, BRUTE, BCLASS_CUT, TRUE)
 		return
-	if(isliving(user) && world.time > last_bump + 20)
+	if(isliving(user) && world.time > last_bump + 1 SECONDS)
 		last_bump = world.time
 		var/mob/living/L = user
 		if(L.m_intent == MOVE_INTENT_SNEAK)
@@ -179,11 +179,12 @@
 	if(switching_states)
 		return FALSE
 	if(door_opened)
-		to_chat(user, span_notice("I cannot lock \the [src] while it is open."))
 		return FALSE
 	return ..()
 
 /obj/structure/door/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/key) || istype(I, /obj/item/storage/keyring))
+		return (..() || attack_hand(user))
 	if(switching_states)
 		return
 	return ..()
@@ -224,7 +225,7 @@
 	. = ..()
 	if(obj_broken || switching_states)
 		return
-	if(world.time < last_bump + 20)
+	if(world.time < last_bump + 1 SECONDS)
 		return
 	last_bump = world.time
 	if(ismob(AM))

--- a/code/game/objects/structures/doors.dm
+++ b/code/game/objects/structures/doors.dm
@@ -183,7 +183,7 @@
 	return ..()
 
 /obj/structure/door/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/key) || istype(I, /obj/item/storage/keyring))
+	if(I.has_access())
 		return (..() || attack_hand(user))
 	if(switching_states)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Halves door bump cooldown
- You can close doors by attacking it with a key or a keyring

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let's you easily pass through doors with one hand.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
