### PR TITLE
Changes to how ingot molds work

### DIFF
--- a/code/game/objects/items/crucible.dm
+++ b/code/game/objects/items/crucible.dm
@@ -1,5 +1,6 @@
 /obj/item/storage/crucible
 	name = "crucible"
+	desc = "A crucible in which metal items can be molten down."
 	layer = ABOVE_ALL_MOB_LAYER
 
 	icon = 'icons/roguetown/weapons/crucible.dmi'

--- a/code/game/objects/items/pouring_mould.dm
+++ b/code/game/objects/items/pouring_mould.dm
@@ -1,5 +1,6 @@
 /obj/item/mould
 	name = "mould"
+	desc = "You shouldn't be seeing this one."
 
 	icon = 'icons/roguetown/weapons/crucible.dmi'
 	icon_state = "flat-mold"
@@ -13,6 +14,7 @@
 
 	var/cooling = FALSE
 	var/cooling_progress = 0
+	var/cooling_bonus = 1
 
 /obj/item/mould/Initialize()
 	. = ..()
@@ -106,7 +108,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mould/process()
-	cooling_progress += 2.5
+	cooling_progress += 5 * cooling_bonus
 	update_appearance(UPDATE_OVERLAYS)
 	if(cooling_progress >= 100)
 		STOP_PROCESSING(SSobj, src)
@@ -124,6 +126,7 @@
 
 /obj/item/mould/ingot
 	name = "ingot mold"
+	desc = "A clay mold for making metal ingots."
 
 	icon_state = "ingot-mold"
 	filling_icon_state = "ingot-mold-color"
@@ -142,4 +145,10 @@
 	fufilled_metal = 0
 	filling_metal = null
 	cooling = FALSE
+	cooling_progress = 0
 	update_appearance(UPDATE_OVERLAYS)
+
+/obj/item/mould/ingot/advanced
+	name = "advanced ingot mold"
+	desc = "An ingot mold that utilizes water for faster cooling."
+	cooling_bonus = 2

--- a/code/modules/crafting/artificer/misc.dm
+++ b/code/modules/crafting/artificer/misc.dm
@@ -168,6 +168,14 @@
 	hammers_per_item = 10
 	craftdiff = 3
 
+/datum/artificer_recipe/contraptions/advanced_ingot_mold
+	name = "Advanced Ingot Mold (+1 Ingot Mold) (+1 Metal Gear) (+1 Bucket)"
+	required_item = /obj/item/ingot/bronze
+	additional_items = list(/obj/item/mould/ingot = 1, /obj/item/gear/metal = 1, /obj/item/reagent_containers/glass/bucket/wooden = 1)
+	created_item = /obj/item/mould/ingot/advanced
+	hammers_per_item = 6
+	craftdiff = 3
+
 /datum/artificer_recipe/contraptions/shears
 	name = "Amputation Shears (+2 Bronze)"
 	required_item = /obj/item/ingot/bronze


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When ingot molds finish hardening the metal into an ingot, they don't need to cool the metal down again.
Naturally, this makes no sense, and turned out it was a bug.
This PR fixes this bug, but also quickens the cooling process.
Also, made a new contraption that cools down metals into ingots even faster. Doesn't need to be an artificier contraption, more so a "proof of concept".

## Why It's Good For The Game

I... I don't know
I mean all this does in practice is make it so smiths cant plop out ingots like mad
It's why I made the cooling process faster, so people can still make ingots without having to wait years
I guess I found it really jarring how you have to wait for the ingot mold to harden the metal, but then don't have to wait after it hardens the first time

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added a new artificer contraption, basically an ingot mold that cools down metal twice as fast as a normal one (normal ingot moulds cool down twice as fast as before)
fix: fixed ingot molds not needing to reharden metal after the first harden-ing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
