### PR TITLE
Athletic Gain XP Change

### DIFF
--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -75,8 +75,6 @@
 		return TRUE
 	if(m_intent == MOVE_INTENT_RUN)
 		var/boon = get_learning_boon(/datum/skill/misc/athletics)
-		var/total =  (STAINT*0.1) * boon
-		message_admins("XP GAINED ATHLETICS = [total], var/boon [boon], STATINT*0.1 = [STAINT*0.1]")
 		adjust_experience(/datum/skill/misc/athletics, (STAINT*0.1) * boon)
 	stamina = CLAMP(stamina+added, 0, maximum_stamina)
 	if(internal_regen && added < 0)

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -41,9 +41,6 @@
 	///This trait specifically affect energy.
 	if(HAS_TRAIT(src, TRAIT_NOENERGY))
 		return TRUE
-	if(m_intent == MOVE_INTENT_RUN)
-		var/boon = get_learning_boon(/datum/skill/misc/athletics)
-		adjust_experience(/datum/skill/misc/athletics, (STAINT*0.02) * boon)
 	energy += added
 	if(energy >= max_energy)
 		energy = max_energy
@@ -76,6 +73,11 @@
 /mob/living/adjust_stamina(added as num, emote_override, force_emote = TRUE, internal_regen = TRUE) //call update_stamina here and set last_fatigued, return false when not enough fatigue left
 	if(HAS_TRAIT(src, TRAIT_NOSTAMINA))
 		return TRUE
+	if(m_intent == MOVE_INTENT_RUN)
+		var/boon = get_learning_boon(/datum/skill/misc/athletics)
+		var/total =  (STAINT*0.1) * boon
+		message_admins("XP GAINED ATHLETICS = [total], var/boon [boon], STATINT*0.1 = [STAINT*0.1]")
+		adjust_experience(/datum/skill/misc/athletics, (STAINT*0.1) * boon)
 	stamina = CLAMP(stamina+added, 0, maximum_stamina)
 	if(internal_regen && added < 0)
 		adjust_energy(added)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Athletic XP was supposed to be gained when the player lost stamina while running, i don't know when this was changed intetionally or not, that meant gained Athletic skills was impossible besides the 0.02 multiplier and it getting ticked once in a while.

Now it ticks everytime you run and the XP gain was increased because even with 15 INT and 0 Athletic Skill draining my entire fatigue bar was not enough to get a single level, now it was increased to a decent value, people with high  INT can hit average with some training while lower INT will have a harder time.

## Why It's Good For The Game

Stamina is something everyone needs, while yes some roles have no athletic skill or a low one, even so round progression is important to their character, this makes feasible to hit something like skilled athletic in a round if you start with 0 skill on that and maybe increasing it from Expert to Master through a 2 hour round if you train hard enough.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
bal: It is not possible to train your athletic skill by running.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
