### PR TITLE
Fixes caffine draining stamina

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -97,7 +97,7 @@
 
 /datum/reagent/consumable/caffeine/on_mob_life(mob/living/carbon/M)
 	. = ..()
-	M.adjust_stamina(5)
+	M.adjust_stamina(-5)
 	M.apply_status_effect(/datum/status_effect/buff/vigor)
 
 /datum/reagent/consumable/caffeine/overdose_process(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
adds a minus sign where it is needed so coffee and tea (subtypes of caffeine) do not drain stamina and instead restore it.

## Why It's Good For The Game

Coffee and tea are supposed to give energy, not make you crash out instantly. Also, this makes them less like a ridiculous poison.
## Changelog

:cl:
Fix: Caffeine now restores stamina instead of draining it. Tea and coffee lovers rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
