### PR TITLE
Port: modified omniwounds from Azure

### DIFF
--- a/code/__DEFINES/medical.dm
+++ b/code/__DEFINES/medical.dm
@@ -95,3 +95,10 @@
 #define WOUND_SEVERITY_FATAL 5
 /// This wound has werewolf infection
 #define WOUND_SEVERITY_BIOHAZARD 6
+
+/// This is used as a reference point for dynamic wounds, so it's better off as a define.
+#define ARTERY_LIMB_BLEEDRATE 20
+/// How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
+#define CONSTITUTION_BLEEDRATE_MOD 0.1
+/// The CON value up to which we get a bleedrate reduction.
+#define CONSTITUTION_BLEEDRATE_CAP 15

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -501,13 +501,6 @@ will handle it, but:
 	if(centered)
 		. += world.icon_size
 
-/proc/can_embed(obj/item/weapon)
-	if(HAS_TRAIT(weapon, TRAIT_NODROP) || HAS_TRAIT(weapon, TRAIT_NOEMBED))
-		return FALSE
-	if(!weapon.embedding?.embed_chance)
-		return FALSE
-	return TRUE
-
 /*
 Checks if that loc and dir has an item on the wall
 */

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -610,7 +610,7 @@
 			next_attack_msg.Cut()
 			if(HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS))
 				var/datum/wound/crit_wound  = simple_woundcritroll(user.used_intent.blade_class, newforce, user, hitlim)
-				if(crit_wound.should_embed(I))
+				if(crit_wound?.should_embed(I))
 					// throw_alert("embeddedobject", /atom/movable/screen/alert/embeddedobject)
 					simple_add_embedded_object(I, silent = FALSE, crit_message = TRUE)
 					src.grabbedby(user, 1, item_override = I)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -610,7 +610,7 @@
 			next_attack_msg.Cut()
 			if(HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS))
 				var/datum/wound/crit_wound  = simple_woundcritroll(user.used_intent.blade_class, newforce, user, hitlim)
-				if(should_embed_weapon(crit_wound, I))
+				if(crit_wound.should_embed(I))
 					// throw_alert("embeddedobject", /atom/movable/screen/alert/embeddedobject)
 					simple_add_embedded_object(I, silent = FALSE, crit_message = TRUE)
 					src.grabbedby(user, 1, item_override = I)

--- a/code/datums/wounds/arteries.dm
+++ b/code/datums/wounds/arteries.dm
@@ -6,7 +6,7 @@
 	sound_effect = 'sound/combat/crit.ogg'
 	whp = 50
 	sewn_whp = 20
-	bleed_rate = 25
+	bleed_rate = ARTERY_LIMB_BLEEDRATE
 	sewn_bleed_rate = 0.2
 	clotting_threshold = null
 	sewn_clotting_threshold = null

--- a/code/datums/wounds/bites.dm
+++ b/code/datums/wounds/bites.dm
@@ -11,8 +11,8 @@
 	can_sew = FALSE
 	can_cauterize = FALSE
 	passive_healing = 0.5
-
 	werewolf_infection_probability = 15
+	associated_bclasses = list(BCLASS_BITE)
 
 /datum/wound/bite/can_apply_to_bodypart(obj/item/bodypart/affected)
 	. = ..()
@@ -23,7 +23,6 @@
 	name = "nip"
 	whp = 15
 	woundpain = 3
-
 	werewolf_infection_probability = 10
 
 /datum/wound/bite/large
@@ -41,5 +40,36 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	passive_healing = 0
-
 	werewolf_infection_probability = 20
+
+// Bite dynamic wounds
+// Vaguely: Hella painful. Hella bleedy. Armor is very effective. Similar to lashing in this way.
+/datum/wound/dynamic/bite
+	name = "bite"
+	bleed_rate = 0
+	sewn_bleed_rate = 0
+	clotting_threshold = null
+	sewn_clotting_threshold = null
+	whp = 30
+	woundpain = 6
+	sew_threshold = 50
+	mob_overlay = "cut"
+	can_sew = TRUE
+	can_cauterize = TRUE
+	passive_healing = 0.5
+	associated_bclasses = list(BCLASS_BITE)
+
+	severity_names = list(
+		"shallow" = 3,
+		"deep" = 8,
+		"gnarly" = 12,
+		"lethal" = 15,
+		"impossible" = 20,
+	)
+	upgrade_bleed_rate = 0.2
+	upgrade_bleed_clamp = 1
+	upgrade_bleed_clam_armor = 3
+	upgrade_whp = 0.1
+	upgrade_sew_threshold = 1
+	upgrade_pain = 1
+	protected_bleed_clamp = 5

--- a/code/datums/wounds/bruises.dm
+++ b/code/datums/wounds/bruises.dm
@@ -10,7 +10,12 @@
 	can_cauterize = FALSE
 	passive_healing = 0.5
 
-	werewolf_infection_probability = 0
+	associated_bclasses = list(
+		BCLASS_BLUNT,
+		BCLASS_SMASH,
+		BCLASS_PUNCH,
+		BCLASS_TWIST,
+	)
 
 /datum/wound/bruise/can_apply_to_bodypart(obj/item/bodypart/affected)
 	. = ..()
@@ -31,3 +36,46 @@
 	clotting_threshold = 0.3
 	sew_threshold = 75
 	woundpain = 25
+
+/datum/wound/bruise/woundheal
+	name = "healed hematoma"
+	whp = 240	//2 mins passively, quicker w/ a miracle
+	bleed_rate = 0
+	clotting_rate = 0
+	clotting_threshold = 0
+	passive_healing = 1
+	woundpain = 100	//lesser miracles reduce woundpain, presumably the receiver will have this on them
+	healable_by_miracles = FALSE
+
+// Bruise dynamic wounds
+// Vaguely: Hella painful. No bleeding. No armor interactions. Every hit also increases its self heal by a little bit.
+/datum/wound/dynamic/bruise
+	name = "hematoma"
+	whp = 5
+	bleed_rate = 0
+	clotting_threshold = null
+	sewn_clotting_threshold = null
+	woundpain = 5
+	passive_healing = 1
+	sew_threshold = 50
+	can_sew = FALSE
+	can_cauterize = FALSE
+	passive_healing = 0.5
+
+	associated_bclasses = list(
+		BCLASS_BLUNT,
+		BCLASS_SMASH,
+		BCLASS_PUNCH,
+		BCLASS_TWIST,
+	)
+	severity_names = list()
+	upgrade_whp = 1
+	upgrade_pain = 1
+
+#define BRUISE_UPG_SELFHEAL 1
+
+/datum/wound/dynamic/bruise/upgrade(damage)
+	passive_healing += BRUISE_UPG_SELFHEAL
+	return ..()
+
+#undef BRUISE_UPG_SELFHEAL

--- a/code/datums/wounds/dismemberment.dm
+++ b/code/datums/wounds/dismemberment.dm
@@ -4,7 +4,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	whp = 75
 	sewn_whp = 25
-	bleed_rate = 25
+	bleed_rate = ARTERY_LIMB_BLEEDRATE
 	sewn_bleed_rate = 0.25
 	clotting_threshold = null
 	sewn_clotting_threshold = null

--- a/code/datums/wounds/punctures.dm
+++ b/code/datums/wounds/punctures.dm
@@ -14,6 +14,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = TRUE
+	associated_bclasses = list(BCLASS_STAB)
 
 /datum/wound/puncture/can_apply_to_bodypart(obj/item/bodypart/affected)
 	. = ..()
@@ -71,3 +72,73 @@
 /datum/wound/puncture/drilling/cauterize_wound()
 	qdel(src)
 	return TRUE
+
+// Puncture (Stab -- not Pick) Omniwounds
+// Vaguely: Not nearly as painful, higher bleed cap, easier to sew / heal.
+/datum/wound/dynamic/puncture
+	name = "puncture"
+	whp = 1
+	sewn_whp = 0
+	bleed_rate = 1
+	sewn_bleed_rate = 0.04
+	clotting_rate = 0.01
+	sewn_clotting_rate = 0.01
+	clotting_threshold = 0.2
+	sewn_clotting_threshold = 0.1
+	sew_threshold = 20
+	mob_overlay = "cut"
+	can_sew = TRUE
+	can_cauterize = TRUE
+	associated_bclasses = list(BCLASS_STAB)
+
+	severity_names = list(
+		"shallow" = 3,
+		"deep" = 6,
+		"gnarly" = 9,
+		"vicious" = 12,
+		"lethal" = 20,
+	)
+	upgrade_bleed_rate = 0.5
+	upgrade_bleed_clamp = 1.3
+	upgrade_bleed_clam_armor = 0.75
+	upgrade_whp = 0.5
+	upgrade_sew_threshold = 0.65
+	upgrade_pain = 0.05
+	protected_bleed_clamp = 6
+
+// Gouge (Pick) dynamic wounds
+// Vaguely: Not very painful, not very bleedy, but you can't cauterize them. You're still better off using stab every time.
+// Addendum: This was made with the assumption that pick intent penetrates most armors (and being able to crit through them).
+/datum/wound/dynamic/gouge
+	name = "gouge"
+	whp = 1
+	sewn_whp = 0
+	bleed_rate = 1
+	sewn_bleed_rate = 0.04
+	clotting_rate = 0.01
+	sewn_clotting_rate = 0.01
+	clotting_threshold = 0.2
+	sewn_clotting_threshold = 0.1
+	sew_threshold = 20
+	mob_overlay = "cut"
+	can_sew = TRUE
+	can_cauterize = FALSE
+	associated_bclasses = list(
+		BCLASS_PICK,
+		BCLASS_PIERCE,
+		BCLASS_SHOT,
+	)
+
+	severity_names = list(
+		"shallow" = 2,
+		"deep" = 4,
+		"gnarly" = 8,
+		"vicious" = 12,
+		"lethal" = 20,
+	)
+	upgrade_bleed_rate = 0.01
+	upgrade_bleed_clamp = 0.5
+	upgrade_whp = 1
+	upgrade_sew_threshold = 0.3
+	upgrade_pain = 0.01
+	protected_bleed_clamp = 4

--- a/code/datums/wounds/slashes.dm
+++ b/code/datums/wounds/slashes.dm
@@ -14,6 +14,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = TRUE
+	associated_bclasses = list(BCLASS_CUT, BCLASS_CHOP)
 
 /datum/wound/slash/can_apply_to_bodypart(obj/item/bodypart/affected)
 	. = ..()
@@ -47,6 +48,38 @@
 	woundpain = 15
 	sewn_woundpain = 5
 	sew_threshold = 75
+
+// Slash Omniwounds
+// Vaguely: Painful, hard to sew, hard to heal, but scales poorly through armor.
+/datum/wound/dynamic/slash
+	name = "slash"
+	whp = 15
+	sewn_whp = 5
+	bleed_rate = 1
+	sew_threshold = 25
+	woundpain = 5
+	clotting_rate = 0.1
+	clotting_threshold = 0.25
+	sewn_clotting_threshold = null
+	sewn_clotting_rate = null
+	sewn_bleed_rate = null
+	can_sew = TRUE
+	can_cauterize = TRUE
+	associated_bclasses = list(BCLASS_CUT, BCLASS_CHOP)
+
+	severity_names = list(
+		"light" = 5,
+		"deep" = 10,
+		"gnarly" = 15,
+		"lethal" = 20,
+	)
+	upgrade_bleed_rate = 0.12
+	upgrade_bleed_clamp = 2.2
+	upgrade_bleed_clam_armor = 1
+	upgrade_whp = 0.6
+	upgrade_sew_threshold = 1.5
+	upgrade_pain = 0.25
+	protected_bleed_clamp = 9
 
 /datum/wound/slash/disembowel
 	name = "disembowelment"
@@ -148,6 +181,7 @@
 	sew_threshold = 65
 	can_sew = TRUE
 	can_cauterize = TRUE
+	associated_bclasses = list(BCLASS_LASHING)
 
 /datum/wound/lashing/small
 	name = "superficial lashing"
@@ -176,3 +210,26 @@
 	woundpain = 22
 	sewn_woundpain = 14
 	sew_threshold = 95
+
+// Lashing (Whip) Omniwounds
+// Vaguely: Painful, huge bleeds, but nearly nothing at all through any armor.
+/datum/wound/dynamic/lashing
+	name = "lashing"
+	whp = 30
+	sewn_whp = 12
+	bleed_rate = 0
+	clotting_rate = 0.02
+	clotting_threshold = 0.2
+	woundpain = 10
+	mob_overlay = "cut"
+	can_sew = TRUE
+	can_cauterize = FALSE	//Ouch owie oof
+	associated_bclasses = list(BCLASS_LASHING)
+
+	upgrade_bleed_rate = 0.1
+	upgrade_bleed_clamp = 3.5
+	upgrade_bleed_clam_armor = 0.2
+	upgrade_whp = 1
+	upgrade_sew_threshold = 1.8
+	upgrade_pain = 0.5
+	protected_bleed_clamp = 2

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1471,3 +1471,9 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 	return new_item
 
+/obj/item/proc/can_embed()
+	if(HAS_TRAIT(src, TRAIT_NODROP) || HAS_TRAIT(src, TRAIT_NOEMBED))
+		return FALSE
+	if(!embedding?.embed_chance)
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -204,7 +204,7 @@
 		blocked = TRUE
 	else if(I)
 		if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
-			if(can_embed(I) && prob(I.embedding.embed_chance) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
+			if(I.can_embed() && prob(I.embedding.embed_chance) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
 				//throw_alert("embeddedobject", /atom/movable/screen/alert/embeddedobject)
 				var/obj/item/bodypart/L = pick(bodyparts)
 				L.add_embedded_object(I, silent = FALSE, crit_message = TRUE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1840,7 +1840,7 @@ GLOBAL_LIST_EMPTY(patreon_races)
 				I.take_damage(1, BRUTE, I.damage_type)
 		if(!nodmg)
 			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block))/100), user, selzone, crit_message = TRUE)
-			if(crit_wound.should_embed(I))
+			if(crit_wound?.should_embed(I))
 				var/can_impale = TRUE
 				if(!affecting)
 					can_impale = FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1840,7 +1840,7 @@ GLOBAL_LIST_EMPTY(patreon_races)
 				I.take_damage(1, BRUTE, I.damage_type)
 		if(!nodmg)
 			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block))/100), user, selzone, crit_message = TRUE)
-			if(should_embed_weapon(crit_wound, I))
+			if(crit_wound.should_embed(I))
 				var/can_impale = TRUE
 				if(!affecting)
 					can_impale = FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -131,7 +131,7 @@
 				else
 					simple_woundcritroll(I.thrown_bclass, I.throwforce, null, zone, crit_message = TRUE)
 					if(((throwingdatum ? throwingdatum.speed : I.throw_speed) >= EMBED_THROWSPEED_THRESHOLD) || I.embedding.embedded_ignore_throwspeed_threshold)
-						if(can_embed(I) && prob(I.embedding.embed_chance) && HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
+						if(I.can_embed() && prob(I.embedding.embed_chance) && HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS) && !HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
 							simple_add_embedded_object(I, silent = FALSE, crit_message = TRUE)
 			visible_message("<span class='danger'>[src] is hit by [I]![next_attack_msg.Join()]</span>", \
 							"<span class='danger'>I'm hit by [I]![next_attack_msg.Join()]</span>")

--- a/code/modules/mob/living/living_wounds.dm
+++ b/code/modules/mob/living/living_wounds.dm
@@ -219,7 +219,7 @@
 
 /// Simple version for adding an embedded object - DO NOT CALL THIS ON CARBON MOBS!
 /mob/living/proc/simple_add_embedded_object(obj/item/embedder, silent = FALSE, crit_message = FALSE)
-	if(!embedder || !can_embed(embedder) || (status_flags & GODMODE) || !HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS) || HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
+	if(!embedder || !embedder.can_embed() || (status_flags & GODMODE) || !HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS) || HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
 		return FALSE
 	LAZYADD(simple_embedded_objects, embedder)
 	embedder.is_embedded = TRUE

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -38,8 +38,10 @@
 /obj/item/bodypart/proc/has_wound(path, specific = FALSE)
 	if(!path)
 		return
+	if(!specific)
+		return locate(path) in wounds
 	for(var/datum/wound/wound as anything in wounds)
-		if((specific && wound.type != path) || !istype(wound, path))
+		if((wound.type != path))
 			continue
 		return wound
 
@@ -124,86 +126,47 @@
 	if(!bclass || !dam || !owner || (owner.status_flags & GODMODE))
 		return FALSE
 
+	var/do_crit = TRUE
+
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.checkcritarmor(zone_precise, bclass))
-			return FALSE
+			do_crit = FALSE
 
-	var/do_crit = TRUE
 	if(user)
-		if(user.stat_roll(STATKEY_LCK,2,10))
+		if(user.stat_roll(STATKEY_LCK, 2, 10))
 			dam += 10
 		if(ispath(user.rmb_intent?.type, /datum/rmb_intent/weak))
 			do_crit = FALSE
-
-	var/added_wound
-	switch(bclass) //do stuff but only when we are a blade that adds wounds
-		if(BCLASS_SMASH, BCLASS_BLUNT, BCLASS_PUNCH)
-			switch(dam)
-				if(30 to INFINITY)
-					added_wound = /datum/wound/bruise/large
-				if(15 to 30)
-					added_wound = /datum/wound/bruise
-				if(5 to 15)
-					added_wound = /datum/wound/bruise/small
-
-		if(BCLASS_CUT, BCLASS_CHOP)
-			switch(dam)
-				if(30 to INFINITY)
-					added_wound = /datum/wound/slash/large
-				if(15 to 30)
-					added_wound = /datum/wound/slash
-				if(5 to 15)
-					added_wound = /datum/wound/slash/small
-
-		if(BCLASS_STAB, BCLASS_PICK, BCLASS_SHOT, BCLASS_PIERCE)
-			switch(dam)
-				if(30 to INFINITY)
-					added_wound = /datum/wound/puncture/large
-				if(15 to 30)
-					added_wound = /datum/wound/puncture
-				if(5 to 15)
-					added_wound = /datum/wound/puncture/small
-
-		if(BCLASS_LASHING)
-			switch(dam)
-				if(20 to INFINITY)
-					added_wound = /datum/wound/lashing/large
-				if(10 to 20)
-					added_wound = /datum/wound/lashing
-				if(1 to 10)
-					added_wound = /datum/wound/lashing/small
-
-		if(BCLASS_BITE)
-			// Change crit handling becase biting is so free
-			switch(dam)
-				if(20 to INFINITY)
-					added_wound = /datum/wound/bite/large
-				if(10 to 20)
-					added_wound = /datum/wound/bite
-					// Areas that don't really make sense to be vulnerable to regular biting
-					var/static/list/bite_crit_hard = list(
-						BODY_ZONE_L_ARM,
-						BODY_ZONE_R_ARM,
-						BODY_ZONE_L_LEG,
-						BODY_ZONE_R_LEG,
-						BODY_ZONE_CHEST,
-						BODY_ZONE_HEAD,
-						BODY_ZONE_PRECISE_SKULL,
-					)
-					// So you can bite exposed parts of the head, hands, feet, neck, and groin which are typically easier to bite and fleshy
-					if(!HAS_TRAIT(user, TRAIT_STRONGBITE) && (zone_precise in bite_crit_hard))
-						do_crit = FALSE
-				if(1 to 10)
-					added_wound = /datum/wound/bite/small
-					do_crit = FALSE // This is like leaving a mark on your skin or getting bit by a cat
 
 	if(do_crit)
 		var/crit_attempt = try_crit(bclass, dam, user, zone_precise, silent, crit_message)
 		if(crit_attempt)
 			return crit_attempt
 
-	return add_wound(added_wound, silent, crit_message)
+	return manage_dynamic_wound(bclass, dam)
+
+/// Add or upgrade a dynamic wound, returns the wound if added or upgraded
+/obj/item/bodypart/proc/manage_dynamic_wound(bclass, damage)
+	var/datum/wound/wound_type
+	for(var/type in GLOB.primordial_wounds)
+		// :(
+		if(!ispath(type, /datum/wound/dynamic))
+			continue
+		var/datum/wound/dynamic/dynwound = GLOB.primordial_wounds[type]
+		if(!length(dynwound.associated_bclasses))
+			continue
+		if(bclass in dynwound.associated_bclasses)
+			wound_type = dynwound.type
+			break
+	if(!wound_type)
+		return
+	var/datum/wound/dynamic/dynwound = has_wound(wound_type)
+	// Yes we upgrade when adding as well
+	dynwound?.upgrade(damage)
+	if(!dynwound)
+		return add_wound(wound_type)
+	return dynwound
 
 /// Behemoth of a proc used to apply a wound after a bodypart is damaged in an attack
 /obj/item/bodypart/proc/try_crit(bclass, dam, mob/living/user, zone_precise, silent = FALSE, crit_message = FALSE)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -525,7 +525,7 @@
 
 /// Embeds an object in this bodypart
 /obj/item/bodypart/proc/add_embedded_object(obj/item/embedder, silent = FALSE, crit_message = FALSE)
-	if(!embedder || !can_embed(embedder))
+	if(!embedder || !embedder.can_embed())
 		return FALSE
 	if(owner && ((owner.status_flags & GODMODE) || HAS_TRAIT(owner, TRAIT_PIERCEIMMUNE)))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3165

Omniwounds will replace tiered wounds, everytime you attack someone if the wound for that damage class is present it will upgrade the wound instead, increasing its severity. 

Eventually these can hit 20 bleed which is is the new bleed rate for arteries, down from 25. When this happens the wound practically becomes an atery wound but you would probably be dead before then.

Todo
- [ ] Numbers tweaks
- [ ] Port the spells? Probably not, maybe pestra?
- [ ] Make stitching wounds progressive and better

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added dynamic wounds to replace tiered wounds for carbon mobs.
balance: All carbon wound sources will scale differently when it comes to damage, sew time, bleed etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
