### PR TITLE
Murderwood greenskin camp

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin_forest.dmm
+++ b/_maps/map_files/vanderlin/vanderlin_forest.dmm
@@ -711,7 +711,7 @@
 "jv" = (
 /obj/structure/roguetent,
 /turf/open/floor/dirt/road,
-/area/rogue/outdoors/woods)
+/area/rogue/indoors)
 "jz" = (
 /obj/structure/fluff/customsign{
 	name = "Thatchwood Smithy"
@@ -1475,6 +1475,9 @@
 	dir = 1
 	},
 /turf/open/floor/ruinedwood/darker,
+/area/rogue/indoors)
+"uH" = (
+/turf/open/floor/dirt/road,
 /area/rogue/indoors)
 "uJ" = (
 /obj/structure/spider/stickyweb,
@@ -2721,7 +2724,7 @@
 "Qq" = (
 /obj/structure/bed/shit,
 /turf/open/floor/dirt/road,
-/area/rogue/outdoors/woods)
+/area/rogue/indoors)
 "Qr" = (
 /obj/structure/chair/stool,
 /turf/open/floor/naturalstone,
@@ -3174,7 +3177,7 @@
 /obj/effect/spawner/map_spawner/loot/coin/low,
 /obj/effect/spawner/map_spawner/loot/weapon,
 /turf/open/floor/dirt/road,
-/area/rogue/outdoors/woods)
+/area/rogue/indoors)
 "Yc" = (
 /obj/structure/fluff/railing/tall/palisade{
 	dir = 1
@@ -9126,8 +9129,8 @@ eX
 wV
 Qd
 tB
-mB
-mB
+YY
+YY
 Xk
 UR
 UR
@@ -9328,9 +9331,9 @@ Qd
 Qd
 Qd
 jv
-Qd
+uH
 XQ
-mB
+YY
 UR
 UR
 UR
@@ -9529,10 +9532,10 @@ Qd
 NR
 wV
 Qd
-mB
-Qd
+YY
+uH
 Qq
-mB
+YY
 UR
 Xk
 UR
@@ -9731,10 +9734,10 @@ Qd
 ba
 NR
 Qd
-mB
-Qd
+YY
+uH
 Qq
-mB
+YY
 tR
 Xk
 Xk
@@ -9934,8 +9937,8 @@ NR
 wV
 Qd
 tB
-mB
-mB
+YY
+YY
 Xk
 Xk
 Xk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a somewhat small/minor greenskin camp to the western part of murderwoods
<img width="898" height="933" alt="image" src="https://github.com/user-attachments/assets/8c74923d-6f39-43dd-8dec-285d27cbfac2" />
<img width="639" height="852" alt="image" src="https://github.com/user-attachments/assets/7617855f-3363-497d-9201-30ec894b3ded" />

Located here
<img width="114" height="129" alt="image" src="https://github.com/user-attachments/assets/5dfd3fa7-496f-4a8c-aa47-f6343bc35473" />

## Why It's Good For The Game

I think more minor places of interest are a good idea, and that part of the woods felt somewhat barren to me, hence this

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: added a minor/small greenskin camp to the west of the vanderlin murderwoods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
