### PR TITLE
Forest Brawler's Dreaded (Or Beloved) Return

### DIFF
--- a/code/modules/jobs/job_types/garrison/forestguard.dm
+++ b/code/modules/jobs/job_types/garrison/forestguard.dm
@@ -218,6 +218,10 @@
 	cmode_music = 'sound/music/cmode/adventurer/CombatMonk.ogg'
 	outfit = /datum/outfit/forestguard/brawler
 
+/datum/job/advclass/forestguard/brawler/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	spawned.verbs |= /mob/proc/haltyell
+
 /datum/outfit/forestguard/brawler
 	name = "Forest Brawler"
 	head = /obj/item/clothing/head/helmet/medium/decorated/skullmet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds back the old forest brawler with a few tweaks that put it in this really wacky kind of fistfight gimmick that isn't me giving them +4 str like they used to have (eugh)

The main changes being removing their dodge expert, giving them the medium armor like the other medium armor users, making their negative speed modifer only -1 because middle aged already gives -1, handing the pugilist gloves over aswell.

And here's some balanceslop speak for those interested: While the crit resistance could look wacky, expert fist fighting is atrocious for blocking and it felt like this class should be that true unarmed, aka no fist weapon. I've given them 1 more dagger skill than they had before so they have some way to say, decap someone who's already out with their hunting knife without making them just a knife fighter.

To be specific. Expert fistfighting vs expert weaponskill is a 5% chance to block whereas against a skilled weaponskill user it's only 20%, thus the idea is that fistfighter's just a big wall that's hard pushed into a aggresive role due to their lack of being able to defend themselves. Almost like a more extreme version of reaver's gimmick without the damage slowdown ignoring trait, Reaver's able to keep running at you, brawler's able to stay standing. Feels better than just making them another master fist-fighter or katar/knuckle user. (Also holding your knife in your hand doesn't make it any better, don't worry.)

I also turned them up to skilled athletics, they were at average before. I'm suprised ravager's actually average athletics when the rest are skilled, something I completely missed. prob gonna change that at some point.

Also if crit resistance ends up being too much I'm taking it out, don't worry

## Why It's Good For The Game
We've been on a little fist-fighting spree, why not get some more in the boiling pot, especially when they're a classic from back in the day.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Brings back the old forest guard subclass Forest Brawler with some slight tweaks to encourage aggression.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
