### PR TITLE
New vampire clan: Eorabella Family 

### DIFF
--- a/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
+++ b/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
@@ -15,7 +15,7 @@
 
 /datum/clan/eoran
 	name = "Eorabella Family"
-	desc = "Eora, moved by your relentless pursuit of art and beauty, has bestowed her blessing upon your cursed bloodline, captivated by your passion. Yet, in her admiration, she has overlooked the darker facets of your nature: your twisted notion of love and your delusions of grandeur. "
+	desc = "Eora, moved by your relentless pursuit of art and beauty, has bestowed her blessing upon your cursed bloodline. Yet, in her admiration, she has overlooked the darker facets of your nature: your twisted notion of love and your delusions of grandeur. "
 	curse = "Obsession with vanity, need to be loved"
 	blood_preference = BLOOD_PREFERENCE_ALL
 	clane_traits = list(
@@ -40,4 +40,5 @@
 
 /datum/clan/eoran/apply_clan_components(mob/living/carbon/human/H)
 	H.AddComponent(/datum/component/vampire_disguise)
+
 

--- a/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
+++ b/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
@@ -14,9 +14,9 @@
 	lord_title = "Elder"
 
 /datum/clan/eoran
-	name = "House Eoran"
-	desc = "TBA"
-	curse = "Obsession with love"
+	name = "Eorabella Family"
+	desc = "Eora, moved by your relentless pursuit of art and beauty, has bestowed her blessing upon your cursed bloodline, captivated by your passion. Yet, in her admiration, she has overlooked the darker facets of your nature: your twisted notion of love and your delusions of grandeur. "
+	curse = "Obsession with vanity, need to be loved"
 	blood_preference = BLOOD_PREFERENCE_ALL
 	clane_traits = list(
 		TRAIT_BEAUTIFUL,
@@ -40,3 +40,4 @@
 
 /datum/clan/eoran/apply_clan_components(mob/living/carbon/human/H)
 	H.AddComponent(/datum/component/vampire_disguise)
+

--- a/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
+++ b/code/modules/antagonists/villain/neu_vampires/clan/real_clans/eoran.dm
@@ -1,0 +1,42 @@
+
+/datum/clan_leader/eoran
+	lord_spells = list(
+		/datum/action/cooldown/spell/undirected/mansion_portal,
+		/datum/action/cooldown/spell/undirected/shapeshift/frog,
+		/datum/action/cooldown/spell/vampiric_charm,
+		/datum/action/cooldown/spell/undirected/list_target/encode_thoughtsvampire
+	)
+	lord_verbs = list(
+		/mob/living/carbon/human/proc/demand_submission,
+		/mob/living/carbon/human/proc/punish_spawn
+	)
+	lord_traits = list(TRAIT_HEAVYARMOR, TRAIT_NOSTAMINA)
+	lord_title = "Elder"
+
+/datum/clan/eoran
+	name = "House Eoran"
+	desc = "TBA"
+	curse = "Obsession with love"
+	blood_preference = BLOOD_PREFERENCE_ALL
+	clane_traits = list(
+		TRAIT_BEAUTIFUL,
+		TRAIT_EMPATH,
+		TRAIT_EXTEROCEPTION,
+		)
+
+	clane_covens = list(
+		/datum/coven/auspex,
+		/datum/coven/presence,
+		/datum/coven/bloodheal,
+		/datum/coven/eora
+	)
+	leader = /datum/clan_leader/eoran
+
+/datum/clan/thronleer/get_blood_preference_string()
+	return "Regular blood, blood of your loved ones"
+
+/datum/clan/thronleer/get_downside_string()
+	return "You are perfect, you do not have any downsides."
+
+/datum/clan/eoran/apply_clan_components(mob/living/carbon/human/H)
+	H.AddComponent(/datum/component/vampire_disguise)

--- a/code/modules/spells/spell_types/pointed/vampiric_charm.dm
+++ b/code/modules/spells/spell_types/pointed/vampiric_charm.dm
@@ -1,0 +1,34 @@
+/datum/action/cooldown/spell/vampiric_charm
+	name = "Vampiric Charm"
+	desc = "Captivate a target and prevent them from moving."
+	button_icon_state = "love"
+	sound = 'sound/magic/whiteflame.ogg'
+	self_cast_possible = FALSE
+
+	cast_range = 4
+	spell_type = SPELL_BLOOD
+	antimagic_flags = MAGIC_RESISTANCE_HOLY
+	associated_skill = /datum/skill/magic/blood
+
+	invocation = "Experiamur vim amoris!"
+	invocation_type = INVOCATION_SHOUT
+
+	charge_time = 6 SECONDS
+	charge_drain = 1
+	charge_slowdown = 1.3
+	cooldown_time = 2 MINUTES
+	spell_cost = 0
+
+/datum/action/cooldown/spell/vampiric_charm/is_valid_target(atom/cast_on)
+	. = ..()
+	if(!.)
+		return FALSE
+	return isliving(cast_on)
+
+/datum/action/cooldown/spell/vampiric_charm/cast(mob/living/cast_on)
+	. = ..()
+	var/charm_to_public = pick("<b style='color:pink'>[owner] is influenced by the beauty of Eora's follower.</b>", "<b style='color:pink'>[cast_on] stares mesmerized at [owner] and does not move.</b>")
+	var/charm_to_target = pick("<b style='color:pink'>Your eyes cannot move away from [owner].</b>", "<b style='color:pink'>You are enchanted by the beauty of the follower of Eora.</b>")
+	cast_on.visible_message(span_warning("[charm_to_public]"), span_warning("[charm_to_target]"))
+	cast_on.apply_status_effect(/datum/status_effect/eorapacify)
+	cast_on.Immobilize(85)

--- a/code/modules/spells/spell_types/undirected/list_target/encode_thoughtsvampire.dm
+++ b/code/modules/spells/spell_types/undirected/list_target/encode_thoughtsvampire.dm
@@ -1,0 +1,38 @@
+/datum/action/cooldown/spell/undirected/list_target/encode_thoughtsvampire
+	name = "Vampiric Manipulation"
+	desc = "Latch onto the mind of one who is nearby, encoding a particular thought into their mind."
+	button_icon_state = null
+	sound = 'sound/magic/whiteflame.ogg'
+
+	point_cost = 1
+	attunements = list(
+		/datum/attunement/dark = 0.5,
+	)
+
+	cooldown_time = 25 SECONDS
+	spell_cost = 0
+
+	choose_target_message = "Choose who to invade the mind of."
+	target_radius = 6
+	spell_flags = SPELL_RITUOS
+	var/message
+
+/datum/action/cooldown/spell/undirected/list_target/encode_thoughtsvampire/before_cast(atom/cast_on)
+	. = ..()
+	if(. & SPELL_CANCEL_CAST)
+		return
+	message = browser_input_text(owner, "What thought do you wish to weave to [cast_on]?", "[src]")
+	if(QDELETED(src) || QDELETED(owner) || QDELETED(cast_on) || !can_cast_spell())
+		return . | SPELL_CANCEL_CAST
+
+	if(!message)
+		reset_spell_cooldown()
+		return . | SPELL_CANCEL_CAST
+
+/datum/action/cooldown/spell/undirected/list_target/encode_thoughtsvampire/cast(mob/living/cast_on)
+	. = ..()
+	log_directed_talk(owner, cast_on, message, LOG_SAY, name)
+
+	to_chat(owner, "I pluck the strings of [cast_on]'s mind!")
+	to_chat(cast_on, "Your mind thinks to itself: </span><font color=#7246ff>\"[message]...\"</font>")
+

--- a/code/modules/spells/spell_types/undirected/shapeshift/frog.dm
+++ b/code/modules/spells/spell_types/undirected/shapeshift/frog.dm
@@ -1,0 +1,28 @@
+/datum/action/cooldown/spell/undirected/shapeshift/frog
+	name = "Frog Form"
+	desc = "Transform into a frog. Damage is not inherited between forms."
+
+	attunements = list(
+		/datum/attunement/dark = 0.4,
+		/datum/attunement/polymorph = 0.5,
+		/datum/attunement/aeromancy = 0.3,
+	)
+
+	charge_required = FALSE
+	cooldown_time = 50 SECONDS
+
+	possible_shapes = list(/mob/living/simple_animal/hostile/retaliate/frog)
+	die_with_shapeshifted_form = FALSE
+	convert_damage = FALSE
+
+/datum/action/cooldown/spell/undirected/shapeshift/frog/can_cast_spell(feedback)
+	if(HAS_TRAIT(owner, TRAIT_COVEN_BANE))
+		return FALSE
+	. = ..()
+
+/datum/action/cooldown/spell/undirected/shapeshift/frog/do_shapeshift(mob/living/caster)
+	. = ..()
+	if(!.)
+		return
+	var/mob/living/new_shape = .
+	new_shape.adjust_stat_modifier("[REF(src)]", STATKEY_SPD, 15 - new_shape.base_speed)

--- a/html/changelogs/AutoChangeLog-pr-2905.json
+++ b/html/changelogs/AutoChangeLog-pr-2905.json
@@ -1,1 +1,0 @@
-{"author":"F-e-r-n","delete-after":true,"changes":[{"balance":"Makes fullplate and encumbered people get up slower"},{"balance":"Removes strength check from encumbrance and makes carryweight scale on either STR or CON depending on whats higher."},{"balance":"50% encumbrance now disables sprinting from 70%"}]}

--- a/html/changelogs/AutoChangeLog-pr-3006.json
+++ b/html/changelogs/AutoChangeLog-pr-3006.json
@@ -1,1 +1,0 @@
-{"author":"Siro","delete-after":true,"changes":[{"rscadd":"Noble boot variants can store small knives, coins, or key. Only one storage space."},{"rscadd":"Storing anything but a knife in your boots will add a stress."},{"rscadd":"Maximum 40% chance to cut yourself storing a knife in your boots at less than 10 luck."}]}

--- a/html/changelogs/AutoChangeLog-pr-3068.json
+++ b/html/changelogs/AutoChangeLog-pr-3068.json
@@ -1,1 +1,0 @@
-{"author":"CheffieGithub","delete-after":true,"changes":[{"bugfix":"fixed an issue with doubled flaw effects."}]}

--- a/html/changelogs/AutoChangeLog-pr-3072.json
+++ b/html/changelogs/AutoChangeLog-pr-3072.json
@@ -1,1 +1,0 @@
-{"author":"wgtjunior743","delete-after":true,"changes":[{"bugfix":"Good Swim Trait name is not ugly anymore"}]}

--- a/html/changelogs/archive/2025-08.json
+++ b/html/changelogs/archive/2025-08.json
@@ -1024,5 +1024,39 @@
                 "bugfix": "Progressives psydonites can roll Paladin and Church can't recruit progressive psydonites anymore."
             }
         ]
+    },
+    "2025-08-30": {
+        "F-e-r-n": [
+            {
+                "balance": "Makes fullplate and encumbered people get up slower"
+            },
+            {
+                "balance": "Removes strength check from encumbrance and makes carryweight scale on either STR or CON depending on whats higher."
+            },
+            {
+                "balance": "50% encumbrance now disables sprinting from 70%"
+            }
+        ],
+        "Siro": [
+            {
+                "rscadd": "Noble boot variants can store small knives, coins, or key. Only one storage space."
+            },
+            {
+                "rscadd": "Storing anything but a knife in your boots will add a stress."
+            },
+            {
+                "rscadd": "Maximum 40% chance to cut yourself storing a knife in your boots at less than 10 luck."
+            }
+        ],
+        "CheffieGithub": [
+            {
+                "bugfix": "fixed an issue with doubled flaw effects."
+            }
+        ],
+        "wgtjunior743": [
+            {
+                "bugfix": "Good Swim Trait name is not ugly anymore"
+            }
+        ]
     }
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

-Adds a new vampire clan themed after Eora (basically Toreador from VTM)
-Incentive on charming people and intrigue over brute force.
-Frog form. (frog prince reference trust)
-2 new spells for the Eorabella VL: Vampiric Charm and Vampiric Manipulation. 
Vampiric charm is an unused eoran miracle, Vampiric Manipulation is basically encode thoughts. (you can put words into people's heads)

## Why It's Good For The Game
Pretty cool clan for vampires who want to rely more on charisma.
Naturally RP heavy clan. 


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Eorabella clan
add: Vampiric Manipulation, Vampiric charm. (encode thoughts and eoran charm but rewritten so they can use it)

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
<img width="1351" height="871" alt="Capture d'écran 2025-08-30 173216" src="https://github.com/user-attachments/assets/d9902562-79df-4c4b-895f-b9d20722147e" />
<img width="732" height="698" alt="Capture d'écran 2025-08-30 172108" src="https://github.com/user-attachments/assets/59e25cd8-5414-43e3-84bd-d6b9e53d0209" />
