### PR TITLE
A follow up PR to #3060

### DIFF
--- a/code/datums/components/container_craft/recipes/cooking_pot/_cooking_pot.dm
+++ b/code/datums/components/container_craft/recipes/cooking_pot/_cooking_pot.dm
@@ -3,7 +3,7 @@
 	category = "Soups"
 	crafting_time = 5 SECONDS
 	reagent_requirements = list(
-		/datum/reagent/water = 33
+		/datum/reagent/water = 25
 	)
 	craft_verb = "cooking for "
 	required_container = /obj/item/reagent_containers/glass/bucket/pot

--- a/code/datums/components/container_craft/recipes/cooking_pot/herbal.dm
+++ b/code/datums/components/container_craft/recipes/cooking_pot/herbal.dm
@@ -4,7 +4,7 @@
 	crafting_time = 8 SECONDS
 	water_conversion = 1
 	reagent_requirements = list(
-		/datum/reagent/water = 27
+		/datum/reagent/water = 20
 	)
 	craft_verb = "brewing "
 	required_chem_temp = 350 // Lower temp for gentle herbal brewing
@@ -54,7 +54,7 @@
 	crafting_time = 15 SECONDS
 	water_conversion = 1
 	reagent_requirements = list(
-		/datum/reagent/consumable/ethanol = 21
+		/datum/reagent/consumable/ethanol = 20
 	)
 	subtype_reagents_allowed = TRUE
 	craft_verb = "preparing "

--- a/code/datums/components/container_craft/recipes/cooking_pot/stews.dm
+++ b/code/datums/components/container_craft/recipes/cooking_pot/stews.dm
@@ -2,9 +2,9 @@
 	name = "Potato Stew"
 	created_reagent = /datum/reagent/consumable/soup/veggie/potato
 	requirements = list(/obj/item/reagent_containers/food/snacks/veg/potato_sliced = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/potato_stew
 	crafting_time = 40 SECONDS
@@ -13,9 +13,9 @@
 	name = "Onion Stew"
 	created_reagent = /datum/reagent/consumable/soup/veggie/onion
 	requirements = list(/obj/item/reagent_containers/food/snacks/veg/onion_sliced = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/onion_stew
 	crafting_time = 30 SECONDS
@@ -24,9 +24,9 @@
 	name = "Cabbage Stew"
 	created_reagent = /datum/reagent/consumable/soup/veggie/cabbage
 	requirements = list(/obj/item/reagent_containers/food/snacks/veg/cabbage_sliced = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/cabbage_stew
 	crafting_time = 35 SECONDS
@@ -35,9 +35,9 @@
 	name = "Turnip Stew"
 	created_reagent = /datum/reagent/consumable/soup/veggie/turnip
 	requirements = list(/obj/item/reagent_containers/food/snacks/veg/turnip_sliced = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/turnip_stew
 	crafting_time = 35 SECONDS
@@ -46,9 +46,9 @@
 	name = "Fish Stew"
 	created_reagent = /datum/reagent/consumable/soup/stew/fish
 	requirements = list(/obj/item/reagent_containers/food/snacks/meat/mince/fish = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/fish_stew
 	crafting_time = 40 SECONDS
@@ -57,9 +57,9 @@
 	name = "Chicken Stew"
 	created_reagent = /datum/reagent/consumable/soup/stew/chicken
 	requirements = list(/obj/item/reagent_containers/food/snacks/meat/mince/poultry = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/chicken_stew
 	crafting_time = 45 SECONDS
@@ -71,9 +71,9 @@
 	name = "Questionable Stew"
 	created_reagent = /datum/reagent/consumable/soup/stew/gross
 	requirements = list(/obj/item/reagent_containers/food/snacks/meat/strange = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/potato_stew
 	crafting_time = 45 SECONDS
@@ -82,9 +82,9 @@
 	name = "Meat Stew"
 	created_reagent = /datum/reagent/consumable/soup/stew/meat
 	wildcard_requirements = list(/obj/item/reagent_containers/food/snacks/meat = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/meat_stew
 	crafting_time = 45 SECONDS
@@ -93,9 +93,9 @@
 	name = "Truffle Stew"
 	created_reagent = /datum/reagent/consumable/soup/stew/truffle
 	requirements = list(/obj/item/reagent_containers/food/snacks/truffles = 1)
-	max_optionals = 2
+	max_optionals = 3
 	optional_wildcard_requirements = list(
-		/obj/item/reagent_containers/food/snacks/produce/vegetable = 2
+		/obj/item/reagent_containers/food/snacks/produce/vegetable = 3
 	)
 	finished_smell = /datum/pollutant/food/truffle_stew
 	crafting_time = 40 SECONDS

--- a/code/game/objects/items/cup.dm
+++ b/code/game/objects/items/cup.dm
@@ -14,7 +14,7 @@
 	possible_transfer_amounts = list(6)
 	dropshrink = 0.75
 	w_class = WEIGHT_CLASS_NORMAL
-	volume = 24
+	volume = 25
 	obj_flags = CAN_BE_HIT
 	sellprice = 1
 	drinksounds = list('sound/items/drink_cup (1).ogg','sound/items/drink_cup (2).ogg','sound/items/drink_cup (3).ogg','sound/items/drink_cup (4).ogg','sound/items/drink_cup (5).ogg')

--- a/code/game/objects/items/waterskins.dm
+++ b/code/game/objects/items/waterskins.dm
@@ -4,10 +4,10 @@
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "waterskin"
 	fill_icon_state = ""
-	amount_per_transfer_from_this = 6
-	possible_transfer_amounts = list(3,6,9)
+	amount_per_transfer_from_this = 5
+	possible_transfer_amounts = list(5,10)
 	fill_icon_thresholds = null
-	volume = 64
+	volume = 65
 	dropshrink = 0.5
 	sellprice = 50
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK

--- a/code/modules/crafting/alchemy/alch_items.dm
+++ b/code/modules/crafting/alchemy/alch_items.dm
@@ -3,9 +3,9 @@
 	desc = "A cute bottle, conviniently holding 3 swigs of a fluid."
 	icon = 'icons/roguetown/items/glass_reagent_container.dmi'
 	icon_state = "vial_bottle"
-	amount_per_transfer_from_this = 9
-	possible_transfer_amounts = list(9)
-	volume = 27
+	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = list(10)
+	volume = 30
 	fill_icon_thresholds = list(0, 33, 66, 100)
 	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -256,7 +256,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	amount_per_transfer_from_this = 9
 	possible_transfer_amounts = list(9)
-	volume = 99
+	volume = 100
 	flags_inv = HIDEHAIR
 	obj_flags = CAN_BE_HIT
 	resistance_flags = NONE

--- a/code/modules/reagents/reagent_containers/powder.dm
+++ b/code/modules/reagents/reagent_containers/powder.dm
@@ -77,7 +77,6 @@
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "spice"
 	item_state = "spice"
-	volume = 15
 	list_reagents = list(/datum/reagent/druqks = 15)
 	sellprice = 16
 
@@ -138,7 +137,6 @@
 	desc = "A potent drug that causes a state of euphoria, but can also arrest breathing."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "ozium"
-	volume = 15
 	list_reagents = list(/datum/reagent/ozium = 15)
 	sellprice = 8
 
@@ -175,7 +173,6 @@
 	desc = "Derived from the skins of certain pallid goblins. Makes folk quick to act and anger."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "moondust"
-	volume = 15
 	list_reagents = list(/datum/reagent/moondust = 15)
 	sellprice = 16
 
@@ -219,8 +216,7 @@
 	desc = "This moondust glitters even in the dark. It seems to have certain pure properties."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "moondust_purest"
-	volume = 18
-	list_reagents = list(/datum/reagent/moondust_purest = 18)
+	list_reagents = list(/datum/reagent/moondust_purest = 15)
 	sellprice = 20
 
 /datum/reagent/moondust_purest
@@ -266,7 +262,6 @@
 	desc = "Crushed manabloom useful as a combat measure against mages."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "salt"
-	volume = 5
 	list_reagents = list(/datum/reagent/toxin/manabloom_juice = 5)
 	sellprice = 10
 	color = COLOR_CYAN
@@ -289,7 +284,6 @@
 	desc = "Explosive powder known to be produced by the dwarves. It's used in many explosives."
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "blastpowder"
-	volume = 15
 	list_reagents = list(/datum/reagent/blastpowder = 15)
 	sellprice = 15
 	var/primed = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

DO NOT MERGE UNTIL #3060 IS MERGED
The PR changes various numbers to work in tandem with the fact that ounces are gone, making most reagent numbers divisible by 2 and/or 5, for ex. the waterskin has now a volume of 65 units instead of 64
I tried making it so the balance of the game isn't disturbed, but obviously that couldn't be always avoided
The changes are as follows:
Buckets and Pots hold 100 units instead of 99, combined with the fact that;
Soups and stews now require 25 units instead of 33, you can now make 4 different soups/stews at once in a pot
Cups hold 25 units instead of 24
Waterskin holds 65 units, and transfers units in amounts of 5 or 10
alchemical vials hold 30 units and transfer 10 units per swig
pure moondust now holds 15 units of the pure moondust reagent instead of 18
herbal remedies and salves now require 25 and 20 water/ethanol, respectively

## Why It's Good For The Game

the old values were made with ounces in mind, which were basically units divided by 3

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Tweaked the volume of a lot of reagent containers, shouldn't be noticeable changes
add: However, soups and stews now require 25 units of water instead of 33, so you can make 4 "batches" of stew in one full pot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
