### PR TITLE
Remove defunct dismember sound effect code

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1111,12 +1111,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if((get_sharpness() || damtype == BURN) && (w_class >= WEIGHT_CLASS_NORMAL) && force >= 10)
 		return force * (affecting.get_damage() / affecting.max_damage)
 
-/obj/item/proc/get_dismember_sound()
-	if(damtype == BURN)
-		. = 'sound/blank.ogg'
-	else
-		. = "desceration"
-
 /obj/item/proc/open_flame(flame_heat=700)
 	var/turf/location = loc
 	if(ismob(location))

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -53,7 +53,6 @@
 			l_leg.dismember()
 		if(r_leg)
 			r_leg.dismember()
-		playsound(user, "desceration", 50, TRUE, -1)
 		return BRUTELOSS
 	else//didnt realize this suicide act existed (was in miscellaneous.dm) and didnt want to remove it, so made it a 50/50 chance. Why not!
 		user.visible_message("<span class='suicide'>[user] is bashing [user.p_their()] own head in with [src]! Ain't that a kick in the head?</span>")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -240,7 +240,6 @@
 		var/probability = I.get_dismemberment_chance(affecting, user)
 		if(prob(probability) && affecting.dismember(I.damtype, user.used_intent?.blade_class, user, user.zone_selected))
 			I.add_mob_blood(src)
-			playsound(get_turf(src), I.get_dismember_sound(), 80, TRUE)
 		return TRUE //successful attack
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1464,8 +1464,7 @@ GLOBAL_LIST_EMPTY(patreon_races)
 				var/easy_dismember = HAS_TRAIT(target, TRAIT_EASYDISMEMBER) || affecting.rotted
 				if(prob(damage/2) || (easy_dismember && prob(damage/2))) //try twice
 					if(affecting.brute_dam > 0)
-						if(affecting.dismember())
-							playsound(get_turf(target), "desceration", 80, TRUE)
+						affecting.dismember()
 
 /*		if(user == target)
 			target.visible_message("<span class='danger'>[user] [atk_verb]ed themself![target.next_attack_msg.Join()]</span>", COMBAT_MESSAGE_RANGE, user)
@@ -1907,7 +1906,6 @@ GLOBAL_LIST_EMPTY(patreon_races)
 		bloody = 1
 		I.add_mob_blood(H)
 		user.update_inv_hands()
-		playsound(get_turf(H), I.get_dismember_sound(), 80, TRUE)
 
 	if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))
 		if(affecting.status == BODYPART_ORGANIC)


### PR DESCRIPTION
`"desceration"` does not exist in `get_sfx()`, so it results in no sound and any code referencing it is pointless. also, `dismember()` uses the bodypart's dismember sound. also it's a typo of `"desecration"` anyway.

due to this `get_dismember_sound()` would always return a blank/invalid sound, so it was removed as well. dismember sounds are handled elsewhere now anyway