### PR TITLE
Physicker balance slop

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/physicker.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/physicker.dm
@@ -13,9 +13,6 @@
 	cmode_music = 'sound/music/cmode/nobility/combat_physician.ogg'
 
 	skills = list(
-		/datum/skill/combat/wrestling = 2,
-		/datum/skill/combat/unarmed = 2,
-		/datum/skill/misc/athletics = 1,
 		/datum/skill/craft/crafting = 2,
 		/datum/skill/misc/reading = 3,
 		/datum/skill/combat/knives = 2,
@@ -37,6 +34,11 @@
 
 	outfit = /datum/outfit/adventurer/physicker
 
+/datum/job/advclass/pilgrim/physicker/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	spawned.adjust_skillrank(/datum/skill/combat/unarmed, pick(0,1,2), TRUE)
+	spawned.adjust_skillrank(/datum/skill/misc/athletics, pick(0,1,2), TRUE)
+	spawned.adjust_skillrank(/datum/skill/combat/wrestling, pick(0,1,2), TRUE)
 
 /datum/outfit/adventurer/physicker
 	mask = /obj/item/clothing/face/phys


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives the physicker slightly better stats and skills (but still worse than feldsher or apothecary), they also have a random chance of having a skill in in wrestling/unarmed/athletics from 0 (aka none) to 2 (aka average)
Also makes the physicker job file follow the guideline.

## Why It's Good For The Game

I found it a bit silly and somewhat annoying that physickers had -1 int.
I also wanted to give them some more skills (they are wandering doctors after all, quacks and rejects of course but still) without buffing them too much, hence the skills being randomized

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Slightly rebalanced Physicker's stats and skills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
