### PR TITLE
Fixes "Ultimate Sacrifice" spell

### DIFF
--- a/code/modules/spells/spell_types/pointed/ultimate_sacrifice.dm
+++ b/code/modules/spells/spell_types/pointed/ultimate_sacrifice.dm
@@ -14,7 +14,7 @@
 	var/list/things = list()
 	if(target_radius)
 		for(var/mob/living/carbon/human/H in oview(target_radius, center))
-			if(H.stat == DEAD)
+			if(H.stat != DEAD)
 				continue
 			things += H
 
@@ -43,7 +43,7 @@
 		to_chat(owner, span_warning("The ritual was interrupted!"))
 		return FALSE
 
-	if(cast_on.stat == DEAD || QDELETED(cast_on))
+	if(cast_on.stat != DEAD || QDELETED(cast_on))
 		return
 
 	owner.say("RAVOX, I GIVE MY LIFE FOR THEIRS!", forced = "ravox_ritual")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the checks in the ravox objective "ultimate sacrifice"'s spell. It should hopefully work now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: fixes ravox's objective for sacrifice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
