### PR TITLE
"Call it a reliquary for Psydon's sake" : Un-frenches the inquisition's hermes

### DIFF
--- a/code/game/objects/structures/fake_machines/mail.dm
+++ b/code/game/objects/structures/fake_machines/mail.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(letters_sent)
 	. += span_info("Load a coin inside, then right click to send a letter.")
 	. += span_info("Left click with a paper to send a prewritten letter for free.")
 	if(HAS_TRAIT(user, TRAIT_INQUISITION))
-		. += span_info("<br>The MARQUETTE can be accessed via a secret compartment fitted within the HERMES. Load a Marque to access it.")
+		. += span_info("<br>The Oratorium's reliquary can be accessed via a secret compartment fitted within the HERMES. Load a Marque to access it.")
 
 		. += span_info("You can send arrival slips, accusation slips, fully loaded INDEXERs or confessions here.")
 		. += span_info("Properly sign them. Include an INDEXER where needed. Stamp them for two additional Marques.")
@@ -796,12 +796,12 @@ GLOBAL_LIST_EMPTY(letters_sent)
 
 /obj/structure/fake_machine/mail/proc/display_marquette(mob/user)
 	var/contents
-	contents = "<center>✤ ── L'INQUISITION MARQUETTE D'ORATORIUM ── ✤<BR>"
-	contents += "POUR L'ÉRADICATION DE L'HÉRÉSIE, TANT QUE PSYDON ENDURE.<BR>"
+	contents = "<center>✤ ── THE ORATORIUM'S RELIQUARY ── ✤<BR>"
+	contents += "ERADICATE HERESY, SO THAT PSYDONIA MAY ENDURE <BR>"
 	if(HAS_TRAIT(user, TRAIT_PURITAN))
-		contents += "✤ ── <a href='?src=[REF(src)];locktoggle=1]'> PURITAN'S LOCK: [inqonly ? "OUI":"NON"]</a> ── ✤<BR>"
+		contents += "✤ ── <a href='?src=[REF(src)];locktoggle=1]'> PURITAN'S LOCK: [inqonly ? "YES":"NO"]</a> ── ✤<BR>"
 	else
-		contents += "✤ ── PURITAN'S LOCK: [inqonly ? "OUI":"NON"] ── ✤<BR>"
+		contents += "✤ ── PURITAN'S LOCK: [inqonly ? "YES":"NO"] ── ✤<BR>"
 	contents += "ᛉ <a href='?src=[REF(src)];eject=1'>MARQUES LOADED: [inqcoins]</a>ᛉ<BR>"
 
 	if(cat_current == "1")


### PR DESCRIPTION
## About The Pull Request
Changes the text in the inquisition's reliquary to not be in French. Also fixes the way the sentence is formed, which was nonsensical even translated in english.

Despite my best attempts, I could not fix the UTF-8 characters showing up as gibberish.

## Why It's Good For The Game

_"Pour l'éradication de l'hérésie, tant que Psydon endvre" ? Passe le jeu en anglais, merde !_

## Changelog

:cl:
fix: The Oratorium reliquary menu no longer is French
/:cl:

## Vérifications avant l'ajout

- [x] Vous avez testé votre code sur un serveur local.
- [x] Ce code n'a pas runtime durant l'exécution.
- [x] Vous avez documenté tous vos changements.
