### PR TITLE
Lowers the cost and CD of bodypart miracle.

### DIFF
--- a/code/datums/faith/devotion_subtypes.dm
+++ b/code/datums/faith/devotion_subtypes.dm
@@ -59,7 +59,8 @@
 	miracles = list(
 		CLERIC_T0 = list(/datum/action/cooldown/spell/healing, /datum/action/cooldown/spell/undirected/conjure_item/summon_leech/pestra),
 		CLERIC_T1 = /datum/action/cooldown/spell/diagnose/holy,
-		CLERIC_T2 = list(/datum/action/cooldown/spell/attach_bodypart, /datum/action/cooldown/spell/cure_rot),
+		CLERIC_T2 = /datum/action/cooldown/spell/attach_bodypart,
+		CLERIC_T3 = /datum/action/cooldown/spell/cure_rot,
 	)
 
 /datum/devotion/divine/malum

--- a/code/datums/faith/devotion_subtypes.dm
+++ b/code/datums/faith/devotion_subtypes.dm
@@ -59,8 +59,7 @@
 	miracles = list(
 		CLERIC_T0 = list(/datum/action/cooldown/spell/healing, /datum/action/cooldown/spell/undirected/conjure_item/summon_leech/pestra),
 		CLERIC_T1 = /datum/action/cooldown/spell/diagnose/holy,
-		CLERIC_T2 = /datum/action/cooldown/spell/attach_bodypart,
-		CLERIC_T3 = /datum/action/cooldown/spell/cure_rot,
+		CLERIC_T2 = list(/datum/action/cooldown/spell/attach_bodypart, /datum/action/cooldown/spell/cure_rot),
 	)
 
 /datum/devotion/divine/malum

--- a/code/modules/spells/spell_types/pointed/attach_bodypart.dm
+++ b/code/modules/spells/spell_types/pointed/attach_bodypart.dm
@@ -12,8 +12,8 @@
 	required_items = list(/obj/item/clothing/neck/psycross/silver)
 
 	charge_required = FALSE
-	cooldown_time = 30 SECONDS
-	spell_cost = 125
+	cooldown_time = 20 SECONDS
+	spell_cost = 50
 
 /datum/action/cooldown/spell/attach_bodypart/is_valid_target(atom/cast_on)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This makes the Pestran miracle "Cure Rot" a T2, and lowers the cost of Bodypart miracle from 125 to 50, while it's cooldown goes from 30 to 20 seconds. 

## Why It's Good For The Game

The Pestran templar has very little going for them  : standard plate armour, not-very-good daggers, and most importantly lacks any spell that is meaningful in combat, bar lesser miracle. Giving them cure rot makes them serviceable against deadites, which are now actually very fucking scary. Remember that Cure Rot is on a 2 minute cooldown and needs a pantheon cross, thus templars do not become deadite-murdering machines, but they can actually protect the temple from the errand swarm.

The bodypart miracle, meanwhile, is not worth calling a T3 : Pestran acolytes have the medical know-how to put organs back inside people anyways. Thus it remains at the T2 level until someone gives Pestra some love.  It also gets a reduced cost because 125 devotion for 1 organ/limb is absolutely stupid. The cooldown is also reduced because it should not take 1 minute to put 2 organs back inside someone when you're are an acolyte to the goddess of medicine. 

## Picture

<img width="1343" height="1021" alt="image" src="https://github.com/user-attachments/assets/b6a21db9-bd93-407c-8713-4dffa690e6a0" />


## Changelog

:cl:

balance: Makes Cure Rot a T2 miracle.
balance: Lowered the cost of Bodypart miracle from 125 to 50, and it's CD from 30 to 20 seconds.

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

