### PR TITLE
Cloth and Plain Robes Fix

### DIFF
--- a/code/modules/crafting/quality_of_crafting/sewing.dm
+++ b/code/modules/crafting/quality_of_crafting/sewing.dm
@@ -565,7 +565,7 @@
 	craftdiff = 4
 
 /datum/repeatable_crafting_recipe/sewing/normal_robes
-	name = "robes"
+	name = "cloth robes"
 	output = /obj/item/clothing/shirt/robe
 	requirements = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/fibers = 1)
@@ -593,7 +593,7 @@
 	craftdiff = 3
 
 /datum/repeatable_crafting_recipe/sewing/robe
-	name = "robes"
+	name = "plain robes"
 	output = /obj/item/clothing/shirt/robe/colored/plain
 	requirements = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)


### PR DESCRIPTION
## About The Pull Request
Makes basic cloth robes craftable by giving them and the plain-dyed version unique names in the sewing menu.

Currently, it will always attempt to craft the diff3 version regardless of which you pick.
## Why It's Good For The Game
More crafting options and more UI clarity.
## Changelog
:cl:
fix: Changed the names of two instances of "robes" to be unique in the sewing menu.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
