### PR TITLE
The Psyaltrist role now gets the "of the inquisition" trait.

### DIFF
--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/psyaltrist.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/psyaltrist.dm
@@ -23,7 +23,12 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE
 	)
 
-	traits = list(TRAIT_DODGEEXPERT, TRAIT_EMPATH)
+	traits = list(	TRAIT_DODGEEXPERT,
+		TRAIT_EMPATH,
+		TRAIT_INQUISITION,
+		TRAIT_SILVER_BLESSED,
+		TRAIT_PSYDONIAN_GRIT,
+		TRAIT_PSYDONITE,)
 
 	spells = list(/datum/action/cooldown/spell/vicious_mockery)
 


### PR DESCRIPTION
## About The Pull Request
Fuck this glorp life.

The Psyaltrist role did NOT get the "of the inquisition" trait when they spawned. And since I'm apparently the only psyaltrist player ever, I thought this was due to triumph buys. Oh, and they also didn't get any other special traits like psydonian grit either.

Needless to say I am quite peeved.

## Why It's Good For The Game
Fixes an absymally stupid bug. I'm going to bite my fist.
fixes #4196 

## Changelog

:cl:
fix: The Psyaltrist role now gets the "of the inquisition", "psydonian grit", and etc.. traits.
/:cl:

## Pre-Merge Checklist
Works on my machine.

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

