### PR TITLE
Opens up yet more jobs for Tolerated Inhumen.

### DIFF
--- a/code/__DEFINES/species/_species.dm
+++ b/code/__DEFINES/species/_species.dm
@@ -207,14 +207,32 @@
 	SPEC_ID_DWARF,\
 )
 
-#define RACES_PLAYER_COURT_PHYSICIAN list(\
-	SPEC_ID_HUMEN,\
-	SPEC_ID_DWARF,\
-	SPEC_ID_AASIMAR,\
-	SPEC_ID_ELF,\
-	SPEC_ID_HALF_ELF,\
-	SPEC_ID_MEDICATOR,\
-)
+/// The butler
+
+#define RACES_BUTLER list(\
+		SPEC_ID_HUMEN,\
+		SPEC_ID_ELF,\
+		SPEC_ID_HALF_ELF,\
+		SPEC_ID_DWARF,\
+		SPEC_ID_DROW,\
+		SPEC_ID_HALF_DROW,\
+		SPEC_ID_TIEFLING,\
+		SPEC_ID_AASIMAR,\
+		SPEC_ID_HARPY,\
+		SPEC_ID_MEDICATOR,\
+		SPEC_ID_TRITON,\
+	)
+
+/// The tennite temple's paladins - Hallowed species excluding Harpies due to their inability to wear plate
+#define RACES_TEMPLAR list(\
+		SPEC_ID_HUMEN,\
+		SPEC_ID_ELF,\
+		SPEC_ID_HALF_ELF,\
+		SPEC_ID_DWARF,\
+		SPEC_ID_AASIMAR,\
+		SPEC_ID_MEDICATOR,\
+		SPEC_ID_TRITON,\
+	)
 
 /// Foreigner Nobility Species - No Tiefling (you know why) or hollow-kin or medicators (too young to have nobles mayhaps)
 #define RACES_PLAYER_FOREIGNNOBLE list(\

--- a/code/modules/jobs/job_types/church/priest.dm
+++ b/code/modules/jobs/job_types/church/priest.dm
@@ -16,7 +16,7 @@
 	selection_color = "#c2a45d"
 	cmode_music = 'sound/music/cmode/church/CombatAstrata.ogg'
 
-	allowed_races = RACES_PLAYER_NONDISCRIMINATED
+	allowed_races = RACES_PLAYER_NONHERETICAL
 
 	outfit = /datum/outfit/priest
 	spells = list(

--- a/code/modules/jobs/job_types/church/templar.dm
+++ b/code/modules/jobs/job_types/church/templar.dm
@@ -12,7 +12,10 @@
 	min_pq = 8
 	bypass_lastclass = TRUE
 
-	allowed_races = RACES_PLAYER_NONDISCRIMINATED
+// Medicators and Tritons are hallowed in the eyes of the Ten, no matter how much Astrata dislikes it, Harpies do not get to be templars because they literally cannot wear plate armour nor lift their weapons.
+	allowed_races = RACES_TEMPLAR
+
+
 	allowed_patrons = ALL_TEMPLAR_PATRONS
 
 	outfit = /datum/outfit/templar

--- a/code/modules/jobs/job_types/nobility/courtphys.dm
+++ b/code/modules/jobs/job_types/nobility/courtphys.dm
@@ -11,7 +11,7 @@
 	spawn_positions = 1
 	min_pq = 6
 
-	allowed_races = RACES_PLAYER_COURT_PHYSICIAN
+	allowed_races = RACES_PLAYER_NONHERETICAL
 
 	outfit = /datum/outfit/courtphys
 	give_bank_account = 100
@@ -58,5 +58,5 @@
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DEADNOSE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_LEGENDARY_ALCHEMIST, TRAIT_GENERIC)
-	if(H.dna.species.id != SPEC_ID_MEDICATOR)
+	if(H.dna.species.id == RACES_PLAYER_NONDISCRIMINATED) // Astrata forbid a medicator gets nobility
 		ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/peasants/butler.dm
+++ b/code/modules/jobs/job_types/peasants/butler.dm
@@ -16,17 +16,7 @@
 	bypass_lastclass = TRUE
 
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD, AGE_IMMORTAL)
-	allowed_races = list(\
-		SPEC_ID_HUMEN,\
-		SPEC_ID_ELF,\
-		SPEC_ID_HALF_ELF,\
-		SPEC_ID_DWARF,\
-		SPEC_ID_DROW,\
-		SPEC_ID_HALF_DROW,\
-		SPEC_ID_TIEFLING,\
-		SPEC_ID_AASIMAR,\
-		SPEC_ID_HARPY,\
-	)
+	allowed_races = RACES_BUTLER
 
 	outfit = /datum/outfit/butler
 	give_bank_account = 30 // Along with the pouch, enough to purchase some ingredients from the farm and give hard working servants a silver here and there. Still need the assistance of the crown's coffers to do anything significant


### PR DESCRIPTION
## About The Pull Request
This opens up the following job to tolerated inhumen species : 

- The Butler (can already be drow or tiefling)
- The Court physician (There is a check to not give nobility if they're not a tolerated inhumen + were already open to medicators).
- The Templar (Barring harpies, which have brittle bones, preventing them from wearing plate armour and holding a longsword)
- The priest (Up for debate, but I'd imagine this is something Astrate begrudginly allows because there are 3/4 other gods putting pressure on her, and 3 of those are amongst the more influencial).

This also removes the "RACE_BUTLER" define, since it will now be using RACE_PLAYER_NONHERETICAL

## Why It's Good For The Game
Tolerated inhumens are, as stated, tolerated, they can't play nobility because Astrata won't allow it, but there's no way in hell they have less rights than the ZIZOSPAWN. Regarding templars, these species are **actively blessed by a living patron of their temple**, akin to dwarves, elves or asimaar.  This does raise the question of balance, with  female tritons being really frigging strong : to this I raise their crummy perception, which cause them to miss more oft than not.
The only contentious part is the priest, but I feel like it makes for a fun dichotomy that the literal specist-in-chief is themself not humen.  This can be changed if needed, but I do admit we could always use more varied priest gimmicks.

## Changelog

:cl:
balance: Tolerated inhumen species may now become butlers, court physicians, and priests.
balance: Tritons and medicators can now become Templars.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

<img width="460" height="188" alt="image" src="https://github.com/user-attachments/assets/b96adf02-d3bb-468d-8408-ce6ca2695c41" />
<img width="512" height="226" alt="image" src="https://github.com/user-attachments/assets/1f9e6da5-4ba2-4a34-b4db-8f130f774800" />

