### PR TITLE
Very minor changes to door access

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -3721,6 +3721,7 @@
 /obj/structure/closet/crate/crafted_closet/dark,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
+/obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/blocks/newstone/alt,
 /area/rogue/indoors/town/church)
 "cfq" = (
@@ -4762,8 +4763,8 @@
 /area/rogue/under/town/caverogue)
 "cOf" = (
 /obj/structure/door,
-/obj/effect/mapping_helpers/access/keyset/church/grave,
 /obj/effect/mapping_helpers/access/locker,
+/obj/effect/mapping_helpers/access/keyset/church/general,
 /turf/open/floor/cobble,
 /area/rogue/indoors/town/church)
 "cOg" = (
@@ -11617,7 +11618,7 @@
 	name = "dungeoneer's quarters"
 	},
 /obj/effect/mapping_helpers/access/locker,
-/obj/effect/mapping_helpers/access/keyset/manor/general,
+/obj/effect/mapping_helpers/access/keyset/manor/dungeon,
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/manor/dungeoneer)
 "gKv" = (
@@ -12177,10 +12178,10 @@
 /area/rogue/outdoors/river)
 "heH" = (
 /obj/effect/mapping_helpers/access/locker,
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/structure/door/violet{
 	name = "Archivist's Chambers"
 	},
+/obj/effect/mapping_helpers/access/keyset/manor/archive,
 /turf/open/floor/tile/checkeralt,
 /area/rogue/indoors/town/manor/archivist)
 "heJ" = (
@@ -17289,11 +17290,11 @@
 /turf/open/floor/cobble,
 /area/rogue/under/dungeon)
 "kjy" = (
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/structure/door/violet{
 	name = "Royal Guard's Storage"
 	},
 /obj/effect/mapping_helpers/access/locker,
+/obj/effect/mapping_helpers/access/keyset/manor/atarms,
 /turf/open/floor/cobble,
 /area/rogue/under/town/basement)
 "kjC" = (
@@ -18904,10 +18905,10 @@
 /area/rogue/indoors/town/garrison)
 "ltJ" = (
 /obj/effect/mapping_helpers/access/locker,
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/structure/door/violet{
 	name = "Archivist's Chambers"
 	},
+/obj/effect/mapping_helpers/access/keyset/manor/archive,
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/manor/library)
 "luj" = (
@@ -21421,8 +21422,8 @@
 /obj/structure/door/violet{
 	name = "Royal Guard's Chambers"
 	},
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/effect/mapping_helpers/access/locker,
+/obj/effect/mapping_helpers/access/keyset/manor/atarms,
 /turf/open/floor/woodturned/nosmooth,
 /area/rogue/indoors/town/manor/knight/knight2)
 "mZl" = (
@@ -23971,8 +23972,8 @@
 /obj/structure/door/violet{
 	name = "Royal Guard's Chambers"
 	},
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/effect/mapping_helpers/access/locker,
+/obj/effect/mapping_helpers/access/keyset/manor/atarms,
 /turf/open/floor/woodturned/nosmooth,
 /area/rogue/indoors/town/manor/knight/knight1)
 "oBI" = (
@@ -27451,10 +27452,10 @@
 /area/rogue/indoors/town/church/chapel)
 "qOn" = (
 /obj/effect/mapping_helpers/access/locker,
-/obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/structure/door/window{
 	name = "Archives"
 	},
+/obj/effect/mapping_helpers/access/keyset/manor/archive,
 /turf/open/floor/blocks,
 /area/rogue/indoors/town/manor/library)
 "qOK" = (
@@ -27938,6 +27939,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
+/obj/item/key/graveyard,
 /obj/item/key/graveyard,
 /obj/item/key/graveyard,
 /turf/open/floor/blocks/newstone/alt,
@@ -29015,7 +29017,7 @@
 /area/rogue/indoors/town)
 "rMu" = (
 /obj/structure/door/iron/bars,
-/obj/effect/mapping_helpers/access/keyset/church/grave,
+/obj/effect/mapping_helpers/access/keyset/church/general,
 /turf/open/floor/cobblerock,
 /area/rogue/outdoors/town)
 "rME" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title
here are the changes
<img width="375" height="335" alt="image" src="https://github.com/user-attachments/assets/2d0de16b-f1f9-4355-827c-7561be30a5a8" />
dungeoneer's quarters uses dungeon lock
<img width="392" height="355" alt="image" src="https://github.com/user-attachments/assets/2da28570-5dec-43c0-bfae-e3225face538" />
royal knight quarters uses atarms lock
<img width="255" height="314" alt="image" src="https://github.com/user-attachments/assets/fa5e2ccd-a4aa-4894-ac65-37cc1b70cba3" />
archives and archivist room uses archives lock
<img width="338" height="329" alt="image" src="https://github.com/user-attachments/assets/413c4044-2cee-411c-868e-69a3b8fa0435" />
gravetender storage has general church lock now, the gravetender rooms still use the graveyard key
<img width="276" height="359" alt="image" src="https://github.com/user-attachments/assets/e8649fd2-7474-46db-b3c3-35aa7893289e" />
graveyard uses normal church lock aswell, the crypts are unchanged

## Why It's Good For The Game

I think these locks make more sense

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: tweaked locks for keep and church
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
