### PR TITLE
Makes Lakkarian Jupon have similar defensive values to the Padded Gambeson ( Oversight Fix )

### DIFF
--- a/code/modules/clothing/armor/gambesson.dm
+++ b/code/modules/clothing/armor/gambesson.dm
@@ -51,7 +51,7 @@
 /obj/item/clothing/armor/gambeson/heavy/colored/dark
 	color = CLOTHING_DARK_INK
 
-/obj/item/clothing/armor/gambeson/lakkarijupon
+/obj/item/clothing/armor/gambeson/heavy/lakkarijupon
 	name = "lakkarian jupon"
 	desc = "a thick, quilted jupon with an iron heart protector. Apart of the standard traveling uniform for Lakkarian clerics. It's great for the southern desert's heat and northern tundra's cold."
 	icon_state = "lakkarijupon"

--- a/code/modules/crafting/quality_of_crafting/sewing.dm
+++ b/code/modules/crafting/quality_of_crafting/sewing.dm
@@ -1002,7 +1002,7 @@
 
 /datum/repeatable_crafting_recipe/sewing/lakkarijupon
 	name = "lakkarian jupon"
-	output = /obj/item/clothing/armor/gambeson/lakkarijupon
+	output = /obj/item/clothing/armor/gambeson/heavy/lakkarijupon
 	requirements = list(/obj/item/natural/cloth = 4,
 				/obj/item/natural/fibers = 2,
 				/obj/item/ingot/iron = 1)

--- a/code/modules/jobs/job_types/adventurer/types/combat/rare/lakkariancleric.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/rare/lakkariancleric.dm
@@ -15,7 +15,7 @@
 	H.cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
 
 	head = /obj/item/clothing/head/helmet/ironpot/lakkariancap
-	armor = /obj/item/clothing/armor/gambeson/lakkarijupon
+	armor = /obj/item/clothing/armor/gambeson/heavy/lakkarijupon
 	shirt = /obj/item/clothing/shirt/undershirt/fancy
 	gloves = /obj/item/clothing/gloves/leather
 	wrists = /obj/item/clothing/neck/psycross/silver/astrata


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR is meant to fix an oversight in one of my previous PRs. I accidentally made the Lakkarian Jupon on par with a gambeson rather than a padded gambeson.  Making it weaker than it was supposed to be. 

## Why It's Good For The Game

The lakkarian jupon was never meant to be on par with a regular gambeson. It was meant to be similar to (or slightly stronger than) the padded gambeson.  This makes Lakkarian clerics have somewhat better survivability against one of the most common damage types in the game, but they are still cooked if their gambeson breaks.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: fixed the lakkarian jupon 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
