### PR TITLE
Parry Balance

### DIFF
--- a/code/modules/mob/living/parry.dm
+++ b/code/modules/mob/living/parry.dm
@@ -172,7 +172,7 @@
 			skill_modifier -= (attacker_skill * 20)
 
 			if(master.wbalance > 0 && user.STASPD > src.STASPD)
-				skill_modifier -= (master.wbalance * ((user.STASPD - src.STASPD) * 10))
+				skill_modifier -= ((user.STASPD - src.STASPD) * 10)
 		else
 			attacker_skill = user.get_skill_level(/datum/skill/combat/unarmed)
 			skill_modifier -= (attacker_skill * 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

While i was doing some local tests, i realized that if someone has more speed and the same skill level and uses a steel dagger, their opponent would have a 5% chance to parry, while the dagger user would have a 20%, still most dagger users are the dodge type, so they have a 80-95% dodge chance, while their opponent has a 5% parry chance even with a kite shield on the same level as the dagger.

Why was that the case? Because the balance of the dagger matters for parry, the same variable that is used to roll for dodge also called wbalance, impacts on how hard it is to parry that weapon if the user is speedier than the other, since the steel dagger is VERY_HARD_TO_DODGE, it would stack up the multiplier to the max, how does that make any sense?, i don't know.

This keeps the speed impact on the parry as i can see someone being fast impacting how difficult it is to parry.

## Why It's Good For The Game

Dagger already got an advantage, it is called being fast , consuming low stamina and having a good AP of 30 (on stab intent), i don't see how a shield user would somehow have a 5% chance to parry a dagger, this change means if you got a good weapon for parrying, you will have a great chance example, kite shield would have a 70% chance, saber 50% (on the same skill level), while even so just the overwhelming speed of the attacks can still have go through that parry.

If the player is using a mace, greatsword, most of the swords(non rare), axes, they will have the 30-40% parry chance

It is essentially a SPD nerf, since just having 1 stat above their opponent would essentially reduce their parry chances by alot.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
bal: wbalance does not impact the parry chance, only the dodge chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
