### PR TITLE
Lockpicking changes

### DIFF
--- a/code/datums/locks/lockpicking.dm
+++ b/code/datums/locks/lockpicking.dm
@@ -34,7 +34,7 @@
 	finish_lockpicking(user)
 
 	//difficulty goes from 1 to 6, hence 6 - difficulty
-	var/break_prob = 60 - (skill_level * 10) + (6 - difficulty * 10)
+	var/break_prob = clamp(60 - (skill_level * 10) + (6 - difficulty * 10), 0, 100)
 	if(prob(break_prob))
 		to_chat(user, span_notice("My \the [lockpick_used] broke!"))
 		playsound(loc, 'sound/items/LPBreak.ogg', min(100 - (15 * skill_level) + (10 * 6 - difficulty), 100), extrarange = SILENCED_SOUND_EXTRARANGE)
@@ -49,7 +49,7 @@
 
 	playsound(loc, 'sound/items/LPWin.ogg', min(100 - (15 * skill_level) + (10 * 6 - difficulty), 100), extrarange = SILENCED_SOUND_EXTRARANGE)
 
-	var/amt2raise = (user.STAINT / 2) * (50 / difficulty)
+	var/amt2raise = (user.STAINT / 2) * (20 / difficulty)
 	var/boon = user.get_learning_boon(/datum/skill/misc/lockpicking)
 	user.adjust_experience(/datum/skill/misc/lockpicking, amt2raise * boon)
 	return TRUE
@@ -309,7 +309,7 @@
 	var/pick_y = 6 + cos(lock_angle)*6 - 6
 	if(failing)
 		if(break_checking_cooldown <= world.time)
-			var/break_prob = 10 - skill_level + (6 - difficulty) * 2
+			var/break_prob = clamp(10 - skill_level + (6 - difficulty) * 2, 0, 100)
 			if(prob(break_prob))
 				to_chat(picker, span_notice("My \the [the_lockpick] broke!"))
 				playsound(loc, 'sound/items/LPBreak.ogg', min(100 - (15 * skill_level) + (10 * 6 - difficulty), 100), extrarange = SILENCED_SOUND_EXTRARANGE)
@@ -317,7 +317,7 @@
 				//one tenth of the usual boost for picking a lock
 				if(isliving(picker))
 					var/mob/living/picker_real = picker
-					var/amt2raise = ((picker_real.STAINT / 2) * (50 / difficulty)) / 10
+					var/amt2raise = ((picker_real.STAINT / 2) * (20 / difficulty)) / 10
 					var/boon = picker_real.get_learning_boon(/datum/skill/misc/lockpicking)
 					picker_real.adjust_experience(/datum/skill/misc/lockpicking, amt2raise * boon)
 			if(picker.client?.prefs.showrolls)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Makes the difficulty of the lock affect the % chance for a lockpick to break and the volume of the sound it creates. (the highest possible volume however will be 100, which is basically the default for most sounds)
Also makes it so you can see what the % chance of the lockpick breaking
Difficulty also affects how often the lockpick will be tested to break.

Also changes how lockpicking levelling works, specifically the experience gain math
instead of
`user.STAINT + (50 / difficulty)`
it's now
`(user.STAINT / 2) * (50 / difficulty)`
Which I think is better but would obviously like it if people gave feedback

Also upon your lock breaking during the middle of lockpicking, you still get XP, just one tenth of what you would get on a succesful pick

## Why It's Good For The Game

It felt like difficulty barely affected anything, and I vaguely remember people complaining that at high enough lockpicking skill it made lockpicking completely silent (whereas those with weak lockpicking were incredibly loud).
Also I think it makes lockpicking actually able to be levelled up.
Hence these changes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Lock's difficulty now affects the % chance for a lockpick to break, how loud the lockpicking is, and how often the lockpick is tested if it will break. Levelling lockpicking should be easier now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
