### PR TITLE
Steam knight armour slop

### DIFF
--- a/code/modules/clothing/armor/steam.dm
+++ b/code/modules/clothing/armor/steam.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/armor/steam
-	name = "steam armor"
-	desc = "The center piece of the steam armor set."
+	name = "steamknight plate"
+	desc = "The center piece of the steamknight armor. Requires knowledge in engineering to operate."
 
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
@@ -23,6 +23,8 @@
 	max_integrity = INTEGRITY_STRONGEST
 	item_weight = 25 * BRONZE_MULTIPLIER
 	stand_speed_reduction = 0.6
+
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/clothing/armor/steam/Initialize()
 	. = ..()
@@ -55,6 +57,14 @@
 		return
 
 	if(!slot || !(slot_flags & slot))
+		power_off(user)
+		remove_status_effect(user)
+		for(var/obj/item/clothing/clothing as anything in equipped_items)
+			clothing:power_off(user)
+		return
+
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
 		power_off(user)
 		remove_status_effect(user)
 		for(var/obj/item/clothing/clothing as anything in equipped_items)

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -1,14 +1,16 @@
 /obj/item/clothing/cloak/boiler
-	name = "steam boiler"
-	desc = "The power center of the steamknight armor"
+	name = "steamknight boiler"
+	desc = "The backpack-sized power center of the steamknight armor. Requires knowledge in engineering to operate."
 
 	icon_state = "boiler"
 	item_state = "boiler"
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
+	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK
 
-	smeltresult = null
+	//you can't unsmelt your boiler Sir Steam Knightus
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/clothing/cloak/boiler/Initialize()
 	. = ..()
@@ -47,12 +49,20 @@
 			clothing:power_off(user)
 		return
 
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
+		power_off(user)
+		remove_status_effect(user)
+		for(var/obj/item/clothing/clothing as anything in equipped_items)
+			clothing:power_off(user)
+		return
 	power_on(user)
 	apply_status_effect(user)
 	for(var/obj/item/clothing/clothing as anything in equipped_items)
 		clothing:power_on(user)
 
 /obj/item/clothing/cloak/boiler/proc/power_on(mob/living/user)
+	to_chat(user, span_info("I hear cogs turning and the hissing of steam as [src] powers on!"))
 	return
 
 /obj/item/clothing/cloak/boiler/proc/power_off(mob/living/user)

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -49,7 +49,7 @@
 			clothing:power_off(user)
 		return
 
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 2)
 		to_chat(user, span_warning("I don't know how to operate [src]!"))
 		power_off(user)
 		remove_status_effect(user)

--- a/code/modules/clothing/gloves/steam.dm
+++ b/code/modules/clothing/gloves/steam.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/gloves/plate/steam
 	name = "steamknight gloves"
-	desc = "Part of the steamknight set."
+	desc = "Part of the the steamknight armor. Requires knowledge in engineering to operate."
 
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
@@ -10,7 +10,7 @@
 	sleevetype = "steamknight_gloves"
 
 	anvilrepair = /datum/skill/craft/engineering
-	smeltresult = null
+	smeltresult = /obj/item/ingot/bronze
 	item_weight = 7 * BRONZE_MULTIPLIER
 
 /obj/item/clothing/gloves/plate/steam/equipped(mob/living/user, slot)
@@ -40,6 +40,14 @@
 		return
 
 	if(!slot || !(slot_flags & slot))
+		power_off(user)
+		remove_status_effect(user)
+		for(var/obj/item/clothing/clothing as anything in equipped_items)
+			clothing:power_off(user)
+		return
+
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
 		power_off(user)
 		remove_status_effect(user)
 		for(var/obj/item/clothing/clothing as anything in equipped_items)

--- a/code/modules/clothing/head/helmets/steam.dm
+++ b/code/modules/clothing/head/helmets/steam.dm
@@ -1,12 +1,13 @@
 /obj/item/clothing/head/helmet/heavy/steam
 	name = "steamknight helmet"
-	desc = "Part of the the steamknight armor."
+	desc = "Part of the the steamknight armor. Requires knowledge in engineering to operate."
 	icon_state = "steamknight_helm"
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
 	anvilrepair = /datum/skill/craft/engineering
-	block2add = null // no fov block.
+	block2add = null // no fov block, was trying to make it so theres a fov block if its unpowered but it didn't really work out sadly, was too buggy
 	item_weight = 9 * BRONZE_MULTIPLIER
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/clothing/head/helmet/heavy/steam/equipped(mob/living/user, slot)
 	update_armor(user, slot)
@@ -35,6 +36,14 @@
 		return
 
 	if(!slot || !(slot_flags & slot))
+		power_off(user)
+		remove_status_effect(user)
+		for(var/obj/item/clothing/clothing as anything in equipped_items)
+			clothing:power_off(user)
+		return
+
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
 		power_off(user)
 		remove_status_effect(user)
 		for(var/obj/item/clothing/clothing as anything in equipped_items)

--- a/code/modules/clothing/shoes/steam.dm
+++ b/code/modules/clothing/shoes/steam.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/shoes/boots/armor/steam
 	name = "steamknight boots"
-
+	desc = "Part of the the steamknight armor. Requires knowledge in engineering to operate."
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
 	icon_state = "steamknight_boots"
@@ -11,6 +11,8 @@
 	anvilrepair = /datum/skill/craft/engineering
 	slowdown = 1.5
 	item_weight = 6 * BRONZE_MULTIPLIER
+
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/clothing/shoes/boots/armor/steam/equipped(mob/living/user, slot)
 	update_armor(user)
@@ -44,6 +46,14 @@
 		return
 
 	if(!slot || !(slot_flags & slot))
+		power_off(user)
+		remove_status_effect(user)
+		for(var/obj/item/clothing/clothing as anything in equipped_items)
+			clothing:power_off(user)
+		return
+
+	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
 		power_off(user)
 		remove_status_effect(user)
 		for(var/obj/item/clothing/clothing as anything in equipped_items)

--- a/code/modules/crafting/artificer/misc.dm
+++ b/code/modules/crafting/artificer/misc.dm
@@ -146,6 +146,52 @@
 	hammers_per_item = 7
 	craftdiff = 4
 
+// --------- ARMOR -----------
+
+//should be armour not armor, fight me
+/datum/artificer_recipe/armor
+	i_type = "Armor"
+
+/datum/artificer_recipe/armor/steam_knight_helm
+	name = "Steamknight Helmet (+3 Bronze) (+3 Metal Gear) (+1 Cloth)"
+	required_item = /obj/item/ingot/steel
+	created_item = /obj/item/clothing/head/helmet/heavy/steam
+	additional_items = list(/obj/item/ingot/bronze = 3, /obj/item/gear/metal = 3, /obj/item/natural/cloth = 1)
+	hammers_per_item = 4
+	craftdiff = 5
+
+/datum/artificer_recipe/armor/steam_knight_plate
+	name = "Steamknight Plate (+5 Bronze) (+3 Metal Gear) (+2 Cloth)"
+	required_item = /obj/item/ingot/steel
+	created_item = /obj/item/clothing/armor/steam
+	additional_items = list(/obj/item/ingot/bronze = 5, /obj/item/gear/metal = 3, /obj/item/natural/cloth = 2)
+	hammers_per_item = 6
+	craftdiff = 5
+
+/datum/artificer_recipe/armor/steam_knight_gloves
+	name = "Steamknight Gloves (+2 Bronze) (+2 Metal Gear) (+1 Cloth)"
+	required_item = /obj/item/ingot/steel
+	created_item = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	additional_items = list(/obj/item/ingot/bronze = 3, /obj/item/gear/metal = 2, /obj/item/natural/cloth = 1)
+	hammers_per_item = 4
+	craftdiff = 5
+
+/datum/artificer_recipe/armor/steam_knight_boots
+	name = "Steamknight Boots (+2 Bronze) (+2 Metal Gear) (+1 Cloth)"
+	required_item = /obj/item/ingot/steel
+	created_item = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	additional_items = list(/obj/item/ingot/bronze = 3, /obj/item/gear/metal = 2, /obj/item/natural/cloth = 1)
+	hammers_per_item = 4
+	craftdiff = 5
+
+/datum/artificer_recipe/contraptions/boiler
+	name = "Steamknight Boiler (+1 Backpack) (+1 Bronze) (+3 Cogs)"
+	required_item = /obj/item/ingot/bronze
+	created_item = /obj/item/clothing/cloak/boiler
+	additional_items = list(/obj/item/gear/metal/bronze = 3, /obj/item/ingot/bronze = 1, /obj/item/storage/backpack/backpack = 1)
+	hammers_per_item = 5
+	craftdiff = 5
+
 // --------- Contraptions -----------
 
 /datum/artificer_recipe/contraptions
@@ -193,18 +239,10 @@
 	craftdiff = 3
 
 /datum/artificer_recipe/contraptions/coolingbackpack
-	name = "Cooling Backpack (+1 Backpack, +2 Cogs)"
+	name = "Cooling Backpack (+1 Backpack) (+2 Cogs)"
 	required_item = /obj/item/ingot/bronze
 	created_item = /obj/item/storage/backpack/backpack/artibackpack
 	additional_items = list(/obj/item/gear/metal = 2, /obj/item/storage/backpack/backpack)
-	hammers_per_item = 4
-	craftdiff = 5
-
-/datum/artificer_recipe/contraptions/boiler
-	name = "Steamknight Boiler (+1 Bar, +3 Cogs)"
-	required_item = /obj/item/ingot/bronze
-	created_item = /obj/item/clothing/cloak/boiler
-	additional_items = list(/obj/item/gear/metal/bronze = 3, /obj/item/ingot/bronze = 1)
 	hammers_per_item = 4
 	craftdiff = 5
 

--- a/code/modules/crafting/artificer/misc.dm
+++ b/code/modules/crafting/artificer/misc.dm
@@ -173,7 +173,7 @@
 /datum/artificer_recipe/armor/steam_knight_gloves
 	name = "Steamknight Gloves (+2 Bronze) (+2 Metal Gear) (+1 Cloth)"
 	required_item = /obj/item/ingot/steel
-	created_item = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	created_item = /obj/item/clothing/gloves/plate/steam
 	additional_items = list(/obj/item/ingot/bronze = 3, /obj/item/gear/metal = 2, /obj/item/natural/cloth = 1)
 	hammers_per_item = 4
 	craftdiff = 5
@@ -181,7 +181,7 @@
 /datum/artificer_recipe/armor/steam_knight_boots
 	name = "Steamknight Boots (+2 Bronze) (+2 Metal Gear) (+1 Cloth)"
 	required_item = /obj/item/ingot/steel
-	created_item = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	created_item = /obj/item/clothing/shoes/boots/armor/steam
 	additional_items = list(/obj/item/ingot/bronze = 3, /obj/item/gear/metal = 2, /obj/item/natural/cloth = 1)
 	hammers_per_item = 4
 	craftdiff = 5

--- a/code/modules/crafting/artificer/misc.dm
+++ b/code/modules/crafting/artificer/misc.dm
@@ -137,6 +137,7 @@
 
 /datum/artificer_recipe/weapons
 	i_type = "Weapons"
+	category = "Weapons"
 
 /datum/artificer_recipe/weapons/crossbow
 	name = "Crossbow (+1 Steel) (+1 Fiber)"
@@ -148,9 +149,10 @@
 
 // --------- ARMOR -----------
 
-//should be armour not armor, fight me
+//should be armour not armor fight me, but most of the codebase uses american english so its armor
 /datum/artificer_recipe/armor
 	i_type = "Armor"
+	category = "Armor"
 
 /datum/artificer_recipe/armor/steam_knight_helm
 	name = "Steamknight Helmet (+3 Bronze) (+3 Metal Gear) (+1 Cloth)"
@@ -184,7 +186,7 @@
 	hammers_per_item = 4
 	craftdiff = 5
 
-/datum/artificer_recipe/contraptions/boiler
+/datum/artificer_recipe/armor/boiler
 	name = "Steamknight Boiler (+1 Backpack) (+1 Bronze) (+3 Cogs)"
 	required_item = /obj/item/ingot/bronze
 	created_item = /obj/item/clothing/cloak/boiler


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Sort of a follow up PR to #3115 , given how that PR gives steam knights the engineering skill.
New artificer crafting category, armor.
You can craft steamknight armour, requires master in engineering. Is, I hope, expensive enough.
Steamknight armour now requires skilled in engineering to be powered on.
Steamknight boiler now requires a backpack to craft.

Also a minor tweak to the cooling backpack recipe name, so its inline with the other recipe names.

## Why It's Good For The Game

Most, if not almost all, things are craftable in the game. I vaguely recall steamknight armour was meant to be craftable (and was for a short period) but was removed due to balance reasons (I think? Not entirely sure)
Anyways, the armour is now craftable. Expensive enough to that getting it will be an expensive feat.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Steamknight armour is now craftable
balance: Steamknight armour now requires skilled in engineering to be properly utilized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
