### PR TITLE
Fixes price inconsistency with GOLDFACE and PURITY

### DIFF
--- a/code/game/objects/structures/fake_machines/drugmachine.dm
+++ b/code/game/objects/structures/fake_machines/drugmachine.dm
@@ -155,7 +155,7 @@
 		if(!ispath(path, /datum/supply_pack))
 			message_admins("APOTHECARY [usr.key] IS TRYING TO BUY A [path] WITH THE GOLDFACE. THIS IS AN EXPLOIT.")
 			return
-		var/datum/supply_pack/PA = new path
+		var/datum/supply_pack/PA = SSmerchant.supply_packs[path]
 		var/cost = PA.cost
 		var/tax_amt=round(SStreasury.tax_value * cost)
 		cost=cost+tax_amt

--- a/code/game/objects/structures/fake_machines/merchant.dm
+++ b/code/game/objects/structures/fake_machines/merchant.dm
@@ -158,7 +158,7 @@
 		if(!ispath(path, /datum/supply_pack))
 			message_admins("MERCHANT [usr.key] IS TRYING TO BUY A [path] WITH THE GOLDFACE. THIS IS AN EXPLOIT.")
 			return
-		var/datum/supply_pack/picked_pack = new path
+		var/datum/supply_pack/picked_pack = SSmerchant.supply_packs[path]
 		base_price = picked_pack.cost
 		taxes = round(SStreasury.tax_value * base_price)
 		final_price = round(base_price + taxes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes an issue where the cost of items was being pulled directly from the datum rather than the randomized value stored in SSmerchant. A side effect of this was also re-generating the random value each time the cost was checked, which was clearly not intended.

Now rather than calling `supply_pack/New()` every time we check an item cost, we just pull it directly from `SSmerchant.supply_packs` the same as when printing the cost.

Fixes #1240
Fixes #3040

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: GOLDFACE and PURITY are now more consistent with price checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
