### PR TITLE
Fix Migrant bug & Slightly change the migration triumph impact

### DIFF
--- a/code/controllers/subsystem/migration.dm
+++ b/code/controllers/subsystem/migration.dm
@@ -339,15 +339,12 @@ SUBSYSTEM_DEF(migrants)
 	var/first_val = -1
 
 	if(length(triumph_weighted))
+		first_val = triumph_weighted[1]
 		for(var/client/client in triumph_weighted)
-			first_val = triumph_weighted[client]
-			break
-
-		for(var/client/client in triumph_weighted)
+			// Check if anything is not equal to the first value in the list
 			if(triumph_weighted[client] != first_val)
 				all_equal = FALSE
 				break
-
 
 	//Convert weighted list to prioritized list
 	while(length(triumph_weighted))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Fix the bug from this issue: https://github.com/Monkestation/Vanderlin/issues/3418 , the issue was happening because the triumph buff was being added even if the user didn't prioritize the role so they could roll squire and the squire would just roll knight.

- Now by spending triumphs on a wave you can basically guarantee rolling a role you prioritize, for example if Jones spends 13 Triumphs, they can roll anything on the wave since the maximum someone can spend now is 12, that works for all the other roles as well.
## Why It's Good For The Game

- Fix

- If you are spending your triumphs on a wave, it should atleast guarantee your roll for atleast one role that you enjoy, same for migrant waves that have a singe slot, you don't want to relay on rng when you spent 25 triumphs to play that.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Rolling a role you didn't prioritize because you spent triumphs on the wave.
bal: When prioritizing for a role, it also takes into account the amount of triumphs you spent in the wave. Those who spent more will be the ones who roll it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
