### PR TITLE
Disallows post round WW transformations

### DIFF
--- a/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
@@ -20,8 +20,10 @@
 	werewolf_untransform(null, TRUE, gibbed)
 
 /mob/living/carbon/human/proc/werewolf_transform()
-	if(HAS_TRAIT(src, TRAIT_SILVER_BLESSED)) return
-
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		return
+	if(HAS_TRAIT(src, TRAIT_SILVER_BLESSED))
+		return
 	if(HAS_TRAIT(src, TRAIT_WEREWOLF_RAGE))
 		return
 	if(is_species(src, /datum/species/werewolf))
@@ -109,6 +111,8 @@
 	invisibility = oldinv
 
 /mob/living/carbon/human/proc/werewolf_untransform(mob/bleh, dead,gibbed)
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		return
 	if(!stored_mob)
 		var/mob/living/carbon/human/species/werewolf/wolf = loc
 		if(istype(wolf))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Disallows WW transformations after the round has ended, as without this WW would transform/untransform during end round period, which was messing with stats, as each WW transform/untransform creates and deletes entirely new mobs.

No real gameplay change.