### PR TITLE
serva without wooden metalizers

### DIFF
--- a/code/modules/crafting/artificer/misc.dm
+++ b/code/modules/crafting/artificer/misc.dm
@@ -208,14 +208,6 @@
 	i_type = "Contraptions"
 	category = "Contraptions"
 
-/*//datum/artificer_recipe/contraptions/metalizer // way too much for serva
-	name = "Wood Metalizer (+1 Wooden Cog)"
-	required_item = /obj/item/ingot/bronze
-	additional_items = list(/obj/item/gear/wood = 1)
-	created_item = /obj/item/contraption/wood_metalizer
-	hammers_per_item = 12
-	craftdiff = 4
-*/
 /datum/artificer_recipe/contraptions/smelter
 	name = "Portable Smelter (+1 Coal)"
 	required_item = /obj/item/ingot/bronze


### PR DESCRIPTION
## About The Pull Request

removes the wood metalizer from the crafting section in serva, is good on a place like vanderlin, not on serva where everyone has a job, wood everywhere and a very unstable settlement

## Why It's Good For The Game

one exploit on long term removed, it would be like the minecraft cobblestone generator except you generate blocks of iron

## Changelog

balance: rebalanced engineering on serva

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
