### PR TITLE
Fixes 2 Aspirant Choices

### DIFF
--- a/code/modules/antagonists/villain/aspirant.dm
+++ b/code/modules/antagonists/villain/aspirant.dm
@@ -57,10 +57,14 @@
 
 		if(CHOICE_GUN)
 			owner.special_items["Puffer"] = /obj/item/gun/ballistic/revolver/grenadelauncher/pistol
+			owner.special_items["Puffer Bullets"] = /obj/item/storage/belt/pouch/bullets
+			owner.special_items["Puffet Gunpowder"] = /obj/item/reagent_containers/glass/bottle/aflask
+			aspirant_mob.set_skillrank(/datum/skill/combat/firearms, 6)
 			to_chat(owner, span_notice("I can retrieve my item from a statue, tree or clock by right clicking it."))
 
 		if(CHOICE_BOMB)
 			owner.special_items["Bomb"] = /obj/item/explosive/bottle
+			aspirant_mob.set_skillrank(/datum/skill/craft/bombs, 6)
 			to_chat(owner, span_notice("I can retrieve my item from a statue, tree or clock by right clicking it."))
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Aspirant BOMB choice didn't gave the player bomb skills so you could not make more.

- Aspirant GUN choice didn't gave the player firearm skills so they could not cock the gun nor bullet or gunpowder.

Closes: https://github.com/Monkestation/Vanderlin/issues/3233

## Why It's Good For The Game

1 - A single Bomb is useless if you could have Legendary swordsman.

2 - The puffer is useless if you can't cock it and gunpowder is hard to get as well, bullets are found more easily (the pouch only got 4)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Aspirant that picks the gun option now has gun skills ammo and gunpowder.
fix: Aspirant that picks the bomb option can make bombs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
