### PR TITLE
Fixes the inquisitor's halberd being unselectable.

### DIFF
--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -45,7 +45,7 @@
 				if("Daybreak - Silver Whip")
 					choice = /obj/item/weapon/whip/antique/psywhip
 				if("Sanctum - Silver Halberd")
-					choice = /obj/item/weapon/polearm/halberd/psydon
+					choice = /obj/item/weapon/polearm/halberd/psydon/relic
 					user.clamped_adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)	//We make sure the weapon is usable by the Inquisitor.
 				if("Crusade - Silver Greatsword")
 					choice = /obj/item/weapon/sword/long/greatsword/psydon

--- a/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
+++ b/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
@@ -76,7 +76,7 @@
 		if("Daybreak (Whip)")
 			H.put_in_hands(new /obj/item/weapon/whip/antique/psywhip(H), TRUE)
 			H.clamped_adjust_skillrank(/datum/skill/combat/whipsflails, 4, 4, TRUE)
-		if("S (Halberd)")
+		if("Sanctum (Halberd)")
 			H.put_in_hands(new /obj/item/weapon/polearm/halberd/psydon/relic(H), TRUE)
 			H.clamped_adjust_skillrank(/datum/skill/combat/polearms, 4, 4, TRUE)
 		if("The Forgotten Blade")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This was my oopsie, misplaced a portion of the selector.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix!!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Inspector's halberd SHOULD be selectable now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
