### PR TITLE
Fixes ALL adv classes using their parent job name

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/adventurer/types/_advclass.dm
@@ -7,7 +7,7 @@
 	abstract_type = /datum/job/advclass
 	total_positions = -1 // Infinite slots unless overriden
 	/// Take on the title of the previous job, if applied through regular means
-	var/inherit_parent_title = TRUE
+	var/inherit_parent_title = FALSE
 	/// Chance for this advanced class to roll for each player
 	var/roll_chance = 100
 	/// What categories we are going to sort it in, handles selection

--- a/code/modules/jobs/job_types/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/garrison/gatemaster.dm
@@ -37,6 +37,9 @@
 		if(!findtext(H.wear_armor.name,"([H.real_name])"))
 			H.wear_armor.name = "[H.wear_armor.name]"+" "+"([H.real_name])"
 
+/datum/job/advclass/gatemaster
+	inherit_parent_title = TRUE
+
 /datum/job/advclass/gatemaster/gatemaster_whip
 	title = "Chainguard Gatemaster"
 	tutorial = "Metal chimes in your hands, their skin rough from those heavy chains you pull. \

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -22,6 +22,9 @@
 	cmode_music = 'sound/music/cmode/nobility/CombatKnight.ogg'
 	job_bitflag = BITFLAG_GARRISON
 
+/datum/job/advclass/royalknight
+	inherit_parent_title = TRUE
+
 /datum/job/advclass/royalknight/knight
 	title = "Royal Knight"
 	tutorial = "The classic Knight in shining armor. Slightly more skilled then their Steam counterpart but has worse armor."

--- a/code/modules/jobs/job_types/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/garrison/veteran.dm
@@ -37,6 +37,9 @@
 		S.name = "veteran cloak ([index])"
 	ADD_TRAIT(spawned, TRAIT_OLDPARTY, TRAIT_GENERIC)
 
+/datum/job/advclass/veteran
+	inherit_parent_title = TRUE
+
 /datum/job/advclass/veteran/battlemaster
 	title = "Veteran Battlemaster"
 	tutorial = "You have served under a hundred masters, some good, some bad. You were a general once. A marshal, a captain. To some a hero, others a monster. Something of the sorts. You made strategies, tactics, new innovations of war. A thousand new ways for one man to kill another. It still keeps you up at night."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

So basically all adventurers titles were Adventurer, same for pilgrims , mercenary, forest guard and etc

Some roles use their job parent like Royal Knight, Consort, Prince, Gatemaster and Veteran

## Why It's Good For The Game

Fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Adv classes who showed their title having all the same name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
