### PR TITLE
Fix Silver Amulets not protecting from transfix like the psycrosses

### DIFF
--- a/code/modules/spells/spell_types/undirected/transfix.dm
+++ b/code/modules/spells/spell_types/undirected/transfix.dm
@@ -88,7 +88,7 @@
 					extra = ", I sense the caster was [owner]!"
 				to_chat(target, "<font color='white'>The silver psycross shines and protect me from unholy magic[extra]</font>")
 				to_chat(owner, span_userdanger("[target] has my BANE! It causes me to fail to ensnare their mind!"))
-				continue
+				return
 
 		if(bloodroll >= willroll)
 			target.drowsyness = min(target.drowsyness + 50, 150)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title, also besides the message it was not really skipping the silver user so it was doing nothing

## Why It's Good For The Game

Fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Silver Amulet not protecting from transfix
fix: Psycross / SIlver amulet not protecting from transfix besides the message.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
