### PR TITLE
Optimize icon smoothing

### DIFF
--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -9,10 +9,18 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/deferred = list()
 
 /datum/controller/subsystem/icon_smooth/fire()
-	var/list/cached = smooth_queue
-	while(cached.len)
-		var/atom/smoothing_atom = cached[cached.len]
-		cached.len--
+	var/list/cached = smooth_queue // local vars are quicker to access than datum vars, even on src
+	//We do this rather then for(var/atom/smoothing_atom in cached) because that sort of for loop copies the whole list.
+	//Normally this isn't expensive, but like SSgarbage the smooth queue can get pretty big.
+	var/static/last_index = 0 // track last index processed
+	// runtimed, we need to cut the remainder
+	if(last_index)
+		var/old_index = last_index
+		last_index = 0 // reset it so if Cut() runtimes we don't try again
+		cached.Cut(1, old_index+1)
+	// We don't cut during the loop so it's faster
+	for(last_index in 1 to length(cached))
+		var/atom/smoothing_atom = cached[last_index]
 		if(QDELETED(smoothing_atom) || !(smoothing_atom.smoothing_flags & SMOOTH_QUEUED))
 			continue
 		if(smoothing_atom.flags_1 & INITIALIZED_1)
@@ -20,10 +28,13 @@ SUBSYSTEM_DEF(icon_smooth)
 		else
 			deferred += smoothing_atom
 		if (MC_TICK_CHECK)
-			return
+			break
+	if(last_index) // don't try cutting from the list if we did no work this run
+		cached.Cut(1, last_index+1)
+		last_index = 0
 
-	if(!cached.len)
-		if(deferred.len)
+	if(!length(cached))
+		if(length(deferred))
 			smooth_queue = deferred
 			deferred = cached
 		else
@@ -33,14 +44,13 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/queue = smooth_queue
 	smooth_queue = list()
 
-	while(length(queue))
-		var/atom/smoothing_atom = queue[length(queue)]
-		queue.len--
+	// we explicitly do not support new stuff being added to the list while we iterate over it
+	for(var/atom/smoothing_atom as anything in queue)
 		if(QDELETED(smoothing_atom) || !(smoothing_atom.smoothing_flags & SMOOTH_QUEUED) || !smoothing_atom.z)
 			continue
 		smoothing_atom.smooth_icon()
 		CHECK_TICK
-
+	queue.Cut()
 	return ..()
 
 /datum/controller/subsystem/icon_smooth/proc/add_to_queue(atom/thing)
@@ -51,6 +61,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	if(!can_fire)
 		can_fire = TRUE
 
+// Try to avoid using this where possible; prefer unsetting smoothing_flags instead. List removals are expensive yo.
 /datum/controller/subsystem/icon_smooth/proc/remove_from_queues(atom/thing)
 	thing.smoothing_flags &= ~SMOOTH_QUEUED
 	smooth_queue -= thing

--- a/code/game/atom/atoms.dm
+++ b/code/game/atom/atoms.dm
@@ -296,8 +296,12 @@
 	QDEL_NULL(light)
 	QDEL_NULL(ai_controller)
 
+	// We used to remove stuff from the smoothing queue here,
+	// but list removals can be REALLY costly.
+	// If this is qdeleted and the flag is unset, it'll just get skipped
+	// which is way faster.
 	if(smoothing_flags & SMOOTH_QUEUED)
-		SSicon_smooth.remove_from_queues(src)
+		smoothing_flags &= ~SMOOTH_QUEUED
 
 	return ..()
 

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -134,6 +134,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			else
 				lighting_clear_overlay()
 
+	// only queue for smoothing if SSatom initialized us, and we'd be changing smoothing state
+	if(flags_1 & INITIALIZED_1)
+		QUEUE_SMOOTH_NEIGHBORS(src)
+		QUEUE_SMOOTH(src)
+
 	return W
 
 /turf/open/ChangeTurf(path, list/new_baseturfs, flags) //Resist the temptation to make this default to keeping air.
@@ -322,8 +327,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		ImmediateCalculateAdjacentTurfs()
 	else
 		CALCULATE_ADJACENT_TURFS(src)
-
-	QUEUE_SMOOTH_NEIGHBORS(src)
 
 	HandleTurfChange(src)
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -40,6 +40,7 @@
 /turf/closed/wall/proc/dismantle_wall(devastated=0, explode=0)
 	playsound(src, 'sound/blank.ogg', 100, TRUE)
 	ScrapeAway()
+	QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/closed/wall/ex_act(severity, target, epicenter, devastation_range, heavy_impact_range, light_impact_range, flame_range)
 	if(target == src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -106,8 +106,6 @@
 	if (opacity)
 		has_opaque_atom = TRUE
 
-	QUEUE_SMOOTH_NEIGHBORS(src)
-
 	if(shine)
 		make_shiny(shine)
 
@@ -318,7 +316,7 @@
 	return zPassOut(A, DOWN, target) && target.zPassIn(A, DOWN, src)
 
 /turf/proc/zFall(atom/movable/A, levels = 1, force = FALSE)
-	var/turf/target = get_step_multiz(src, DOWN)
+	var/turf/target = GET_TURF_BELOW(src)
 	if(!target || (!isobj(A) && !ismob(A)))
 		return FALSE
 	if(!force && (!can_zFall(A, levels, target) || !A.can_zFall(src, levels, target, DOWN)))


### PR DESCRIPTION
Does a bunch of stuff to make icon smoothing faster, like removing unnecessary QUEUE_SMOOTH_NEIGHBORS calls, various list iteration improvements, etc. Also avoids removing stuff from the queue unnecessarily because we just skip qdeleted/unqueued things anyway.

I tested this but then changed some stuff so it needs even more testing. Woo.