### PR TITLE
Makes alchemy spells use alchemy as the associated skill

### DIFF
--- a/code/modules/crafting/alchemy/essence_machines/essence_gauntlet/spells/_base.dm
+++ b/code/modules/crafting/alchemy/essence_machines/essence_gauntlet/spells/_base.dm
@@ -11,6 +11,7 @@
 	point_cost = 2
 	spell_type = SPELL_ESSENCE
 	experience_modifer = 0
+	associated_skill = /datum/skill/craft/alchemy
 
 /datum/action/cooldown/spell/essence/get_adjusted_charge_time()
 	return charge_time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title

## Why It's Good For The Game

This will prevent players from levelling up arcane by just using the gauntlet
plus fits thematically

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: essence spells (used by the essence gauntlet) now require alchemy spell instead of arcyne, like they should've been
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
