### PR TITLE
Change How Continue Vote works and Remove Old First vote code

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -247,12 +247,8 @@ SUBSYSTEM_DEF(ticker)
 			if(firstvote)
 				if(world.time > round_start_time + time_until_vote)
 					SSvote.initiate_vote("endround", "The Gods")
-					time_until_vote = 40 MINUTES
-					last_vote_time = world.time
 					firstvote = FALSE
 				return
-			if(world.time > last_vote_time + time_until_vote)
-				SSvote.initiate_vote("endround", "The Gods")
 
 /datum/controller/subsystem/ticker/proc/checkreqroles()
 	var/list/readied_jobs = list()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -46,9 +46,6 @@ SUBSYSTEM_DEF(ticker)
 	//376000 day
 	var/gametime_offset = 288001		//Deciseconds to add to world.time for station time.
 	var/station_time_rate_multiplier = 40		//factor of station time progressal vs real time.
-	var/time_until_vote = 135 MINUTES
-	var/last_vote_time = null
-	var/firstvote = TRUE
 
 	var/totalPlayers = 0					//used for pregame stats on statpanel
 	var/totalPlayersReady = 0				//used for pregame stats on statpanel
@@ -243,11 +240,6 @@ SUBSYSTEM_DEF(ticker)
 				declare_completion(force_ending)
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 			if(SSgamemode.roundvoteend)
-				return
-			if(firstvote)
-				if(world.time > round_start_time + time_until_vote)
-					SSvote.initiate_vote("endround", "The Gods")
-					firstvote = FALSE
 				return
 
 /datum/controller/subsystem/ticker/proc/checkreqroles()

--- a/code/controllers/subsystem/triumph/buy_datums/communal/longer_week.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/communal/longer_week.dm
@@ -7,7 +7,6 @@
 /datum/triumph_buy/communal/preround/longer_week/on_activate()
 	. = ..()
 	SSmapping.add_world_trait(/datum/world_trait/longer_week, 0)
-	SSticker.time_until_vote += 40 MINUTES
 	GLOB.round_timer += 40 MINUTES
 
 	to_chat(world, "<br>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

First of all, the continue timer was a bit messy, even tho it actually says 40 or 32 minutes in the code what actually was happening, after the first vote it would keep trying to trigger the ticker subsystem vote but votes have a 15 mins cd between eachother (That number is in the config file and the default is 10), so everytime someone was hitting continue it would wait 15 mins and trigger that again.

This changes so you can control it with code, basically the minimum continue time is 15 minutes while the maximum is 30, this scales depending on the amount of people who voted continue and end round, if alot of people voted continue and barely any end round it will reach 30 mins if the vote was nearly similar it will be 15-16 mins and that is it.

This is also remove the old initiate vote code the ticker subsystem had and focus everything on the storyteller subsystem since both were conflicting with eachother, now INITIAL_ROUND_TIMER under compile_options is the one who decides when the first vote happens (the default is 99).

## Why It's Good For The Game

I think vote scaling is good, if people want to continue a round it will continue for a longer time instead of being the same vote being repeated again and again until ppl get tired, now it will take abit longer.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Vote Continue time scales of the amount of ppl who voted Continue or End round.
add: INITIAL_ROUND_TIMER now decides when the first vote of the round happens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
