### PR TITLE
Great Axe Balance

### DIFF
--- a/code/game/objects/items/weapons/melee/axes.dm
+++ b/code/game/objects/items/weapons/melee/axes.dm
@@ -422,7 +422,8 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/axesmaces
 	blade_dulling = DULLING_BASHCHOP
-	wdefense = MEDIOCRE_PARRY
+	wdefense = AVERAGE_PARRY 
+	wbalance = EASY_TO_DODGE
 
 /obj/item/weapon/greataxe/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/weapons/melee/axes.dm
+++ b/code/game/objects/items/weapons/melee/axes.dm
@@ -400,8 +400,8 @@
 	reach = 2
 
 /obj/item/weapon/greataxe
-	force = 15
-	force_wielded = 30
+	force = DAMAGE_AXE
+	force_wielded = DAMAGE_HEAVYAXE_WIELD
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/spear/bash) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/axe/cut/battle/greataxe, /datum/intent/axe/chop/battle/greataxe,  /datum/intent/spear/bash)
 	name = "greataxe"
@@ -436,8 +436,8 @@
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/weapon/greataxe/steel
-	force = 15
-	force_wielded = 30
+	force = DAMAGE_AXE
+	force_wielded = DAMAGE_HEAVYAXE_WIELD 
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/spear/bash) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/axe/cut/battle/greataxe, /datum/intent/axe/chop/battle/greataxe,  /datum/intent/spear/bash)
 	name = "steel greataxe"
@@ -449,14 +449,15 @@
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/weapon/greataxe/steel/doublehead
-	force = 15
-	force_wielded = 35
+	force = DAMAGE_AXE
+	force_wielded = DAMAGE_HEAVYAXE_WIELD 
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/spear/bash) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(/datum/intent/axe/cut/battle/greataxe, /datum/intent/axe/chop/battle/greataxe,  /datum/intent/spear/bash)
 	name = "double-headed steel greataxe"
 	desc = "A steel great axe with a wicked double-bladed head. Perfect for cutting either men or trees into stumps.."
 	icon_state = "doublegreataxe"
 	icon = 'icons/roguetown/weapons/64.dmi'
+	max_blade_int = 400
 	minstr = 12
 
 /obj/item/weapon/greataxe/steel/doublehead/graggar
@@ -464,8 +465,8 @@
 	desc = "A greataxe who's edge thrums with the motive force, violence, oh, sweet violence!"
 	icon_state = "graggargaxe"
 	blade_dulling = DULLING_BASHCHOP
-	force = 20
-	force_wielded = 40
+	force = DAMAGE_AXE
+	force_wielded = DAMAGE_HEAVYAXE_WIELD 
 	icon = 'icons/roguetown/weapons/64.dmi'
 
 /obj/item/weapon/greataxe/dreamscape

--- a/code/game/objects/items/weapons/melee/axes.dm
+++ b/code/game/objects/items/weapons/melee/axes.dm
@@ -422,7 +422,7 @@
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/axesmaces
 	blade_dulling = DULLING_BASHCHOP
-	wdefense = 6
+	wdefense = MEDIOCRE_PARRY
 
 /obj/item/weapon/greataxe/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Greataxes who had more than 30 Force from wielded got reduced to 30, non wield great axe force got buffed from 15 to 20, some as well got their integrity max increased.

Greataxe wdefense was reduced from 6(Above ULTMATE_PARRY) to 2 Average Parry.

Greataxe dodge chance is now set to EASY_TO_DODGE since it was not set it was most likely DODGE_CHANCE_NORMAL.

## Why It's Good For The Game

Greatswords and Halberds got nerfed from 35 to 30 for this same reason, while they are not craftable some roles can spawn with it and an admin may spawn the weapon without knowing how strong it is.

It is a greataxe with reach 2 in two intents, you hit hard from far without the need to charge unlike polearms, it is not a parry weapon but instead a strong range weapon that chop your limbs off.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
bal: Greataxe got now a max of 30 force just like Greatswords and Halberds
bal: Greataxe wdefense  changed from 6(Above ULTIMATE_PARRY) to 2 Average Parry
bal: Greataxe is not easier to dodge
bal: Greataxe non wielded force increased from 15 to 20
bal: Some Greataxes integrity got buffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
