### PR TITLE
Fix Mirrors to Change Hair Color Again

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -114,8 +114,9 @@
 				hairs = H.dna.species.get_hairc_list()
 				new_hair = browser_input_list(user, "Choose your character's hair color:", "", hairs)
 			if(new_hair)
-				H.set_hair_color(hairs[new_hair], FALSE)
-				H.set_facial_hair_color(hairs[new_hair], FALSE)
+				new_hair = "#" + hairs[new_hair]
+				H.set_hair_color(new_hair, FALSE)
+				H.set_facial_hair_color(new_hair, FALSE) // This doesn't work for some reason?  Just change facial hair and its fine.
 				should_update = TRUE
 
 		if("skin")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the mirrors in-game to once again be capable of changing hair color.  Beards do not update due to a problem with set_facial_hair_color beyond the scope of my ability to correct.  This can be worked around by just using the mirror again and selecting to adjust your facial hair;  it gets the new hair color afterwards.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mirrors work again!  No longer are we bound by the hair we got stuck with.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: corrected a missing # that was causing mirrors to set hair color to #000000
:/cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
