### PR TITLE
Werewolf stat fix and compilation of claw var's

### DIFF
--- a/code/modules/antagonists/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/villain/werewolf/werewolf.dm
@@ -189,7 +189,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "claw"
 	hitsound = "genslash"
-	penfactor = 30
+	penfactor = 45
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"
@@ -208,7 +208,6 @@
 	force = 15
 	block_chance = 0
 	wdefense = 2
-	armor_penetration = 15
 	associated_skill = /datum/skill/combat/unarmed
 	wlength = WLENGTH_NORMAL
 	wbalance = EASY_TO_DODGE

--- a/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/villain/werewolf/werewolf_transformation.dm
@@ -94,9 +94,9 @@
 	W.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 	W.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
 
-	W.base_constitution = 15
-	W.base_strength = 15
-	W.base_endurance = 15
+	W.base_constitution = 10 //werewolf.dm in the species has their ACTUAL stats, don't edit these, they'll make them stack ontop of each other.
+	W.base_strength = 10
+	W.base_endurance = 10
 	W.recalculate_stats()
 
 	W.add_spell(/datum/action/cooldown/spell/undirected/howl)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This is just a fix to get werewolf to be actually 15 str, 15 con, 15 end, like Borbop intended. Turns out it was stacking because werewolve's species itself gives them +5 stats. So I've made the transformation itself just put them at 10 str, 10 con, 10 end. Ends up with them having 15 in all.

Also removes the Armor_penetration var from the werewolf claws, instead adding it's value to the penfactor var, I tested using values of both, they seem to basically do the same thing? I haven't seen armor_penetration used anywhere else either, so this is for ease of understanding for future changes.

This is NOT A BALANCE PR, just to make things as intended and easier for coders.

## Why It's Good For The Game

Makes werewolf as intended, makes it easier to understand it's stats from a code perspective.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: rebalanced something
fix: Werewolf stats fixed, down to the intended 15.
code: Removed armor_penetration var from werevolf claws, combined it's value with the claw's penfactor var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
