### PR TITLE
Steamknight Armor Toggle Refactor

### DIFF
--- a/code/datums/components/steam_storage.dm
+++ b/code/datums/components/steam_storage.dm
@@ -41,12 +41,15 @@
 	current_steam -= amount_used
 	return TRUE
 
-/datum/component/steam_storage/proc/try_proxy_use_steam(mob/proxy, atom/source, amount_used, id, var/emptying = FALSE)
+/datum/component/steam_storage/proc/try_proxy_use_steam(mob/proxy, atom/source, amount_used, id, var/emptying = FALSE, var/check_only = FALSE)
 	if(tank_id && id != tank_id)
 		return FALSE
 
 	if((amount_used > current_steam) && !emptying)
 		return FALSE
+
+	if(check_only)
+		return TRUE
 
 	if(!emptying)
 		current_steam -= amount_used

--- a/code/datums/components/steam_storage.dm
+++ b/code/datums/components/steam_storage.dm
@@ -41,14 +41,17 @@
 	current_steam -= amount_used
 	return TRUE
 
-/datum/component/steam_storage/proc/try_proxy_use_steam(mob/proxy, atom/source, amount_used, id)
+/datum/component/steam_storage/proc/try_proxy_use_steam(mob/proxy, atom/source, amount_used, id, var/emptying = FALSE)
 	if(tank_id && id != tank_id)
 		return FALSE
 
-	if(amount_used > current_steam)
+	if((amount_used > current_steam) && !emptying)
 		return FALSE
 
-	current_steam -= amount_used
+	if(!emptying)
+		current_steam -= amount_used
+	else
+		current_steam = 0
 	return TRUE
 
 /datum/component/steam_storage/proc/try_increase_steam(atom/source, amount_increased)

--- a/code/datums/migrants/waves/heartfell_wave.dm
+++ b/code/datums/migrants/waves/heartfell_wave.dm
@@ -222,7 +222,6 @@
 		if(H.backl && istype(H.backl, /obj/item/clothing/cloak/boiler))
 			var/obj/item/clothing/cloak/boiler/B = H.backl
 			SEND_SIGNAL(B, COMSIG_ATOM_STEAM_INCREASE, rand(500, 900))
-			B.update_armor()
 
 /datum/migrant_role/heartfelt/magos
 	name = "Magos of Heartfelt"

--- a/code/game/rotational_objects/fluid_objects/steam_recharger.dm
+++ b/code/game/rotational_objects/fluid_objects/steam_recharger.dm
@@ -34,7 +34,7 @@
 		return
 
 	if(placed_atom.obj_broken)
-		src.visible_message(span_notice("[placed_atom] is broken."))
+		visible_message(span_notice("[placed_atom] is broken."))
 		remove_placed()
 
 	var/taking_pressure = min(100, input.water_pressure)

--- a/code/game/rotational_objects/fluid_objects/steam_recharger.dm
+++ b/code/game/rotational_objects/fluid_objects/steam_recharger.dm
@@ -33,6 +33,10 @@
 	if(!ispath(input.carrying_reagent, /datum/reagent/steam))
 		return
 
+	if(placed_atom.obj_broken)
+		src.visible_message(span_notice("[placed_atom] is broken."))
+		remove_placed()
+
 	var/taking_pressure = min(100, input.water_pressure)
 	var/obj/structure/water_pipe/picked_provider = pick(input.providers)
 	picked_provider?.taking_from?.use_water_pressure(taking_pressure)

--- a/code/modules/clothing/armor/steam.dm
+++ b/code/modules/clothing/armor/steam.dm
@@ -30,11 +30,9 @@
 	. = ..()
 	AddComponent(/datum/component/item_equipped_movement_rustle, custom_sounds = SFX_POWER_ARMOR_STEP)
 
-/obj/item/clothing/armor/steam/dropped(mob/living/user)
-	var/mob/living/carbon/human/user_carbon = user
-
+/obj/item/clothing/armor/steam/dropped(mob/living/carbon/user)
 	// Locate the boiler in the back slots
-	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user.backr, user.backl)
 	if(B)
 		B.power_off(user)
 

--- a/code/modules/clothing/armor/steam.dm
+++ b/code/modules/clothing/armor/steam.dm
@@ -30,61 +30,12 @@
 	. = ..()
 	AddComponent(/datum/component/item_equipped_movement_rustle, custom_sounds = SFX_POWER_ARMOR_STEP)
 
-/obj/item/clothing/armor/steam/equipped(mob/living/user, slot)
-	update_armor(user, slot)
-	. = ..()
-
 /obj/item/clothing/armor/steam/dropped(mob/living/user)
-	update_armor(user)
+	var/mob/living/carbon/human/user_carbon = user
+
+	// Locate the boiler in the back slots
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	if(B)
+		B.power_off(user)
+
 	. = ..()
-
-/obj/item/clothing/armor/steam/proc/update_armor(mob/living/user, slot)
-	if(QDELETED(user))
-		return
-	var/list/equipped_types = list()
-	var/list/equipped_items = list()
-	for(var/obj/item/clothing/V as anything in user.get_equipped_items(FALSE))
-		if(!is_type_in_list(V, GLOB.steam_armor))
-			continue
-		equipped_types |= V.type
-		equipped_items |= V
-
-	if(length(equipped_types) != length(GLOB.steam_armor))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(!slot || !(slot_flags & slot))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
-		to_chat(user, span_warning("I don't know how to operate [src]!"))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	power_on(user)
-	apply_status_effect(user)
-	for(var/obj/item/clothing/clothing as anything in equipped_items)
-		clothing:power_on(user)
-
-/obj/item/clothing/armor/steam/proc/power_on(mob/living/user)
-	return
-
-/obj/item/clothing/armor/steam/proc/power_off(mob/living/user)
-	return
-
-/obj/item/clothing/armor/steam/proc/apply_status_effect(mob/living/user)
-	user.apply_status_effect(/datum/status_effect/buff/powered_steam_armor)
-
-/obj/item/clothing/armor/steam/proc/remove_status_effect(mob/living/user)
-	user.remove_status_effect(/datum/status_effect/buff/powered_steam_armor)
-

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -42,7 +42,7 @@
 		equipped_items |= V
 
 	if(length(equipped_types) != length(GLOB.steam_armor))
-		to_chat(user, "<span class='warning'>You must be wearing the full steam armor set to operate the [src]...</span>")
+		to_chat(user, span_warning("You must be wearing the full steam armor set to operate the [src]..."))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	//Toggle on/off

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -23,6 +23,7 @@
 	. = ..()
 
 /obj/item/clothing/cloak/boiler/attack_hand_secondary(mob/living/user, params)
+	..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
 

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -53,7 +53,7 @@
 
 	if(do_after(user, windtime SECONDS, src))
 		if(toggling_on)
-			if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 1, "steam_armor"))
+			if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))
 				to_chat(user, span_warning("The [src.name] is out of steam!"))
 				return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 			active = TRUE

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -53,7 +53,7 @@
 
 	if(do_after(user, windtime SECONDS, src))
 		if(toggling_on)
-			if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))
+			if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor", FALSE, TRUE))
 				to_chat(user, span_warning("The [src.name] is out of steam!"))
 				return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 			active = TRUE
@@ -83,7 +83,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/user_carbon = user
 		var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
-	
+
 		if(boots)
 			boots.power_off(user)
 

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -64,7 +64,6 @@
 		else
 			active = FALSE
 			power_off(user)
-			remove_status_effect(user)
 			to_chat(user, span_info("You power down [src], the steam quiets."))
 			user.audible_message(span_info("The [src.name] sputters and hisses, coming to a stop."), runechat_message = TRUE)
 

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -73,7 +73,7 @@
 
 
 /obj/item/clothing/cloak/boiler/proc/power_on(mob/living/carbon/user)
-	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user.shoes)
 	//Stops the speed debuff from the boots
 	if(boots)
 		boots.power_on(user)
@@ -82,7 +82,7 @@
 	return
 
 /obj/item/clothing/cloak/boiler/proc/power_off(mob/living/carbon/user, var/disable = FALSE, var/broken = FALSE)
-	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user.shoes)
 
 	if(boots)
 		boots.power_off(user)

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -45,6 +45,10 @@
 		to_chat(user, span_warning("You must be wearing the full steam armor set to operate the [src]..."))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+	if(src.obj_broken)
+		to_chat(user, span_warning("The [src.name] is broken!"))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	//Toggle on/off
 	var/windtime = 5
 	windtime = max(0, windtime - skill_level)   //Higher engineering = faster activation/deactivation
@@ -68,29 +72,25 @@
 			user.audible_message(span_info("The [src.name] sputters and hisses, coming to a stop."), runechat_message = TRUE)
 
 
-/obj/item/clothing/cloak/boiler/proc/power_on(mob/living/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/user_carbon = user
-		var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
-		//Stops the speed debuff from the boots
-		if(boots)
-			boots.power_on(user)
+/obj/item/clothing/cloak/boiler/proc/power_on(mob/living/carbon/user)
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+	//Stops the speed debuff from the boots
+	if(boots)
+		boots.power_on(user)
 
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(try_steam_usage), override = TRUE)
 	return
 
-/obj/item/clothing/cloak/boiler/proc/power_off(mob/living/user, var/disable = FALSE)
-	if(ishuman(user))
-		var/mob/living/carbon/human/user_carbon = user
-		var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+/obj/item/clothing/cloak/boiler/proc/power_off(mob/living/carbon/user, var/disable = FALSE, var/broken = FALSE)
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
 
-		if(boots)
-			boots.power_off(user)
+	if(boots)
+		boots.power_off(user)
 
 	remove_status_effect(user)
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED) // stop burning steam
 	//Triggers when the player removes the boiler or any steamknight armor without turning the boiler off, penalizes them.
-	if(active && !disable)
+	if(active && !disable && !broken)
 		active = FALSE
 		to_chat(user, span_warning("The [src.name] sputters violently and shuts down forcibly, steam dissipating..."))
 		user.audible_message(span_warning("The [src.name] sputters violently before stopping."), runechat_message = TRUE)
@@ -101,15 +101,27 @@
 		else
 			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor")
 
-	//Triggers when the steamknight armor runs out of steam.
+	//Triggers when the steamknight boiler runs out of steam.
 	if(disable)
 		active = FALSE
 		user.audible_message(span_warning("The [src.name] hisses and sputters, running completely out of steam!"), runechat_message = TRUE)
+
+	//Triggers when steamknight boiler breaks while active.
+	if(broken)
+		active = FALSE
+		to_chat(user, span_warning("The [src.name] breaks!"))
+		user.audible_message(span_warning("The [src.name] sputters violently as you hear a loud crack!"), runechat_message = TRUE)
+		SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor", TRUE)
+
 	return
 
 /obj/item/clothing/cloak/boiler/proc/try_steam_usage(mob/living/source)
 	//Only trigger if the boiler is active
 	if(!active)
+		return FALSE
+	//If the boiler breaks while it is active, forcibly shut it down and remove all the steam inside.
+	if(src.obj_broken)
+		power_off(source, FALSE, TRUE)
 		return FALSE
 
 	if(!SEND_SIGNAL(source, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -12,21 +12,27 @@
 	//you can't unsmelt your boiler Sir Steam Knightus
 	smeltresult = /obj/item/ingot/bronze
 
+	var/active = FALSE
+
 /obj/item/clothing/cloak/boiler/Initialize()
 	. = ..()
 	AddComponent(/datum/component/steam_storage, 1000, 0.5, "steam_armor")
 
-/obj/item/clothing/cloak/boiler/equipped(mob/living/user, slot)
-	update_armor(user, slot)
-	. = ..()
-
 /obj/item/clothing/cloak/boiler/dropped(mob/living/user)
-	update_armor(user)
+	power_off(user)
 	. = ..()
 
-/obj/item/clothing/cloak/boiler/proc/update_armor(mob/living/user, slot)
-	if(QDELETED(user))
+/obj/item/clothing/cloak/boiler/attack_hand_secondary(mob/living/user, params)
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
+
+	//Engineering skill check
+	var/skill_level = user.get_skill_level(/datum/skill/craft/engineering)
+	if(skill_level <= 2)
+		to_chat(user, span_warning("I don't know how to operate [src]!"))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	//Full steam armor check
 	var/list/equipped_types = list()
 	var/list/equipped_items = list()
 	for(var/obj/item/clothing/V as anything in user.get_equipped_items(FALSE))
@@ -36,37 +42,81 @@
 		equipped_items |= V
 
 	if(length(equipped_types) != length(GLOB.steam_armor))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
+		to_chat(user, "<span class='warning'>You must be wearing the full steam armor set to operate the [src]...</span>")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-	if(!slot || !(slot_flags & slot))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
+	//Toggle on/off
+	var/windtime = 5
+	windtime = max(0, windtime - skill_level)   //Higher engineering = faster activation/deactivation
 
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 2)
-		to_chat(user, span_warning("I don't know how to operate [src]!"))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-	power_on(user)
-	apply_status_effect(user)
-	for(var/obj/item/clothing/clothing as anything in equipped_items)
-		clothing:power_on(user)
+	var/toggling_on = !active
+
+	if(do_after(user, windtime SECONDS, src))
+		if(toggling_on)
+			active = TRUE
+			power_on(user)
+			apply_status_effect(user)
+			to_chat(user, span_info("You activate [src], steam hisses as the armor comes to life!"))
+			user.audible_message(span_info("The [src.name] rumbles and lets out a hiss of pressurized steam!"), runechat_message = TRUE)
+		else
+			active = FALSE
+			power_off(user)
+			remove_status_effect(user)
+			to_chat(user, span_info("You power down [src], the steam quiets."))
+			user.audible_message(span_info("The [src.name] sputters and hisses, coming to a stop."), runechat_message = TRUE)
+
 
 /obj/item/clothing/cloak/boiler/proc/power_on(mob/living/user)
-	to_chat(user, span_info("I hear cogs turning and the hissing of steam as [src] powers on!"))
+	var/mob/living/carbon/human/user_carbon = user
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+	//Stops the speed debuff from the boots
+	if(boots)
+		boots.power_on(user)
+
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(try_steam_usage), override = TRUE)
 	return
 
-/obj/item/clothing/cloak/boiler/proc/power_off(mob/living/user)
+/obj/item/clothing/cloak/boiler/proc/power_off(mob/living/user, var/disable = FALSE)
+	var/mob/living/carbon/human/user_carbon = user
+	var/obj/item/clothing/shoes/boots/armor/steam/boots = locate() in list(user_carbon.shoes)
+
+	if(boots)
+		boots.power_off(user)
+
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED) // stop burning steam
+	//Triggers when the player removes the boiler or any steamknight armor without turning the boiler off, penalizes them.
+	if(active && !disable)
+		active = FALSE
+		to_chat(user, span_warning("The [src.name] sputters violently and shuts down forcibly, steam dissipating..."))
+		user.audible_message(span_warning("The [src.name] sputters violently before stopping."), runechat_message = TRUE)
+		var/random_loss = rand(100, 200)
+		//If they can reduce the steam, do it, if it can't it will be set to zero.
+		if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor"))
+			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor", TRUE)
+		else
+			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor")
+
+		if(boots)
+			boots.power_off(user)
+		user.remove_status_effect(/datum/status_effect/buff/powered_steam_armor)
+	//Triggers when the steamknight armor runs out of steam.
+	if(disable)
+		active = FALSE
+		user.audible_message(span_warning("The [src.name] hisses and sputters, running completely out of steam!"), runechat_message = TRUE)
 	return
+
+/obj/item/clothing/cloak/boiler/proc/try_steam_usage(mob/living/source)
+	//Only trigger if the boiler is active
+	if(!active)
+		return FALSE
+
+	if(!SEND_SIGNAL(source, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))
+		//Out of steam, shut down the boiler forcibly
+		power_off(source, TRUE)
+		return FALSE
+
+	return TRUE
+
 
 /obj/item/clothing/cloak/boiler/proc/apply_status_effect(mob/living/user)
 	user.apply_status_effect(/datum/status_effect/buff/powered_steam_armor)

--- a/code/modules/clothing/gloves/steam.dm
+++ b/code/modules/clothing/gloves/steam.dm
@@ -13,61 +13,12 @@
 	smeltresult = /obj/item/ingot/bronze
 	item_weight = 7 * BRONZE_MULTIPLIER
 
-/obj/item/clothing/gloves/plate/steam/equipped(mob/living/user, slot)
-	update_armor(user, slot)
+/obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/user)
+	var/mob/living/carbon/human/user_carbon = user
+
+	// Locate the boiler in the back slots
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	if(B)
+		B.power_off(user)
+
 	. = ..()
-
-/obj/item/clothing/gloves/plate/steam/dropped(mob/living/user)
-	update_armor(user)
-	. = ..()
-
-/obj/item/clothing/gloves/plate/steam/proc/update_armor(mob/living/user, slot)
-	if(QDELETED(user))
-		return
-	var/list/equipped_types = list()
-	var/list/equipped_items = list()
-	for(var/obj/item/clothing/V as anything in user.get_equipped_items(FALSE))
-		if(!is_type_in_list(V, GLOB.steam_armor))
-			continue
-		equipped_types |= V.type
-		equipped_items |= V
-
-	if(length(equipped_types) != length(GLOB.steam_armor))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(!slot || !(slot_flags & slot))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
-		to_chat(user, span_warning("I don't know how to operate [src]!"))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	power_on(user)
-	apply_status_effect(user)
-	for(var/obj/item/clothing/clothing as anything in equipped_items)
-		clothing:power_on(user)
-
-/obj/item/clothing/gloves/plate/steam/proc/power_on(mob/living/user)
-	return
-
-/obj/item/clothing/gloves/plate/steam/proc/power_off(mob/living/user)
-	return
-
-/obj/item/clothing/gloves/plate/steam/proc/apply_status_effect(mob/living/user)
-	user.apply_status_effect(/datum/status_effect/buff/powered_steam_armor)
-
-/obj/item/clothing/gloves/plate/steam/proc/remove_status_effect(mob/living/user)
-	user.remove_status_effect(/datum/status_effect/buff/powered_steam_armor)
-

--- a/code/modules/clothing/gloves/steam.dm
+++ b/code/modules/clothing/gloves/steam.dm
@@ -13,11 +13,9 @@
 	smeltresult = /obj/item/ingot/bronze
 	item_weight = 7 * BRONZE_MULTIPLIER
 
-/obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/user)
-	var/mob/living/carbon/human/user_carbon = user
-
+/obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/carbon/user)
 	// Locate the boiler in the back slots
-	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user.backr, user.backl)
 	if(B)
 		B.power_off(user)
 

--- a/code/modules/clothing/head/helmets/steam.dm
+++ b/code/modules/clothing/head/helmets/steam.dm
@@ -9,11 +9,9 @@
 	item_weight = 9 * BRONZE_MULTIPLIER
 	smeltresult = /obj/item/ingot/bronze
 
-/obj/item/clothing/head/helmet/heavy/steam/dropped(mob/living/user)
-	var/mob/living/carbon/human/user_carbon = user
-
+/obj/item/clothing/head/helmet/heavy/steam/dropped(mob/living/carbon/user)
 	// Locate the boiler in the back slots
-	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user.backr, user.backl)
 	if(B)
 		B.power_off(user)
 

--- a/code/modules/clothing/head/helmets/steam.dm
+++ b/code/modules/clothing/head/helmets/steam.dm
@@ -9,61 +9,12 @@
 	item_weight = 9 * BRONZE_MULTIPLIER
 	smeltresult = /obj/item/ingot/bronze
 
-/obj/item/clothing/head/helmet/heavy/steam/equipped(mob/living/user, slot)
-	update_armor(user, slot)
-	. = ..()
-
 /obj/item/clothing/head/helmet/heavy/steam/dropped(mob/living/user)
-	update_armor(user)
+	var/mob/living/carbon/human/user_carbon = user
+
+	// Locate the boiler in the back slots
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	if(B)
+		B.power_off(user)
+
 	. = ..()
-
-/obj/item/clothing/head/helmet/heavy/steam/proc/update_armor(mob/living/user, slot)
-	if(QDELETED(user))
-		return
-	var/list/equipped_types = list()
-	var/list/equipped_items = list()
-	for(var/obj/item/clothing/V as anything in user.get_equipped_items(FALSE))
-		if(!is_type_in_list(V, GLOB.steam_armor))
-			continue
-		equipped_types |= V.type
-		equipped_items |= V
-
-	if(length(equipped_types) != length(GLOB.steam_armor))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(!slot || !(slot_flags & slot))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
-		to_chat(user, span_warning("I don't know how to operate [src]!"))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	power_on(user)
-	apply_status_effect(user)
-	for(var/obj/item/clothing/clothing as anything in equipped_items)
-		clothing:power_on(user)
-
-/obj/item/clothing/head/helmet/heavy/steam/proc/power_on(mob/living/user)
-	return
-
-/obj/item/clothing/head/helmet/heavy/steam/proc/power_off(mob/living/user)
-	return
-
-/obj/item/clothing/head/helmet/heavy/steam/proc/apply_status_effect(mob/living/user)
-	user.apply_status_effect(/datum/status_effect/buff/powered_steam_armor)
-
-/obj/item/clothing/head/helmet/heavy/steam/proc/remove_status_effect(mob/living/user)
-	user.remove_status_effect(/datum/status_effect/buff/powered_steam_armor)
-

--- a/code/modules/clothing/shoes/steam.dm
+++ b/code/modules/clothing/shoes/steam.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/shoes/boots/armor/steam
 	name = "steamknight boots"
-
+	desc = "Part of the the steamknight armor. Requires knowledge in engineering to operate."
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
 	icon_state = "steamknight_boots"

--- a/code/modules/clothing/shoes/steam.dm
+++ b/code/modules/clothing/shoes/steam.dm
@@ -12,11 +12,9 @@
 	slowdown = 1.5
 	item_weight = 6 * BRONZE_MULTIPLIER
 
-/obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/user)
-	var/mob/living/carbon/human/user_carbon = user
-
+/obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/carbon/user)
 	// Locate the boiler in the back slots
-	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user.backr, user.backl)
 	if(B)
 		B.power_off(user)
 

--- a/code/modules/clothing/shoes/steam.dm
+++ b/code/modules/clothing/shoes/steam.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/shoes/boots/armor/steam
 	name = "steamknight boots"
-	desc = "Part of the the steamknight armor. Requires knowledge in engineering to operate."
+
 	icon = 'icons/roguetown/clothing/steamknight.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/steamknight_onmob.dmi'
 	icon_state = "steamknight_boots"
@@ -12,73 +12,20 @@
 	slowdown = 1.5
 	item_weight = 6 * BRONZE_MULTIPLIER
 
-	smeltresult = /obj/item/ingot/bronze
-
-/obj/item/clothing/shoes/boots/armor/steam/equipped(mob/living/user, slot)
-	update_armor(user)
-	. = ..()
-
-/obj/item/clothing/shoes/boots/armor/steam/proc/try_steam_usage(mob/living/source)
-	if(!SEND_SIGNAL(source, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))
-		update_armor(source)
-	return TRUE
-
 /obj/item/clothing/shoes/boots/armor/steam/dropped(mob/living/user)
-	update_armor(user)
+	var/mob/living/carbon/human/user_carbon = user
+
+	// Locate the boiler in the back slots
+	var/obj/item/clothing/cloak/boiler/B = locate(/obj/item/clothing/cloak/boiler) in list(user_carbon.backr, user_carbon.backl)
+	if(B)
+		B.power_off(user)
+
 	. = ..()
-
-/obj/item/clothing/shoes/boots/armor/steam/proc/update_armor(mob/living/user, slot)
-	if(QDELETED(user))
-		return
-	var/list/equipped_types = list()
-	var/list/equipped_items = list()
-	for(var/obj/item/clothing/V as anything in user.get_equipped_items(FALSE))
-		if(!is_type_in_list(V, GLOB.steam_armor))
-			continue
-		equipped_types |= V.type
-		equipped_items |= V
-
-	if(length(equipped_types) != length(GLOB.steam_armor))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(!slot || !(slot_flags & slot))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	if(user.get_skill_level(/datum/skill/craft/engineering) <= 3)
-		to_chat(user, span_warning("I don't know how to operate [src]!"))
-		power_off(user)
-		remove_status_effect(user)
-		for(var/obj/item/clothing/clothing as anything in equipped_items)
-			clothing:power_off(user)
-		return
-
-	power_on(user)
-	apply_status_effect(user)
-	for(var/obj/item/clothing/clothing as anything in equipped_items)
-		clothing:power_on(user)
 
 /obj/item/clothing/shoes/boots/armor/steam/proc/power_on(mob/living/user)
 	slowdown = 0
 	user.update_equipment_speed_mods()
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(try_steam_usage), override = TRUE)
-	return
 
 /obj/item/clothing/shoes/boots/armor/steam/proc/power_off(mob/living/user)
 	slowdown = 1.5
 	user.update_equipment_speed_mods()
-	return
-
-/obj/item/clothing/shoes/boots/armor/steam/proc/apply_status_effect(mob/living/user)
-	user.apply_status_effect(/datum/status_effect/buff/powered_steam_armor)
-
-/obj/item/clothing/shoes/boots/armor/steam/proc/remove_status_effect(mob/living/user)
-	user.remove_status_effect(/datum/status_effect/buff/powered_steam_armor)
-

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -165,4 +165,3 @@
 	if(H.backr && istype(H.backr, /obj/item/clothing/cloak/boiler))
 		var/obj/item/clothing/cloak/boiler/B = H.backr
 		SEND_SIGNAL(B, COMSIG_ATOM_STEAM_INCREASE, 1000)
-		B.update_armor()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Scrap the old system but of course keeping the signals, now instead of auto activating it, you need to right click the boiler while you have the full set of steamknight armor to turn it on, pass the enginner skill check, then it has a delay based of the player enginner skill.

If you remove the boiler or part of the armor without turning off you will lose a rng amount of steam between 100-200 so turn off your armor.

You can't charge steam items that are broken, at the moment only the boiler can break if the user keeps hitting it with their sword. (Drill auto destroy itself and the harpoon can't be hit)

## Why It's Good For The Game

Even tho it lacks sprite, i believe this is way more simple both in terms of code and gameplay, right click the boiler to both turn it on and off, it also makes the code way more cleaner and easier to understand, now it is prob possible to put the unpowered and powered FOV but i will leave that to another PR.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
refactor: How the Steamknight Armor turns off and on
qol: To turn the steamknight armor on or off you can right click the boiler
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
