### PR TITLE
Vanderlin Map Touch Ups

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -3429,7 +3429,7 @@
 /obj/structure/window/openclose/reinforced{
 	dir = 8
 	},
-/turf/open/floor/ruinedwood,
+/turf/open/floor/wood/nosmooth,
 /area/rogue/under/town/caverogue)
 "bKC" = (
 /obj/structure/chair/bench/church{
@@ -17721,7 +17721,7 @@
 /obj/structure/window/openclose/reinforced{
 	dir = 8
 	},
-/turf/open/floor/ruinedwood,
+/turf/open/floor/wood/nosmooth,
 /area/rogue/under/town/caverogue)
 "jam" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -20247,7 +20247,7 @@
 /obj/structure/window/openclose/reinforced{
 	dir = 1
 	},
-/turf/open/floor/ruinedwood/darker,
+/turf/open/floor/wood/nosmooth,
 /area/rogue/indoors/town)
 "kos" = (
 /obj/structure/fluff/railing/wood{
@@ -21779,7 +21779,7 @@
 /obj/effect/mapping_helpers/access/locker,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/access/keyset/manor/Noble2,
-/turf/open/floor/ruinedwood/darker,
+/turf/open/floor/wood/nosmooth,
 /area/rogue/indoors/town)
 "ljt" = (
 /obj/structure/chair/wood/alt/chair3,
@@ -34972,7 +34972,7 @@
 /obj/structure/window/openclose/reinforced{
 	dir = 4
 	},
-/turf/open/floor/ruinedwood,
+/turf/open/floor/wood/nosmooth,
 /area/rogue/outdoors/beach)
 "slM" = (
 /obj/machinery/light/fueled/wallfire/candle/l,
@@ -39025,7 +39025,7 @@
 	},
 /obj/effect/mapping_helpers/access/locker,
 /obj/effect/mapping_helpers/access/keyset/manor/Noble1,
-/turf/closed/wall/mineral/stonebrick,
+/turf/open/floor/herringbone,
 /area/rogue/indoors/town)
 "urH" = (
 /obj/structure/fluff/walldeco/church/line{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes and touch ups
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes various small things before Vanderlin the Map freeze
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: Fixes some small issues with Vanderlin
map: Touches up the noble estates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
