### PR TITLE
Fix for drugs causing error signs

### DIFF
--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -10,23 +10,15 @@
 	druggy = max(druggy+amount, 0)
 	if(druggy)
 		overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)
-//		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "high", /datum/mood_event/high)
 	else
 		clear_fullscreen("high")
-//		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "high")
-//	update_body_parts_head_only()
-//	update_body_parts_eyes_only() FIX FOR PERMASPICEEYES, CAUSED VAMPEYES TO NEVER STOP BEING WHITE
 
 /mob/living/carbon/set_drugginess(amount)
 	druggy = max(amount, 0)
 	if(druggy)
 		overlay_fullscreen("high", /atom/movable/screen/fullscreen/high)
-//		throw_alert("high", /atom/movable/screen/alert/high)
 	else
 		clear_fullscreen("high")
-//		clear_alert("high")
-//	update_body_parts_head_only()
-//	update_body_parts_eyes_only() FIX FOR PERMASPICEEYES, CAUSED VAMPEYES TO NEVER STOP BEING WHITE
 
 /mob/living/carbon/adjust_disgust(amount)
 	disgust = CLAMP(disgust+amount, 0, DISGUST_LEVEL_MAXEDOUT)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -30,23 +30,11 @@
 	M.set_drugginess(30)
 	M.apply_status_effect(/datum/status_effect/buff/weed)
 	M.overlay_fullscreen("weedsm", /atom/movable/screen/fullscreen/weedsm)
-	M.update_body_parts_head_only()
-
-/*
-	if(M.client)
-		SSdroning.area_entered(get_area(M), M.client)
-*/
 
 /datum/reagent/drug/space_drugs/on_mob_end_metabolize(mob/living/M)
 	M.set_drugginess(0)
 	M.clear_fullscreen("weedsm")
 	M.remove_status_effect(/datum/status_effect/buff/weed)
-	M.update_body_parts_head_only()
-
-/*
-	if(M.client)
-		SSdroning.play_area_sound(get_area(M), M.client)
-*/
 
 /atom/movable/screen/fullscreen/weedsm
 	icon_state = "smok"

--- a/code/modules/reagents/reagent_containers/powder.dm
+++ b/code/modules/reagents/reagent_containers/powder.dm
@@ -114,7 +114,6 @@
 	if(M.client)
 		ADD_TRAIT(M, TRAIT_DRUQK, "based")
 		M.refresh_looping_ambience()
-	M.update_body_parts_head_only()
 
 /datum/reagent/druqks/on_mob_end_metabolize(mob/living/M)
 	M.clear_fullscreen("druqk")
@@ -123,7 +122,6 @@
 	if(M.client)
 		REMOVE_TRAIT(M, TRAIT_DRUQK, "based")
 		M.refresh_looping_ambience()
-	M.update_body_parts_head_only()
 
 /datum/reagent/druqks/overdose_process(mob/living/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25*REM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
update_body_parts_eyes_only() needs an overlay key or it just stacks overlays with no way to track and remove them. This isn't fixing that but it is not using it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Fixed weed and spice causing error signs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
