### PR TITLE
Makes voting force a popup in your face forcing you to realize that there is a vote taking place.

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -160,7 +160,7 @@
 
 	players_report()
 
-	SSvote.initiate_vote("map", "Psydon")
+	SSvote.initiate_vote("map", "Psydon", TRUE)
 
 	CHECK_TICK
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -231,7 +231,7 @@ SUBSYSTEM_DEF(vote)
 				return vote
 	return 0
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, forced_popup = FALSE)
 	if(!mode)
 		if(started_time && initiator_key)
 			var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))
@@ -294,6 +294,9 @@ SUBSYSTEM_DEF(vote)
 		var/vp = CONFIG_GET(number/vote_period)
 		to_chat(world, "\n<font color='purple'><b>[text]</b>\nClick <a href='byond://?src=[REF(src)]'>here</a> to place your vote.\nYou have [DisplayTimeText(vp)] to vote.</font>")
 		time_remaining = round(vp/10)
+		if(forced_popup)
+			for(var/client/C in GLOB.clients)
+				browser_alert(C, "New vote started by [initiator], you can click <a href='byond://?src=[REF(src)]'>here</a> to place your vote.")
 //		for(var/c in GLOB.clients)
 //			var/client/C = c
 //			var/datum/action/vote/V = new

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -379,7 +379,13 @@
 			type = "map"
 		if("Custom")
 			type = "custom"
-	SSvote.initiate_vote(type, usr.key)
+	var/force = input("Force the players into seeing a popup about the vote?") as null|anything in list("Yes", "No")
+	switch(force)
+		if("Yes")
+			force = TRUE
+		if("No")
+			force = FALSE
+	SSvote.initiate_vote(type, usr.key, force)
 
 /datum/admins/proc/adjusttriumphs(mob/living/M in GLOB.mob_list)
 	set name = "Adjust Triumphs"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

lightnovel name

also makes it so the admin, upon starting a vote, can choose to give a popup

## Why It's Good For The Game

people regularly forget there is a vote taking place (can't blame them, shit gets burried underneath the wall of text)
this rectifies that by literally forcing the vote popup into your face.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
admin: admins can choose if the vote (roundend, custom, etc.) is shoved into the players face
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
