### PR TITLE
Steam knight slop

### DIFF
--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -154,8 +154,7 @@
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axesmaces, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, -1, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/crossbows, -1, TRUE)
-	H.adjust_skillrank(/datum/skill/craft/engineering, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/engineering, 3, TRUE)//replaces the int buff
 
 /datum/outfit/job/royalknight/steam/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -104,14 +104,15 @@
 	var/grant_shield = TRUE
 	switch(choice)
 		if("Flail")
-			H.clamped_adjust_skillrank(/datum/skill/combat/whipsflails, 1, 4, TRUE)
+			H.clamped_adjust_skillrank(/datum/skill/combat/whipsflails, 2, 4, TRUE)
 		if("Halberd")
-			H.clamped_adjust_skillrank(/datum/skill/combat/polearms, 1, 4, TRUE)
+			H.clamped_adjust_skillrank(/datum/skill/combat/polearms, 2, 4, TRUE)
 			grant_shield = FALSE
 		if("Longsword")
 			grant_shield = FALSE
+			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, 4, TRUE)
 		if("Unarmed")
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+			H.clamped_adjust_skillrank(/datum/skill/combat/unarmed, 3, 5, TRUE)
 			H.clamped_adjust_skillrank(/datum/skill/combat/knives, 2, 4, TRUE)
 			grant_shield = FALSE
 	if(grant_shield)
@@ -132,7 +133,8 @@
 	tutorial = "The pinnacle of Vanderlin's steam technology. \
 	Start with a set of Steam Armor that requires steam to function. \
 	The suit is powerful when powered but will slow you down when not \
-	and has the cost of reducing your space for arms."
+	learning how to use it has cost you precious time \
+	you could have spent learning to use other weapons."
 
 	outfit = /datum/outfit/job/royalknight/steam
 
@@ -149,6 +151,8 @@
 	head = /obj/item/clothing/head/helmet/heavy/steam
 
 	H.adjust_skillrank(/datum/skill/combat/swords, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/shields, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, -1, TRUE)

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -148,15 +148,14 @@
 	gloves = /obj/item/clothing/gloves/plate/steam
 	head = /obj/item/clothing/head/helmet/heavy/steam
 
-	// Steam armour is complex
-	H.change_stat(STATKEY_INT, 2)
-	// Stronger armour than base RK
-	// Stat punishment for not having the armour active
-	H.change_stat(STATKEY_STR, -1)
-	H.change_stat(STATKEY_CON, -1)
-	H.change_stat(STATKEY_END, -1)
-	// Way heavier
-	H.change_stat(STATKEY_SPD, -1)
+	H.adjust_skillrank(/datum/skill/combat/swords, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/whipsflails, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/axesmaces, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/bows, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/crossbows, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/engineering, 3, TRUE)
 
 /datum/outfit/job/royalknight/steam/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The images are not meant to be the exact changes, just a rough example of what to expect

Unchanged, basic royal knight with flail specialization
<img width="231" height="342" alt="image" src="https://github.com/user-attachments/assets/7ec64e88-132f-459e-8764-6a3262deff47" />

Steam knight with nerfed skills with flail specialization
<img width="220" height="367" alt="image" src="https://github.com/user-attachments/assets/6ea28e32-a37e-481a-9af2-2dffd671187d" />

Basically, replaces the stat malus with a skill malus for steam knights

## Why It's Good For The Game

The main benefit of the steam knight armour, aside from being tough as nails, is that it grants you a stat boon
the steam knight getting a stat malus sort of undermines that
instead, the steam knight gets a skill malus, so they are not as versatile as the basic knight
they also get skilled in engineering, as a replacement of the int stat bonus
>why engineering

Because Its the closest thing related to steam armour (also because I'm going to make steam knight armour craftable in another PR and there should be some sort of requirement before you can put the damn thing on)
ALSO, engineering skills lets them repair their armour

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: steam knight no longer gets a stat malus, instead they get a skill malus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
