### PR TITLE
Update bandit.dm to no longer force change worship.

### DIFF
--- a/code/modules/antagonists/villain/bandit.dm
+++ b/code/modules/antagonists/villain/bandit.dm
@@ -44,7 +44,6 @@
 /datum/antagonist/bandit/proc/finalize_bandit()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/music/traitor.ogg', 80, FALSE, pressure_affected = FALSE)
 	var/mob/living/carbon/human/H = owner.current
-	H.set_patron(/datum/patron/inhumen/matthios)
 
 /datum/antagonist/bandit/greet()
 	to_chat(owner.current, span_alertsyndie("I am a BANDIT!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the force-patron from bandits that aren't mages. Simple as that.

## Why It's Good For The Game

Banditry is kind-of one dimensional at the moment. Everyone hates your guts, but at the same time you are generally outclassed, and this generally leads to you getting bludgeoned to death/beheaded on the spot/burned at the stake/etc depending on who gets their hands on you. In particular, this feels stupid because banditry can have a number of causes BESIDES heresy.

 By making bandits not automatic heretics, it lessens the chance that the church and inquisition in particular decides to execute any caught bandit on the spot, and thrusts the job of dealing with them back onto the town watch (who are supposed to be the main ones handling outlaws anyway, duh-uh.) while still leaving open the avenue of interrogation/reprisal RP for those roles when they DO catch bandits (after all, the patron of most free men is Matthios, and there is even a special confession for bandit roles).
 
 Finally, if the change allowing luxless creatures to have lux implanted goes through, this allows said creatures to receive it while being bandits (assuming they don't follow inhumen gods anyway) since it otherwise blocks lux transplants.

## Changelog
:cl:

del: Bandits are no longer forcibly indoctrinated. they're BANDITS, not cultists.
/:cl:

