### PR TITLE
Update on the men at arms

### DIFF
--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -23,6 +23,7 @@
 	cmode_music = 'sound/music/cmode/garrison/CombatManAtArms.ogg'
 	give_bank_account = 15
 	min_pq = 6
+	give_bank_account = 30
 
 	job_bitflag = BITFLAG_GARRISON
 


### PR DESCRIPTION
## About the pull request

adds a hauberk to the men at arms pikeman, removing his cuirass and chain gloves for a bevor

adds splint mailles & bevors to the archer & the fencer, the top men of the lord should have the iron gear at least, since recent feedback and code review shows the men at arms being way ill geared than the town watchmen and antags, i should have added iron boots and chain gloves to them too.

thinking about it i said no since the men at arms are way more comfortable in the keep than the town watchmen being on the streets, a MAA just needed a reinforcement on their gear, not a whole upgrade

the pikeman has arm/leg defense since he is the frontline alongside knights & veteran

swordsman and bowman a fancy gambeson, splint maille & bevor to don't get knocked out inmediately like a town watchmen could be

## Why It's Good For The Game

the town watchmen wouldn't be better armed than the men at arms of the lord, adds them more coverage in general without add too much on upgrades, even if is steel 

<img width="588" height="350" alt="ShareX_mz3Sr9RAZb" src="https://github.com/user-attachments/assets/4b3ce2e7-56f1-4c2d-afaa-af4fd3ac41d0" />


## Changelog

:cl:

balance: reinforced the men at arms loadouts

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
