### PR TITLE
Fixes #3207 by making clay require crafting instead of masonry

### DIFF
--- a/code/datums/pottery_recipes/_base.dm
+++ b/code/datums/pottery_recipes/_base.dm
@@ -16,11 +16,12 @@
 	var/speed_sweetspot = 8
 	///difficulty of recipe
 	var/difficulty = 0
+	var/skill = /datum/skill/craft/crafting
 
 /datum/pottery_recipe/proc/get_delay(mob/user, rotations_per_minute)
 	rotations_per_minute = max(1, rotations_per_minute)
 	var/time = step_to_time[1]
-	var/skill_level = max(1, user?.get_skill_level(/datum/skill/craft/masonry))
+	var/skill_level = max(1, user?.get_skill_level(skill))
 
 	if(rotations_per_minute < speed_sweetspot)
 		time *= ((speed_sweetspot / rotations_per_minute) * 0.25)
@@ -37,31 +38,31 @@
 	return TRUE
 
 /datum/pottery_recipe/proc/update_step(mob/living/user, rotations_per_minute)
-	var/skill_level = max(0, user?.get_skill_level(/datum/skill/craft/masonry))
+	var/skill_level = max(0, user?.get_skill_level(skill))
 	var/success_chance = 25 * ((skill_level - difficulty) + 1)
-	success_chance = clamp(success_chance, 5, 95) // No reason to block pottery with lower masonry skills, just make it not worth the time.
+	success_chance = clamp(success_chance, 5, 95) // No reason to block pottery with lower skills, just make it not worth the time.
 
 	if(rotations_per_minute > speed_sweetspot)
 		success_chance -= (rotations_per_minute - speed_sweetspot) * 2
 	if(!prob(success_chance))
 		if(user.client?.prefs.showrolls)
-			to_chat(user, "<span class='danger'>I've messed up \the [name]. (Success chance: [success_chance]%)</span>")
+			to_chat(user,span_danger("I've messed up \the [name]. (Success chance: [success_chance]%)"))
 			return
-		to_chat(user, "<span class='danger'>I've messed up \the [name].</span>")
+		to_chat(user, span_danger("I've messed up \the [name]"))
 		return
 
 	recipe_steps.Cut(1,2)
 	step_to_time.Cut(1,2)
 	var/amt2raise = (user.STAINT * 0.5) + (difficulty * 2)
 
-	user?.mind?.add_sleep_experience(/datum/skill/craft/masonry, amt2raise, FALSE)
+	user?.mind?.add_sleep_experience(skill, amt2raise, FALSE)
 
 	if(!length(recipe_steps))
 		return TRUE
 
 /datum/pottery_recipe/proc/finish(mob/living/user)
 	var/amt2raise = (user.STAINT * 2) + (difficulty * 10)
-	user?.mind?.add_sleep_experience(/datum/skill/craft/masonry, amt2raise, FALSE)
+	user?.mind?.add_sleep_experience(skill, amt2raise, FALSE)
 	return TRUE
 
 /datum/pottery_recipe/proc/generate_html(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title, issue linked #3207
also makes the code use a variable instead of having the skill datum everywhere

## Why It's Good For The Game

So smiths can make clay stuff without needing masonry

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: making stuff from clay requires crafting now instead of masonry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
