### PR TITLE
raise secondary antag chance when a maniac/aspirant rolls

### DIFF
--- a/code/modules/events/antagonist/solo/minor/aspirant.dm
+++ b/code/modules/events/antagonist/solo/minor/aspirant.dm
@@ -32,7 +32,7 @@
 		/datum/round_event_control/antagonist/solo/werewolf,
 		/datum/round_event_control/antagonist/solo/zizo_cult
 	)
-	secondary_prob = 60
+	secondary_prob = 90
 	weight = 8
 
 	typepath = /datum/round_event/antagonist/solo/aspirant

--- a/code/modules/events/antagonist/solo/minor/maniac.dm
+++ b/code/modules/events/antagonist/solo/minor/maniac.dm
@@ -37,7 +37,7 @@
 		/datum/round_event_control/antagonist/solo/werewolf,
 		/datum/round_event_control/antagonist/solo/zizo_cult
 	)
-	secondary_prob = 60
+	secondary_prob = 90
 	typepath = /datum/round_event/antagonist/solo/maniac
 
 /datum/round_event_control/antagonist/solo/maniac/canSpawnEvent(players_amt, gamemode, fake_check)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
-This does not affect lowpop antag rolls, you need to have over 50 pop for a secondary antagonist to roll.

-Its a bit weird that you have highpop rounds with 1-2 maniacs or just 1 aspirant when these are supposedly minor antags that should spawn alongside the major ones. (it was like this before)

## Why It's Good For The Game

Proper antags like a zizo cult or vampires can be fun to have around, it seems like half the rounds are aspirant/maniac only rounds nowadays

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: more chance to roll secondary antag if the storyteller rolls maniac or aspirant in highpop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
