### PR TITLE
adds 4 specials + reduce unlucky weight

### DIFF
--- a/code/_globalvars/special_traits/traits.dm
+++ b/code/_globalvars/special_traits/traits.dm
@@ -240,6 +240,48 @@
 	character.grant_language(/datum/language/zalad)
 	character.grant_language(/datum/language/thievescant)
 
+/datum/special_trait/uniglot
+	name = "Uniglot"
+	greet_text = span_notice("I could never pick up on languages easily, \
+	even those that most people speak... What even is that Imperial nonsense?")
+	weight = 50
+
+/datum/special_trait/uniglot/on_apply(mob/living/carbon/human/character, silent)
+	character.remove_language(/datum/language/common)
+	switch(rand(1,7))
+		if(1)
+			character.grant_language(/datum/language/elvish)
+		if(2)
+			character.grant_language(/datum/language/deepspeak)
+		if(3)
+			character.grant_language(/datum/language/dwarvish)
+		if(4)
+			character.grant_language(/datum/language/zalad)
+		if(5)
+			character.grant_language(/datum/language/oldpsydonic)
+		if(6)
+			character.grant_language(/datum/language/hellspeak)
+		if(7)
+			character.grant_language(/datum/language/orcish)
+
+/datum/special_trait/languageidiot
+	name = "Somewhat Polyglot"
+	greet_text = span_notice("I have always picked up on languages easily, \
+	even those that are forbidden to mortals... except that accursed Imperial chatter. What even is that nonsense?")
+	weight = 50
+
+/datum/special_trait/languageidiot/on_apply(mob/living/carbon/human/character, silent)
+	character.remove_language(/datum/language/common)
+	character.grant_language(/datum/language/dwarvish)
+	character.grant_language(/datum/language/elvish)
+	character.grant_language(/datum/language/hellspeak)
+	character.grant_language(/datum/language/celestial)
+	character.grant_language(/datum/language/orcish)
+	character.grant_language(/datum/language/deepspeak)
+	character.grant_language(/datum/language/oldpsydonic)
+	character.grant_language(/datum/language/zalad)
+	character.grant_language(/datum/language/thievescant)
+
 /datum/special_trait/tavernbrawler
 	name = "Tavern Brawler"
 	greet_text = span_notice("I love a good pub fight!")
@@ -382,7 +424,7 @@
 /datum/special_trait/unlucky
 	name = "Unlucky"
 	greet_text = span_boldwarning("Ever since you knocked over that glass vase, you just feel... off")
-	weight = 100
+	weight = 50
 
 /datum/special_trait/unlucky/on_apply(mob/living/carbon/human/character, silent)
 	character.STALUC = rand(1, 10)
@@ -407,6 +449,13 @@
 	character.reagents.add_reagent(pick(/datum/reagent/ozium, /datum/reagent/moondust, /datum/reagent/druqks), 15)
 	character.reagents.add_reagent(/datum/reagent/consumable/ethanol/beer, 72)
 	grant_lit_torch(character)
+
+/datum/special_trait/bald
+	name = "Bald"
+	greet_text = span_boldwarning("MY HAIIIR!! WHERE IS IT!! WHERE IS MY HAIR!!")
+	weight = 100
+/datum/special_trait/bald/on_apply(mob/living/carbon/human/character)
+	character.set_hair_style(/datum/sprite_accessory/hair/head/bald, FALSE)
 
 /datum/special_trait/atrophy
 	name = "Atrophy"
@@ -711,3 +760,17 @@
 
 /datum/special_trait/keenears/on_apply(mob/living/carbon/human/character, silent)
 	ADD_TRAIT(character, TRAIT_KEENEARS, "[type]")
+
+/datum/special_trait/bestial
+	name = "Bestial"
+	greet_text = span_notice("I am blessed by Dendor I feel closer to beasts than men, I can whisper in their tongue.")
+	weight = 50
+	req_text = "Worship Dendor and be an acolyte"
+	allowed_jobs = list(/datum/job/monk)
+	allowed_patrons = list(/datum/patron/divine/dendor)
+
+/datum/special_trait/bestial/on_apply(mob/living/carbon/human/character, silent)
+	character.grant_language(/datum/language/beast)
+	character.add_spell(/datum/action/cooldown/spell/undirected/howl/call_of_the_moon, silent = TRUE)
+	ADD_TRAIT(character, TRAIT_NASTY_EATER, "[type]") // eat the raw meat
+

--- a/code/_globalvars/special_traits/traits.dm
+++ b/code/_globalvars/special_traits/traits.dm
@@ -244,7 +244,7 @@
 	name = "Uniglot"
 	greet_text = span_notice("I could never pick up on languages easily, \
 	even those that most people speak... What even is that Imperial nonsense?")
-	weight = 50
+	weight = 25
 
 /datum/special_trait/uniglot/on_apply(mob/living/carbon/human/character, silent)
 	character.remove_language(/datum/language/common)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR adds 4 specials:
-bald: you're bald

-Uniglot: you can only speak 1 random language besides Imperial

-Somewhat Polyglat: You can speak everything but Imperial

-Bestial: Must be dendor acolyte, can speak beastish, gets call of the moon (basically WW communicate spell) and nasty eater.

Unlucky weight reduced to 50, the weight was way too big for a special that makes you pretty much incapable of combat.

## Why It's Good For The Game

More special variety is good.
<img width="1118" height="616" alt="Capture d'écran 2025-09-29 235337" src="https://github.com/user-attachments/assets/44d68e50-9ffe-4179-b1a0-5498c3be258f" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added 4 new specials and reduced unlucky weight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
