### PR TITLE
Fixes Minotaur dissapearing and Nerf it

### DIFF
--- a/code/datums/ai/subtrees/minotaur_target.dm
+++ b/code/datums/ai/subtrees/minotaur_target.dm
@@ -28,7 +28,6 @@
 				boss.playsound_local(get_turf(boss), 'sound/misc/explode/explosionfar (1).ogg', 50, TRUE)
 				new /obj/effect/temp_visual/minotaur_rage(get_turf(boss))
 				controller.set_blackboard_key(BB_MINOTAUR_ENRAGE_BONUS, 15)
-				boss.add_atom_colour(rgb(255, 0, 0, 50), TEMPORARY_COLOUR_PRIORITY)
 			else if(boss.health < boss.maxHealth * 0.6 && controller.blackboard[BB_MINOTAUR_PHASE] < 2)
 				controller.set_blackboard_key(BB_MINOTAUR_PHASE, 2)
 				boss.visible_message("<span class='warning'>[boss] stomps the ground in anger, its eyes burning with hatred!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/minotaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/minotaur.dm
@@ -37,7 +37,7 @@
 	retreat_health = 0
 
 	attack_sound = list('sound/combat/wooshes/blunt/wooshhuge (1).ogg','sound/combat/wooshes/blunt/wooshhuge (2).ogg','sound/combat/wooshes/blunt/wooshhuge (3).ogg')
-	dodgetime = 0
+	dodgetime = 50
 	aggressive = 1
 //	stat_attack = UNCONSCIOUS
 	remains_type = /obj/item/weapon/axe/battle


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

 - Minotaur was dissapearing because of once it hit it's third stage, an atom colour was added, removed because this sprite will be probably changed in the future. (From what i could tell from my tests this was it, i managed to kill a minotaur without they turning invisible)

- Decreased chance of dodge of the minotaur, i was trying to hit the minotaur as WW with claws, not a single hit was going through, now it got the same dodge chance as the troll.

## Why It's Good For The Game

- Fix

- By no means it is weaker now but you can actually hit as melee user instead of depending of putting them in a corner or using ranged stuff.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Minotaur dissapearing mid fight.
bal: Reduces the chances of the minotaur dodging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
