### PR TITLE
Fix Minotaur bug and add Minotaur drop

### DIFF
--- a/code/datums/ai/subtrees/minotaur_melee.dm
+++ b/code/datums/ai/subtrees/minotaur_melee.dm
@@ -29,6 +29,8 @@
 /datum/ai_behavior/minotaur_melee_attack/perform(delta_time, datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key)
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/minotaur/boss = controller.pawn
+	if(!boss || boss.stat != CONSCIOUS)
+		return
 	if(!istype(boss))
 		finish_action(controller, FALSE)
 		return

--- a/code/datums/ai/subtrees/minotaur_special.dm
+++ b/code/datums/ai/subtrees/minotaur_special.dm
@@ -64,6 +64,8 @@
 /datum/ai_behavior/minotaur_charge_attack/perform(delta_time, datum/ai_controller/controller, target_key)
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/minotaur/boss = controller.pawn
+	if(!boss || boss.stat != CONSCIOUS)
+		return
 	var/atom/target = controller.blackboard[target_key]
 
 	if(!istype(boss) || QDELETED(target))
@@ -204,6 +206,8 @@
 /datum/ai_behavior/minotaur_fury_slam/perform(delta_time, datum/ai_controller/controller, target_key)
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/minotaur/boss = controller.pawn
+	if(!boss || boss.stat != CONSCIOUS)
+		return
 	var/atom/target = controller.blackboard[target_key]
 
 	if(!istype(boss) || QDELETED(target))
@@ -278,6 +282,8 @@
 /datum/ai_behavior/minotaur_ground_slam/perform(delta_time, datum/ai_controller/controller)
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/minotaur/boss = controller.pawn
+	if(!boss || boss.stat != CONSCIOUS)
+		return
 	if(!istype(boss))
 		finish_action(controller, FALSE)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/minotaur.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/minotaur.dm
@@ -40,7 +40,6 @@
 	dodgetime = 50
 	aggressive = 1
 //	stat_attack = UNCONSCIOUS
-	remains_type = /obj/item/weapon/axe/battle
 
 	ai_controller = /datum/ai_controller/minotaur
 	dendor_taming_chance = DENDOR_TAME_PROB_NONE
@@ -62,6 +61,7 @@
 	base_intents = list(/datum/intent/simple/minotaur_axe)
 	melee_damage_lower = 65
 	melee_damage_upper = 85
+	loot = list(/obj/item/weapon/greataxe/steel/doublehead)
 
 /mob/living/simple_animal/hostile/retaliate/minotaur/axe/female
 	icon_state = "MinotaurFem_Axe"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fix minotaur being able to attack as a corpse, i was not able to replicate it but this should prevent it from happening.

Minotaur now drops the doublehead greataxe for the minotaur axe variant.

## Why It's Good For The Game

Fix and a hard boss like npc needs a good drop.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Minotaur sometimes attacking as a corpse.
add: Minotaur axe variant now drops a double head greataxe upon death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
