### PR TITLE
possible fire nuke fix (fixes a thing that leads to it, might not fix ALL fire nukes)

### DIFF
--- a/code/modules/antagonists/villain/neu_vampires/covens/coven_powers/demonic.dm
+++ b/code/modules/antagonists/villain/neu_vampires/covens/coven_powers/demonic.dm
@@ -23,7 +23,6 @@
 
 /datum/coven_power/demonic/sense_the_sin/activate()
 	. = ..()
-	owner.physiology.burn_mod /= 100
 	ADD_TRAIT(owner, TRAIT_NOFIRE, VAMPIRE_TRAIT)
 	owner.color = "#884200"
 
@@ -31,7 +30,6 @@
 	. = ..()
 	owner.color = initial(owner.color)
 	REMOVE_TRAIT(owner, TRAIT_NOFIRE, VAMPIRE_TRAIT)
-	owner.physiology.burn_mod *= 100
 
 //FEAR OF THE VOID BELOW
 /mob/living/carbon/human/proc/give_demon_flight()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
After some testing it turns out you always get fire nuked if you use sense the sin, I don't know if its going to fix fire nukes as a whole but its its worth a try.

This removes physiology.burn_mod from sense the sin (they already have nofire trait)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not getting one shot is good.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: possible fire nuke fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
