### PR TITLE
Fix a few harpoon bugs & Fix a few royal knight steam class bugs.

### DIFF
--- a/code/game/objects/items/harpoon_gun.dm
+++ b/code/game/objects/items/harpoon_gun.dm
@@ -58,7 +58,7 @@
 	update_appearance(UPDATE_ICON_STATE)
 
 /obj/item/harpoon_gun/apply_components()
-	AddComponent(/datum/component/steam_storage, 300, 0)
+	AddComponent(/datum/component/steam_storage, 300, 0, "harpoon_gun")
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
 
 /obj/item/harpoon_gun/Destroy()
@@ -97,7 +97,7 @@
 	if(user.CanReach(attacked_atom))
 		return
 
-	if(!SEND_SIGNAL(src, COMSIG_ATOM_STEAM_USE, 50))
+	if(!SEND_SIGNAL(src, COMSIG_ATOM_STEAM_USE, 50, "harpoon_gun"))
 		return
 	. |= TRUE
 

--- a/code/modules/clothing/cloak/steam.dm
+++ b/code/modules/clothing/cloak/steam.dm
@@ -97,10 +97,10 @@
 		user.audible_message(span_warning("The [src.name] sputters violently before stopping."), runechat_message = TRUE)
 		var/random_loss = rand(100, 200)
 		//If they can reduce the steam, do it, if it can't it will be set to zero.
-		if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor"))
+		if(!SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor", FALSE, FALSE))
 			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor", TRUE)
 		else
-			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor")
+			SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, random_loss, "steam_armor", FALSE, FALSE)
 
 	//Triggers when the steamknight boiler runs out of steam.
 	if(disable)
@@ -112,7 +112,7 @@
 		active = FALSE
 		to_chat(user, span_warning("The [src.name] breaks!"))
 		user.audible_message(span_warning("The [src.name] sputters violently as you hear a loud crack!"), runechat_message = TRUE)
-		SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor", TRUE)
+		SEND_SIGNAL(user, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor", TRUE, FALSE)
 
 	return
 
@@ -125,7 +125,7 @@
 		power_off(source, FALSE, TRUE)
 		return FALSE
 
-	if(!SEND_SIGNAL(source, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor"))
+	if(!SEND_SIGNAL(source, COMSIG_ATOM_PROXY_STEAM_USE, src, 0.5, "steam_armor", FALSE, FALSE))
 		//Out of steam, shut down the boiler forcibly
 		power_off(source, TRUE)
 		return FALSE

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -111,6 +111,8 @@
 		if("Longsword")
 			grant_shield = FALSE
 			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, 4, TRUE)
+		if("Sabre")
+			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, 4, TRUE)
 		if("Unarmed")
 			H.clamped_adjust_skillrank(/datum/skill/combat/unarmed, 3, 5, TRUE)
 			H.clamped_adjust_skillrank(/datum/skill/combat/knives, 2, 4, TRUE)
@@ -158,6 +160,7 @@
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axesmaces, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, -1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/crossbows, -1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/engineering, 3, TRUE)//replaces the int buff
 
 /datum/outfit/job/royalknight/steam/post_equip(mob/living/carbon/human/H, visualsOnly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- FIxes Harpoon consuming steam while using the steamknight armor.

- Fixes Harpon signals accidentally emptying the steamknight boiler.

- Fixes Steamknight only being skilled if they picked saber.

- FIxes steamknight being expert on crossbow.

## Why It's Good For The Game

Fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Harpoon consuming steam when it is not being used.
fix: Harpoon being able to remove all the steam from the steamknight boiler.
fix: Steamknight being skilled if they picked saber, they are not expert.
fix: Steamknight still being expert on crossbow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
