### PR TITLE
Vampire armor consistency changes 

### DIFF
--- a/code/modules/antagonists/villain/vampire/objects/bloodpool.dm
+++ b/code/modules/antagonists/villain/vampire/objects/bloodpool.dm
@@ -368,7 +368,7 @@
 	new /obj/item/clothing/pants/platelegs/vampire (bloodpool.loc)
 	new /obj/item/clothing/gloves/chain/vampire (bloodpool.loc)
 	new /obj/item/clothing/armor/chainmail/hauberk/vampire (bloodpool.loc)
-	new /obj/item/clothing/armor/cuirass/vampire (bloodpool.loc)
+	new /obj/item/clothing/armor/plate/vampire (bloodpool.loc)
 	new /obj/item/clothing/shoes/boots/armor/vampire (bloodpool.loc)
 	new /obj/item/clothing/head/helmet/heavy/vampire (bloodpool.loc)
 	creation_point.visible_message(span_notice("A complete set of armor materializes from the crimson crucible."))

--- a/code/modules/clothing/armor/chainmail.dm
+++ b/code/modules/clothing/armor/chainmail.dm
@@ -59,7 +59,7 @@
 
 //................ Ancient Haubergon ............... //
 /obj/item/clothing/armor/chainmail/hauberk/vampire
-	name = "ancient hauberk"
+	name = "ancient haubergeon"
 	desc = "A style of armor long out of use, rests easy on the shoulders. Has sleeves but doesn't cover the legs."
 	icon_state = "vunder"
 	sellprice = VALUE_STEEL_ARMOR_FINE

--- a/code/modules/clothing/armor/cuirass.dm
+++ b/code/modules/clothing/armor/cuirass.dm
@@ -91,3 +91,13 @@
 	max_integrity = INTEGRITY_POOR
 	item_weight = 5.5 * COPPER_MULTIPLIER
 
+/obj/item/clothing/armor/cuirass/vampire
+	name = "ancient plate"
+	desc = "A ornate, ceremonial plate cuirass of considerable age."
+	icon_state = "vplate"
+
+	armor_class = AC_MEDIUM
+	armor = ARMOR_PLATE_GOOD
+	body_parts_covered = COVERAGE_TORSO
+	prevent_crits = ALL_CRITICAL_HITS_VAMP
+	item_weight = 5.5 * IRON_MULTIPLIER

--- a/code/modules/clothing/armor/cuirass.dm
+++ b/code/modules/clothing/armor/cuirass.dm
@@ -91,13 +91,3 @@
 	max_integrity = INTEGRITY_POOR
 	item_weight = 5.5 * COPPER_MULTIPLIER
 
-/obj/item/clothing/armor/cuirass/vampire
-	name = "ancient plate"
-	desc = "A ornate, ceremonial plate cuirass of considerable age."
-	icon_state = "vplate"
-
-	armor_class = AC_MEDIUM
-	armor = ARMOR_PLATE_GOOD
-	body_parts_covered = COVERAGE_TORSO
-	prevent_crits = ALL_CRITICAL_HITS_VAMP
-	item_weight = 5.5 * IRON_MULTIPLIER

--- a/code/modules/clothing/armor/plate.dm
+++ b/code/modules/clothing/armor/plate.dm
@@ -32,6 +32,14 @@
 	armor = ARMOR_PLATE_BAD
 	max_integrity = INTEGRITY_STRONG
 
+/obj/item/clothing/armor/plate/vampire
+	name = "ancient plate"
+	desc = "An ornate, ceremonial plate of considerable age."
+	icon_state = "vplate"
+
+	armor = ARMOR_PLATE_GOOD
+	prevent_crits = ALL_CRITICAL_HITS_VAMP
+
 //................ Full Plate Armor ............... //
 /obj/item/clothing/armor/plate/full
 	name = "plate armor"

--- a/code/modules/clothing/gloves/chain.dm
+++ b/code/modules/clothing/gloves/chain.dm
@@ -38,5 +38,6 @@
 
 /obj/item/clothing/gloves/chain/vampire
 	name = "ancient ceremonial gloves"
+	desc = "A weathered gauntlet with an ancient design."
 	icon_state = "vgloves"
 	item_weight = 6 * STEEL_MULTIPLIER

--- a/code/modules/clothing/head/helmets/heavy.dm
+++ b/code/modules/clothing/head/helmets/heavy.dm
@@ -73,15 +73,12 @@
 // Vampire Lord is no longer as OP, but the armor should protect against dreaded stabs or it makes the vitae spent on it pointless.
 /obj/item/clothing/head/helmet/heavy/vampire
 	name = "savoyard"
-	desc = "A terrifying yet crude iron helmet shaped like a humen skull. Commands the inspiring terror of inhumen tyrants from yils past."
+	desc = "A terrifying yet crude helmet shaped like a humen skull. Commands the inspiring terror of inhumen tyrants from yils past."
 	icon_state = "savoyard"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
-	smeltresult = /obj/item/ingot/iron
-	sellprice = VALUE_IRON_HELMET + BONUS_VALUE_MODEST
 
 	prevent_crits = ALL_CRITICAL_HITS_VAMP
-	max_integrity = INTEGRITY_STRONG
-	item_weight = 6 * IRON_MULTIPLIER
+	max_integrity = INTEGRITY_STRONGEST // steel
 	body_parts_covered = HEAD_NECK
 	block2add = FOV_BEHIND
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
-Turns out some of the vampire lord's armor was iron..? It should all be steel now.

-The vampire **plate** was actually a cuirass for some reason, changed to half plate.
<img width="79" height="75" alt="Capture d'écran 2025-09-19 144943" src="https://github.com/user-attachments/assets/0595f005-c1bb-4d7e-9197-5e9cb34cd079" /> how is this a cuirass

-The ancient hauberk is a haubergeon.

-The ancient gloves have a description now.


## Why It's Good For The Game

Consistant armor for the VL.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added descriptions for the ancient gauntlet, ancient hauberk renamed to ancient haubergeon
balance: Vampire plate is now a half-plate like the sprite.
balance: Savoyard now has steel durability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
