### PR TITLE
Fix the Werewolf Younglig sprite not appearing even for Younglings who turned into a werewolf

### DIFF
--- a/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
@@ -86,11 +86,12 @@
 					to_chat(H, span_warning("Daylight shines around me... the curse begins to fade."))
 					COOLDOWN_START(src, message_cooldown, 10 SECONDS)
 
-/datum/antagonist/werewolf/proc/generate_werewolf(mob/living/user)
-	var/mob/living/carbon/human/H = user
+/datum/antagonist/werewolf/proc/generate_werewolf(mob/living/carbon/human/user)
+	if(!istype(user))
+		return
 	var/mob/living/carbon/human/species/werewolf/W = new (get_turf(user))
 
-	if(H.age == AGE_CHILD)
+	if(user.age == AGE_CHILD)
 		W.age = AGE_CHILD
 
 	W.set_patron(user.patron)

--- a/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
@@ -87,7 +87,11 @@
 					COOLDOWN_START(src, message_cooldown, 10 SECONDS)
 
 /datum/antagonist/werewolf/proc/generate_werewolf(mob/living/user)
+	var/mob/living/carbon/human/H = user
 	var/mob/living/carbon/human/species/werewolf/W = new (get_turf(user))
+
+	if(H.age == AGE_CHILD)
+		W.age = AGE_CHILD
 
 	W.set_patron(user.patron)
 	W.limb_destroyer = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title, for some reason once they gain the werewolf species the Age is not carried even tho the gender is.

## Why It's Good For The Game

Fix.

Size difference for those wondering:

<img width="223" height="132" alt="werewolf_SIZE" src="https://github.com/user-attachments/assets/8770bd0c-e78f-4571-8ff7-9a85b0748ba4" />


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Younglings that turn into werewolves will have their proper WW sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
