### PR TITLE
Makes the Locate Dead miracle less expensive.

### DIFF
--- a/code/modules/spells/spell_types/undirected/locate_dead.dm
+++ b/code/modules/spells/spell_types/undirected/locate_dead.dm
@@ -13,8 +13,8 @@
 	invocation_type = INVOCATION_WHISPER
 
 	charge_required = FALSE
-	cooldown_time = 60 SECONDS
-	spell_cost = 50
+	cooldown_time = 30 SECONDS
+	spell_cost = 15
 
 /datum/action/cooldown/spell/undirected/locate_dead/cast(atom/cast_on)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Changes the devotion cost of the "find corpse" miracle from 50 to 15. And it's cooldown from 60 seconds to 30 seconds.

## Why It's Good For The Game

Locate corpse is an essential tool to gravekeepers, but it costing 50 devotion means it takes one entire minute to muster the necessary resources to cast it. It also has a long cooldown despite being (purposefully) vague. Buffing it will make it less of a chore to find bodies.

## Changelog

:cl:

balance: the Find Corpse Necran miracle now costs 15 devotion, down from 50, it also has a CD of 30 seconds, down from 60.

/:cl:
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

