### PR TITLE
Fixes Nocshades and gives them (and the confessor's mask) a description.

### DIFF
--- a/code/modules/clothing/face/spectacle.dm
+++ b/code/modules/clothing/face/spectacle.dm
@@ -45,7 +45,13 @@
 	body_parts_covered = EYES
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD
 	anvilrepair = /datum/skill/craft/armorsmithing
-	var/lensmoved = FALSE
+	var/lensmoved = TRUE // starts with the lenses out of the way, night vision being off.
+
+/obj/item/clothing/face/spectacles/inq/examine(mob/user) // informs inquisition members of the night vision functionality.
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_INQUISITION))
+		. += span_info("These spectacles posess photosensitive lenses. The user may slide them into place for short-range dark-vision.")
+		. += span_warning("Use the Middle Mouse Button on the glasses, with your jump, bite, etc.. intents OFF to (de)activate nightvision.")
 
 /obj/item/clothing/face/spectacles/inq/spawnpair
 	lensmoved = TRUE
@@ -64,18 +70,22 @@
 		to_chat(user, span_info("You discreetly slide the inner lenses out of the way."))
 		REMOVE_TRAIT(user, TRAIT_NOCSHADES, "redlens")
 		lensmoved = TRUE
+		user.update_sight()
 		return
 	to_chat(user, span_info("You discreetly slide the inner lenses back into place."))
 	ADD_TRAIT(user, TRAIT_NOCSHADES, "redlens")
 	lensmoved = FALSE
+	user.update_sight()
 
 /obj/item/clothing/face/spectacles/inq/dropped(mob/user, slot)
 	..()
 	if(!(slot & ITEM_SLOT_MASK) || slot & ITEM_SLOT_HEAD)
 		if(!lensmoved)
 			REMOVE_TRAIT(user, TRAIT_NOCSHADES, "redlens")
+			user.update_sight()
+			lensmoved = TRUE // set the night vision to off, to avoid weirdness
 			return
-		lensmoved = FALSE
+
 
 
 /obj/item/clothing/face/sack
@@ -111,6 +121,12 @@
 	var/worn = FALSE
 	slot_flags = ITEM_SLOT_MASK
 
+/obj/item/clothing/face/facemask/steel/confessor/examine(mob/user) // informs inquisition members that nocshades can be installed in the mask.
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_INQUISITION) && !istype(src, /obj/item/clothing/face/facemask/steel/confessor/lensed))
+		. += span_info("This mask may have nocshades installed into it.")
+
+
 /obj/item/clothing/face/facemask/steel/confessor/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(user.wear_mask == src)
@@ -145,27 +161,38 @@
 	icon_state = "confessormask_lens"
 	var/lensmoved = TRUE
 
+/obj/item/clothing/face/facemask/steel/confessor/lensed/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_INQUISITION))
+		. += span_info("This mask contains noc-shades, which provide the user with short-range dark-vision when activated.")
+		. += span_warning("Use the Middle Mouse Button on the glasses, with your jump, bite, etc.. intents OFF to (de)activate nightvision.")
+
 /obj/item/clothing/face/facemask/steel/confessor/lensed/equipped(mob/user, slot)
 	..()
 	if(slot & ITEM_SLOT_MASK || slot & ITEM_SLOT_HEAD)
 		if(!lensmoved)
 			ADD_TRAIT(user, TRAIT_NOCSHADES, "redlens")
+			user.update_sight()
 			return
 
-/obj/item/clothing/face/facemask/steel/confessor/lensed/attack_hand_secondary(mob/user, params)
+/obj/item/clothing/face/facemask/steel/confessor/lensed/MiddleClick(mob/user, params)
 	. = ..()
 	if(!lensmoved)
 		to_chat(user, span_info("You discreetly slide the inner lenses out of the way."))
 		REMOVE_TRAIT(user, TRAIT_NOCSHADES, "redlens")
 		lensmoved = TRUE
+		user.update_sight()
 		return
 	to_chat(user, span_info("You discreetly slide the inner lenses back into place."))
 	ADD_TRAIT(user, TRAIT_NOCSHADES, "redlens")
 	lensmoved = FALSE
+	user.update_sight()
 
 /obj/item/clothing/face/facemask/steel/confessor/lensed/dropped(mob/user, slot)
 	..()
 	if(!(slot & ITEM_SLOT_MASK) || slot & ITEM_SLOT_HEAD)
 		if(!lensmoved)
 			REMOVE_TRAIT(user, TRAIT_NOCSHADES, "redlens")
+			user.update_sight()
+			lensmoved = TRUE // set the night vision to off, to avoid weirdness
 			return


### PR DESCRIPTION
## About The Pull Request
Fixes Nocshades updating nightvision only when you put a hat on/off. Lets member of the Oratorium know that it has Night Vision functionnalities on examine. 
Also adds description to the confessor's mask clearly saying that they can receive noc-shades. 

## Why It's Good For The Game

Fixes #3849 and #4250 . Also gives good QoL to the members of the inquisition, telling them why NocShades are worth like 16 marques or something.

## Screenshots
<img width="613" height="130" alt="image" src="https://github.com/user-attachments/assets/414c7eb3-56dd-4141-878c-b73ad853b2dc" />

<img width="640" height="139" alt="image" src="https://github.com/user-attachments/assets/a92ab1fb-e756-4d94-bae7-8ee23c2561e1" />

<img width="638" height="175" alt="image" src="https://github.com/user-attachments/assets/c7771fdd-c30d-4994-bc2c-54004e91f6ce" />



## Changelog
<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Adds a description to nocshades and the confessor mask regarding night-vision + the ability to put nocshades in the confessor's mask. 
fix: Fixes the Noc-Shades not updating your nightvision when turned on/off or taken off. 
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

