### PR TITLE
Bracer changes

### DIFF
--- a/code/modules/clothing/wrists/bracer.dm
+++ b/code/modules/clothing/wrists/bracer.dm
@@ -5,13 +5,16 @@
 	body_parts_covered = ARMS
 	icon_state = "bracers"
 	item_state = "bracers"
-	armor = list("blunt" = 80, "slash" = 80, "stab" = 80,  "piercing" = 60, "fire" = 0, "acid" = 0)
-	prevent_crits = list(BCLASS_LASHING, BCLASS_BITE, BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
+	armor = ARMOR_PLATE
+	prevent_crits = ALL_EXCEPT_BLUNT_AND_STAB
 	blocksound = PLATEHIT
 	resistance_flags = FIRE_PROOF
 	anvilrepair = /datum/skill/craft/armorsmithing
 	sewrepair = FALSE
-	smeltresult = /obj/item/ingot/iron //no 1 to 1 conversion
+	smeltresult = null
+	melt_amount = 75
+	max_integrity = INTEGRITY_STRONG
+	melting_material = /datum/material/steel
 
 /obj/item/clothing/wrists/bracers/iron
 	name = "iron plate vambraces"
@@ -20,6 +23,7 @@
 	item_state = "ibracers"
 	armor = ARMOR_MAILLE
 	max_integrity = INTEGRITY_STANDARD
+	melting_material = /datum/material/iron
 
 
 /obj/item/clothing/wrists/bracers/jackchain
@@ -27,42 +31,67 @@
 	desc = "Thin strips of steel attached to small shoulder and elbow plates, worn on the outside of the arms to protect against slashes."
 	icon_state = "jackchain"
 	item_state = "jackchain"
-	armor = ARMOR_MAILLE
-	max_integrity = INTEGRITY_STANDARD
+	armor = ARMOR_MAILLE_IRON
+	max_integrity = INTEGRITY_STANDARD - 25
 	prevent_crits = CUT_AND_MINOR_CRITS
-	smeltresult = null //Gives two per smith, gives none per smelt.
+	melt_amount = 35
+	melting_material = /datum/material/iron
+
+/obj/item/clothing/wrists/bracers/copper
+	name = "copper bracers"
+	desc = "Copper forearm guards that offer some protection while looking rather stylish."
+	icon_state = "copperarm"
+	item_state = "copperarm"
+	armor = ARMOR_MAILLE_IRON
+	max_integrity = INTEGRITY_POOR //worse than jackchains in terms of integrity
+	//however they protect better than the jackchains when it comes to crits
+	melt_amount = 75
+	melting_material = /datum/material/copper
 
 /obj/item/clothing/wrists/bracers/leather
 	name = "leather bracers"
 	desc = "Boiled leather bracers typically worn by archers to protect their forearms."
 	icon_state = "lbracers"
 	item_state = "lbracers"
-	armor = list("blunt" = 30, "slash" = 30, "stab" = 30,  "piercing" = 15, "fire" = 0, "acid" = 0)
-	prevent_crits = list(BCLASS_LASHING, BCLASS_BITE, BCLASS_CUT)
+	armor = ARMOR_LEATHER_BAD
+	prevent_crits = CUT_AND_MINOR_CRITS
+	max_integrity = INTEGRITY_STANDARD
 	resistance_flags = null
 	blocksound = SOFTHIT
-	smeltresult = /obj/item/fertilizer/ash
 	blade_dulling = DULLING_BASHCHOP
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
-	anvilrepair = null
-	sewrepair = TRUE
-	salvage_result = null
+	smeltresult = /obj/item/fertilizer/ash
+	melt_amount = 0
+	melting_material = null
 
 /obj/item/clothing/wrists/bracers/leather/advanced
 	name = "hardened leather bracers"
 	desc = "Hardened leather braces that will keep your wrists safe from bludgeoning."
 	armor = list("blunt" = 60, "slash" = 40, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST) //We're losing stab here
-	max_integrity = 250
+	max_integrity = INTEGRITY_STANDARD + 50
 
 /obj/item/clothing/wrists/bracers/leather/masterwork
 	name = "masterwork leather bracers"
 	desc = "These bracers are a craftsmanship marvel. Made with the finest leather. Strong, nimible, reliable."
 	armor = list("blunt" = 80, "slash" = 60, "stab" = 40, "piercing" = 0, "fire" = 0, "acid" = 0)
-	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST) //We're getting chop here
-	max_integrity = 300
+	prevent_crits = ALL_EXCEPT_BLUNT_AND_STAB
+	max_integrity = INTEGRITY_STANDARD + 100
 
 /obj/item/clothing/wrists/bracers/leather/masterwork/Initialize()
 	. = ..()
 	filters += filter(type="drop_shadow", x=0, y=0, size=0.5, offset=1, color=rgb(218, 165, 32))
+
+/obj/item/clothing/wrists/bracers/rare
+	abstract_type = /obj/item/clothing/wrists/bracers/rare
+
+/obj/item/clothing/wrists/bracers/rare/hoplite
+	name = "ancient bracers"
+	desc = "Stalwart bronze bracers, from an age long past."
+	icon_state = "aasimarwrist"
+	item_state = "aasimarwrist"
+	armor = ARMOR_PLATE_BAD
+	armor_class = AC_LIGHT
+	melt_amount = 75
+	melting_material = /datum/material/bronze


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Bracer armour values slightly changed, barely noticeable
Jackchains however were nerfed, as they are cheaper to make than iron bracers

crit resistance has been changed. Generally bracers cant resist blunt and stab now
leather and jackchains can resist cuts and small crits (so lash, bite and twist)

hardened leather bracers have the same crit resistance as normal leather ones
masterwork have the same crit resistance as steel/iron vambraces

## Why It's Good For The Game

I think it makes things more consistent, like using defines and stuff

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: tweaked the armour values of bracers
qol: bracers are now smeltable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
