### PR TITLE
Ballooning

### DIFF
--- a/code/modules/antagonists/villain/neu_vampires/covens/coven_powers/demonic.dm
+++ b/code/modules/antagonists/villain/neu_vampires/covens/coven_powers/demonic.dm
@@ -101,19 +101,7 @@
 
 /datum/coven_power/demonic/conflagration/post_gain()
 	. = ..()
-	var/datum/action/cooldown/spell/projectile/fireball/baali/balefire = new(owner)
-	balefire.Grant(owner)
-
-/datum/action/cooldown/spell/projectile/fireball/baali
-	name = "Infernal Fireball"
-	desc = "This spell fires an explosive fireball at a target."
-	school = "evocation"
-	charge_time = 4 SECONDS
-	invocation = "FR BRTH"
-	invocation_type = "whisper"
-	cooldown_time = 20 //10 deciseconds reduction per rank
-	projectile_type = /obj/projectile/magic/aoe/fireball/rogue
-	sound = 'sound/magic/fireball.ogg'
+	owner.add_spell(/datum/action/cooldown/spell/projectile/fireball/baali, source = src)
 
 //PSYCHOMACHIA
 /datum/coven_power/demonic/psychomachia

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -205,7 +205,7 @@
 
 	if(charge_drain)
 		if(!check_cost(charge_drain))
-			to_chat(owner, span_userdanger("I cannot uphold the channeling!"))
+			owner.balloon_alert(owner, "I cannot uphold the channeling!")
 			cancel_casting()
 			return PROCESS_KILL
 		invoke_cost(charge_drain)
@@ -214,7 +214,7 @@
 	if(world.time > (charge_started_at + charge_target_time))
 		// We don't want that mouseUp to end in sadness
 		if(!check_cost(charge_drain))
-			to_chat(owner, span_userdanger("I cannot uphold the channeling!"))
+			owner.balloon_alert(owner, "I cannot uphold the channeling!")
 			cancel_casting()
 			return PROCESS_KILL
 		owner.client.mouse_override_icon = 'icons/effects/mousemice/charge/spell_charged.dmi'
@@ -436,12 +436,12 @@
 
 	if(!(spell_flags & SPELL_IGNORE_SPELLBLOCK) && HAS_TRAIT(owner, TRAIT_SPELLBLOCK))
 		if(feedback)
-			to_chat(owner, span_warning("I can't seem to concentrate on casting..."))
+			owner.balloon_alert(owner, "Can't focus on casting...")
 		return FALSE
 
 	if(HAS_TRAIT(owner, TRAIT_NOC_CURSE))
 		if(feedback)
-			to_chat(owner, span_warning("My magicka has left me..."))
+			owner.balloon_alert(owner, "My magicka has left me...")
 		return FALSE
 
 	for(var/datum/action/cooldown/spell/spell in owner.actions)
@@ -449,7 +449,7 @@
 			continue
 		if(spell.currently_charging)
 			if(feedback)
-				to_chat(owner, span_warning("I am already channeling a spell!"))
+				owner.balloon_alert(owner, "Already channeling!")
 			return FALSE
 
 	if(!check_cost(feedback = feedback))
@@ -459,7 +459,7 @@
 	var/turf/caster_turf = get_turf(owner)
 	if((spell_requirements & SPELL_REQUIRES_STATION) && is_centcom_level(caster_turf.z))
 		if(feedback)
-			to_chat(owner, span_warning("You can't cast [src] here!"))
+			owner.balloon_alert(owner, "Cannot cast here!")
 		return FALSE
 
 	if((spell_requirements & SPELL_REQUIRES_MIND) && !owner.mind)
@@ -470,7 +470,7 @@
 	// that corresponds with the spell's antimagic, then they can't actually cast the spell
 	if((spell_requirements & SPELL_REQUIRES_NO_ANTIMAGIC) && !owner.can_cast_magic(antimagic_flags))
 		if(feedback)
-			to_chat(owner, span_warning("Some form of antimagic is preventing you from casting [src]!"))
+			owner.balloon_alert(owner, "Antimagic is preventing casting!")
 		return FALSE
 
 	if(!can_invoke(feedback = feedback))
@@ -479,13 +479,8 @@
 	if(!ishuman(owner))
 		if(spell_requirements & (SPELL_REQUIRES_HUMAN))
 			if(feedback)
-				to_chat(owner, span_warning("[src] can only be cast by humans!"))
+				owner.balloon_alert(owner, "Can only be cast by humans!")
 			return FALSE
-
-		// if(spell_type == SPELL_MIRACLE)
-		// 	if(feedback)
-		// 		to_chat(owner, span_warning("My link to the divine is too weak to cast [src]!"))
-		// 	return FALSE
 
 	if(LAZYLEN(required_items))
 		var/found = FALSE
@@ -494,7 +489,7 @@
 				found = TRUE
 				break
 		if(!found && feedback)
-			to_chat(owner, span_warning("I'm missing something to cast this!"))
+			owner.balloon_alert(owner, "Missing something to cast!")
 			return FALSE
 
 	return TRUE
@@ -508,7 +503,7 @@
 /datum/action/cooldown/spell/proc/is_valid_target(atom/cast_on)
 	if(click_to_activate && !self_cast_possible)
 		if(cast_on == owner)
-			to_chat(owner, span_warning("You cannot cast [src] on yourself!"))
+			owner.balloon_alert(owner, "Can't self cast!")
 			return FALSE
 
 	return TRUE
@@ -586,7 +581,7 @@
 			return sig_return
 
 		if(get_dist(owner, cast_on) > cast_range)
-			to_chat(owner, span_warning("Too far away!"))
+			owner.balloon_alert(owner, "Too far away!")
 			return sig_return | SPELL_CANCEL_CAST
 
 		if((spell_type == SPELL_MIRACLE) && HAS_TRAIT(cast_on, TRAIT_ATHEISM_CURSE))
@@ -712,10 +707,10 @@
 		caster.start_spell_visual_effects(attunements)
 
 	if(charge_message)
-		to_chat(owner, span_warning(charge_message))
+		owner.balloon_alert(owner, charge_message)
 
 	if(spell_requirements & SPELL_REQUIRES_NO_MOVE)
-		to_chat(owner, span_warning("I must be still while I channel [src]!"))
+		owner.balloon_alert(owner, "Be still while channelling...")
 
 	if(owner?.mmb_intent)
 		owner.mmb_intent_change(null)
@@ -729,7 +724,7 @@
 		charged = TRUE
 		return
 	if(owner)
-		to_chat(owner, span_warning("My channeling of [src] was interrupted!"))
+		owner.balloon_alert(owner, "Channeling was interrupted!")
 
 /// End the charging cycle
 /datum/action/cooldown/spell/proc/end_charging()
@@ -772,12 +767,12 @@
 	var/mob/living/living_owner = owner
 	if(invocation_type == INVOCATION_EMOTE && HAS_TRAIT(living_owner, TRAIT_EMOTEMUTE))
 		if(feedback)
-			to_chat(owner, span_warning("You can't position your hands correctly to invoke [src]!"))
+			owner.balloon_alert(owner, "Can't position your hands correctly to invoke!")
 		return FALSE
 
 	if((invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT) && !living_owner.can_speak_vocal())
 		if(feedback)
-			to_chat(owner, span_warning("You can't get the words out to invoke [src]!"))
+			owner.balloon_alert(owner, "Can't get the words out to invoke!")
 		return FALSE
 
 	return TRUE
@@ -861,7 +856,7 @@
 		var/not_stamina_spell = (spell_type != SPELL_STAMINA)
 		if(!caster.check_stamina(used_cost / (1 + not_stamina_spell)))
 			if(feedback)
-				to_chat(owner, span_warning("I don't have enough stamina to cast!"))
+				owner.balloon_alert(owner, "Not enough stamina to cast!")
 			return FALSE
 
 	if(spell_type == NONE || spell_type == SPELL_STAMINA)
@@ -871,7 +866,7 @@
 		if(SPELL_MANA)
 			if(!caster.has_mana_available(attunements, used_cost))
 				if(feedback)
-					to_chat(owner, span_warning("I am too drained to cast!"))
+					owner.balloon_alert(owner, "Not enough mana to cast!")
 				return FALSE
 
 			return TRUE
@@ -879,7 +874,7 @@
 		if(SPELL_BLOOD)
 			if(!caster.has_bloodpool_cost(used_cost))
 				if(feedback)
-					to_chat(owner, span_warning("I am too drained to cast!"))
+					owner.balloon_alert(owner, "Need more blood to cast!")
 				return FALSE
 
 			return TRUE
@@ -888,7 +883,7 @@
 			var/mob/living/carbon/human/H = caster
 			if(!istype(H) || !H.cleric?.check_devotion(spell_cost))
 				if(feedback)
-					to_chat(owner, span_warning("My devotion is too weak!"))
+					owner.balloon_alert(owner, "Devotion too weak!")
 				return FALSE
 
 			return TRUE
@@ -908,7 +903,7 @@
 				return FALSE
 			if(!gaunt.can_consume_essence(used_cost, attunements))
 				if(feedback)
-					to_chat(owner, span_warning(("The gauntlet hasn't got enough essence to cast!")))
+					owner.balloon_alert(owner, "Not enough essence!")
 				return FALSE
 
 			return TRUE

--- a/code/modules/spells/spell_types/pointed/projectile/fireball.dm
+++ b/code/modules/spells/spell_types/pointed/projectile/fireball.dm
@@ -3,6 +3,7 @@
 	desc = "Shoot out a ball of fire that emits a light explosion on impact, setting the target alight."
 	button_icon_state = "fireball"
 	charge_sound = 'sound/magic/charging_fire.ogg'
+	sound = 'sound/magic/fireball.ogg'
 
 	cast_range = 8
 	point_cost = 4
@@ -24,19 +25,14 @@
 	to_fire.exp_light *= attuned_strength
 	to_fire.exp_fire *= attuned_strength
 
-/obj/projectile/magic/aoe/fireball/rogue
-	name = "fireball"
-	exp_heavy = 0
-	exp_light = 3
-	exp_flash = 0
-	exp_fire = 3
-	damage = 10
-	damage_type = BURN
-	nodamage = FALSE
-	flag = "magic"
-	hitsound = 'sound/fireball.ogg'
-	aoe_range = 0
-	speed = 3
+/datum/action/cooldown/spell/projectile/fireball/baali
+	name = "Infernal Fireball"
+
+	invocation = "FR BRTH"
+	invocation_type = "whisper"
+
+	charge_time = 4 SECONDS
+	cooldown_time = 20 SECONDS
 
 /datum/action/cooldown/spell/projectile/fireball/greater
 	name = "Fireball (Greater)"
@@ -56,6 +52,20 @@
 	spell_flags = NONE
 
 	projectile_type = /obj/projectile/magic/aoe/fireball/rogue/great
+
+/obj/projectile/magic/aoe/fireball/rogue
+	name = "fireball"
+	exp_heavy = 0
+	exp_light = 3
+	exp_flash = 0
+	exp_fire = 3
+	damage = 10
+	damage_type = BURN
+	nodamage = FALSE
+	flag = "magic"
+	hitsound = 'sound/fireball.ogg'
+	aoe_range = 0
+	speed = 3
 
 /obj/projectile/magic/aoe/fireball/rogue/great
 	name = "fireball"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Convert some important stuff to balloon alerts so they are immediately obvious for situations like combat.

Converted all base datum spell to_chats except the activation and deactivation message to avoid spam.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Converted various to_chats to ballon alerts so they are more clear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
