### PR TITLE
Halves the VL's "power increase research" costs

### DIFF
--- a/code/modules/antagonists/villain/vampire/objects/bloodpool.dm
+++ b/code/modules/antagonists/villain/vampire/objects/bloodpool.dm
@@ -1,7 +1,7 @@
-#define VAMPCOST_ONE 10000
-#define VAMPCOST_TWO 12000
-#define VAMPCOST_THREE 15000
-#define VAMPCOST_FOUR 20000
+#define VAMPCOST_ONE 5000
+#define VAMPCOST_TWO 6000
+#define VAMPCOST_THREE 7500
+#define VAMPCOST_FOUR 10000
 
 /obj/structure/vampire/bloodpool
 	name = "Crimson Crucible"


### PR DESCRIPTION
## About The Pull Request

Title, really.

## Why It's Good For The Game

Currently, if you want to raise even level 1, you need to input TEN. THOUSAND. UNITS of blood. You can only hold up to ~3000 on your person at one time, and that's also the resource used for your spells. Halving this cost means you don't have to spend all of your round farming goblins and get to mess around with the funny spells a bit more. You're supposed to be a server-wide antagonist, not a facebook idle game.

<img width="351" height="210" alt="image" src="https://github.com/user-attachments/assets/afb076f0-e718-4d24-9688-52bf81df7452" />

## Changelog
:cl:
balance: Halves the blood requirement for the vampire lord's blood rites research (the ones that make you stronger).
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
