### PR TITLE
New Admin Option to manage jobs and safety checks for enable/disabled jobs.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -159,6 +159,10 @@ SUBSYSTEM_DEF(job)
 			JobDebug("GRJ player did not pass special check, Player: [player], Job:[job.title]")
 			continue
 
+		if(!job.enabled)
+			JobDebug("GRJ player tried to play a disabled job, Player: [player], Job:[job.title]")
+			continue
+
 		if(CONFIG_GET(flag/usewhitelist))
 			if(job.whitelist_req && (!player.client.whitelisted()))
 				continue
@@ -316,6 +320,10 @@ SUBSYSTEM_DEF(job)
 
 				if(!job.special_job_check(player))
 					JobDebug("DO player did not pass special check, Player: [player], Job:[job.title]")
+					continue
+
+				if(!job.enabled)
+					JobDebug("DO player tried to play a disabled job, Player: [player], Job:[job.title]")
 					continue
 
 				// If the player wants that job on this level, then try give it to him.
@@ -511,6 +519,9 @@ SUBSYSTEM_DEF(job)
 				continue
 
 			if(!job.special_job_check(player))
+				continue
+
+			if(!job.enabled)
 				continue
 
 			// If the player wants that job on this level, then try give it to him.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -825,6 +825,10 @@
 				dat += "<A href='byond://?src=[REF(src)];[HrefToken()];removejobslot=[job.title]'>Remove</A> | "
 			else
 				dat += "Remove | "
+			if(job.enabled)
+				dat += "<A href='byond://?src=[REF(src)];[HrefToken()];disablejob=[job.title]'>Disable</A> | "
+			else
+				dat += "<A href='byond://?src=[REF(src)];[HrefToken()];enablejob=[job.title]'>Enable</A> | "
 			dat += "<A href='byond://?src=[REF(src)];[HrefToken()];unlimitjobslot=[job.title]'>Unlimit</A></td>"
 		else
 			dat += "<A href='byond://?src=[REF(src)];[HrefToken()];limitjobslot=[job.title]'>Limit</A></td>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -694,6 +694,33 @@
 
 		src.manage_free_slots()
 
+	else if(href_list["enablejob"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/Enable = href_list["enablejob"]
+		for(var/datum/job/job in SSjob.joinable_occupations)
+			if(job.title == Enable)
+				job.enabled = TRUE
+				job.total_positions = initial(job.total_positions)
+				job.spawn_positions = initial(job.spawn_positions)
+				break
+
+		src.manage_free_slots()
+
+	else if(href_list["disablejob"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/Disable = href_list["disablejob"]
+		for(var/datum/job/job in SSjob.joinable_occupations)
+			if(job.title == Disable)
+				job.enabled = FALSE
+				job.total_positions = 0
+				job.spawn_positions = 0
+				break
+		src.manage_free_slots()
+
 
 	else if(href_list["adminsmite"])
 		if(!check_rights(R_ADMIN|R_FUN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title

## Why It's Good For The Game

Admin can just press a button to disable a job or enable it, much easier, but for Persistence job use the specific admin verb for that.

Jobs that are disabled also got a check on the job subsystem to prevent issues.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
admin: New Admin option at Manage Job to disable or enable jobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
