### PR TITLE
Adds the icon for ABSOLVE and WEEP.

### DIFF
--- a/code/modules/spells/spell_types/pointed/absolve.dm
+++ b/code/modules/spells/spell_types/pointed/absolve.dm
@@ -11,6 +11,7 @@
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	cooldown_time = 30 SECONDS // 60 seconds cooldown
+	button_icon_state = "ABSOLVE"
 
 /datum/action/cooldown/spell/psydonabsolve/cast(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/spells/spell_types/pointed/lux_tamper.dm
+++ b/code/modules/spells/spell_types/pointed/lux_tamper.dm
@@ -11,6 +11,7 @@
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	cooldown_time = 1 MINUTES // 60 seconds cooldown
+	button_icon_state = "WEEP"
 
 /datum/action/cooldown/spell/psydonlux_tamper/cast(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Seems like they didn't have an icon despite the icon being in code, this adds it to the spells.
<img width="266" height="220" alt="image" src="https://github.com/user-attachments/assets/baca0415-f53f-44fd-b549-36001496b1ff" />


## Why It's Good For The Game
Icons are peak.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added icon to absolve and weep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
