### PR TITLE
Fix advclass names

### DIFF
--- a/code/controllers/subsystem/role_class_handler/role_class_handler.dm
+++ b/code/controllers/subsystem/role_class_handler/role_class_handler.dm
@@ -134,6 +134,7 @@ SUBSYSTEM_DEF(role_class_handler)
 	qdel(related_handler)
 
 	if(picked_class.inherit_parent_title)
+		// At this point the job is the job of the previous advclass "parent" or null
 		var/datum/job/old = SSjob.GetJob(H.job)
 		if(old)
 			picked_class.title_override = old.title

--- a/code/controllers/subsystem/role_class_handler/role_class_handler.dm
+++ b/code/controllers/subsystem/role_class_handler/role_class_handler.dm
@@ -56,7 +56,12 @@ SUBSYSTEM_DEF(role_class_handler)
 // This covers both class datums and drifter waves
 /datum/controller/subsystem/role_class_handler/proc/build_category_lists()
 	var/list/all_classes = list()
-	init_subtypes(/datum/job/advclass, all_classes) // Init all the classes
+	for(var/datum/job/job as anything in subtypesof(/datum/job/advclass))
+		if(is_abstract(job))
+			continue
+		var/datum/job/real_datum = SSjob.GetJobType(job)
+		if(real_datum)
+			all_classes += real_datum
 	sorted_class_categories[CTAG_ALLCLASS] = all_classes
 
 	//Time to sort these classes, and sort them we shall.

--- a/code/controllers/subsystem/role_class_handler/role_class_handler.dm
+++ b/code/controllers/subsystem/role_class_handler/role_class_handler.dm
@@ -131,7 +131,7 @@ SUBSYSTEM_DEF(role_class_handler)
 	if(picked_class.inherit_parent_title)
 		var/datum/job/old = SSjob.GetJob(H.job)
 		if(old)
-			picked_class.title = old.title
+			picked_class.title_override = old.title
 
 	SSjob.EquipRank(H, picked_class, H.client)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -3,6 +3,8 @@
 	var/enabled = TRUE
 	/// The name of the job , used for preferences, bans and more. Make sure you know what you're doing before changing this.
 	var/title = "NOPE"
+	/// Visual title override
+	var/title_override = null
 	/// The title of this job given to female mobs. Fluff, not as important as [var/title].
 	var/f_title = null
 	/// When joining the round, this text will be shown to the player.
@@ -485,6 +487,9 @@
 	equipped_human.remove_spells(source = src)
 
 /datum/job/proc/get_informed_title(mob/mob)
+	if(title_override)
+		return title_override
+
 	if(mob.gender == FEMALE && f_title)
 		return f_title
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
I neglected to change the new datums to getting the job singletons, and overrode the titles of those jobs directly...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Fixed every role getting renamed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
