### PR TITLE
Harpy remembered they can speak Celestial

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
@@ -170,13 +170,13 @@
 
 /datum/species/harpy/after_creation(mob/living/carbon/C)
 	. = ..()
-	C.grant_language(/datum/language/beast)
-	to_chat(C, "<span class='info'>I can speak Beastish with ,b before my speech.</span>")
+	C.grant_language(/datum/language/celestial)
+	to_chat(C, "<span class='info'>I can speak Celestial with ,c before my speech.</span>")
 
 /datum/species/harpy/on_species_loss(mob/living/carbon/C)
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
-	C.remove_language(/datum/language/beast)
+	C.remove_language(/datum/language/celestial)
 
 /datum/species/harpy/get_skin_list()
 	return sortList(list(


### PR DESCRIPTION
Being creatures that are favored by eora, they have been blessed with the ability to speak the language of the gods.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A simple addition that gives harpies the ability to speak celestial, because lore reasons
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
L o r e.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Harpies can now understand and speak Celestial.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
