### PR TITLE
Fixes message bottles

### DIFF
--- a/code/modules/reagents/reagent_containers/bottles/_bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottles/_bottle.dm
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	desc = "Inside is a scroll, pop it open and read the ancient wisdoms."
 	icon = 'icons/roguetown/items/glass_reagent_container.dmi'
 	dropshrink = 0.8
-	icon_state = "clear_bottle1"
+	icon_state = "clear_bottle1_message"
 	w_class = WEIGHT_CLASS_NORMAL
 	var/obj/item/paper/contained
 
@@ -186,6 +186,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	btle.closed = FALSE
 	user.dropItemToGround(src, silent=TRUE)
 	user.put_in_active_hand(btle)
+	user.put_in_hands(contained)
 	contained = null
 	qdel(src)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Re-adds a line of code that was erroneously removed with #2344 which left message bottles in a broken state. Also gives them the proper initial icon state.

Without the use of `put_in_hands` the contents of the message bottle weren't moving anywhere before being nulled out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Message bottles work again and initialize with the proper icon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
