### PR TITLE
Admin Delay / Accelerate Round end or round end vote verb.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -685,6 +685,47 @@
 			log_admin("[key_name(usr)] set the pre-game delay to [DisplayTimeText(newtime)].")
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Delay Game Start") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/accelerate_or_delay_round_end()
+	set category = "Server"
+	set desc="Delay / Accelerate the round ending or vote time"
+	set name="Delay / Accelerate the round ending or vote time"
+
+
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		return alert("This is only available while the game is in progress.")
+	var/list/choices = list("Time before the round end vote.", "Time until the game ends.")
+	var/choice = browser_input_list(src, "Choose what you want to adjust.", "Delay Tools", choices)
+	var/number
+	switch(choice)
+		if("Time before the round end vote.")
+			number = input(usr, "By how many minutes do you want to delay or accelerate it? (positive numbers delay, negative numbers accelerate)", "Time before the first round end vote.") as num
+			if(number)
+				if(number > 0)
+					to_chat(world, "<b>The round end vote will now occur in [(GLOB.round_timer + (number * 1 MINUTES))/600] minutes instead of [GLOB.round_timer/600] minutes.</b>")
+					log_admin("[key_name(usr)] delayed the round end vote by [number] minutes.")
+					message_admins("[key_name(usr)] delayed the round end vote by [number] minutes.")
+				else
+					to_chat(world, "<b>The round end vote will now occur in [(GLOB.round_timer - (-number * 1 MINUTES))/600] minutes instead of [GLOB.round_timer/600] minutes.</b>")
+					log_admin("[key_name(usr)] accelerated the round end vote by [-number] minutes.")
+					message_admins("[key_name(usr)] accelerated the round end vote by [-number] minutes.")
+				number *= 1 MINUTES
+				GLOB.round_timer += number
+				SSblackbox.record_feedback("tally", "admin_verb", 1, "Time before the round end vote triggered.")
+		if("Time until the game ends.")
+			number = input(usr, "By how many minutes do you want to delay or accelerate it? (positive numbers delay, negative numbers accelerate)", "Time until the round ends.") as num
+			if(number)
+				if(number > 0)
+					to_chat(world, "<b>The round ending will now occur after an additional [number] minutes.</b>")
+					log_admin("[key_name(usr)] delayed the round ending by [number] minutes.")
+					message_admins("[key_name(usr)] delayed the round ending by [number] minutes.")
+				else
+					to_chat(world, "<b>The round ending has been accelerated by [-number] minutes.</b>")
+					log_admin("[key_name(usr)] accelerated the round ending by [-number] minutes.")
+					message_admins("[key_name(usr)] accelerated the round ending by [-number] minutes.")
+				number *= 1 MINUTES
+				SSgamemode.round_ends_at += number
+				SSblackbox.record_feedback("tally", "admin_verb", 1, "Time until round ends triggered.")
+
 /datum/admins/proc/unprison(mob/M in GLOB.mob_list)
 	set category = "Admin"
 	set name = "Unprison"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -160,6 +160,7 @@ GLOBAL_PROTECT(admin_verbs_server)
 	/datum/admins/proc/restart,
 	/datum/admins/proc/end_round,
 	/datum/admins/proc/delay,
+	/datum/admins/proc/accelerate_or_delay_round_end,
 	/datum/admins/proc/toggleaban,
 	/client/proc/everyone_random,
 	/datum/admins/proc/toggleAI,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

With the first option you can delay when the first round vote happens with a positive or accelerate when that happens with a negative.

Example lets say the first vote happens in 60 minutes after round start, you can put -30 and it will happen in 30 minutes or you can put 30 and it will happen in 90 minutes based on the roundstart time.

With the second option you accelerate or delay the round time that appears when ppl voted for round end.

12 minutes until the round ends, then you put 10 and now it will take 22 minutes or if you put -10 it will take 2 minutes to end the round.

If you put 0 nothing will happen. 

## Why It's Good For The Game

More tools for admins.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
admin: New tool to delay/accelerate round end or round end vote.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
