### PR TITLE
Fix code duplication in tram and ledger code

### DIFF
--- a/code/game/machinery/trams_and_elevators/lift_master.dm
+++ b/code/game/machinery/trams_and_elevators/lift_master.dm
@@ -674,7 +674,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 							reputation_purchases[pack] = TRUE
 							// Calculate reputation cost
 							var/quantity = cargo_manifest.orders[pack] || 0
-							var/rep_cost = calculate_reputation_cost_for_processing(pack)
+							var/rep_cost = pack.calculate_reputation_cost()
 							total_reputation_cost += rep_cost * quantity
 
 				qdel(listed_atom)
@@ -695,7 +695,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 							if(cargo_manifest.reputation_orders[pack])
 								reputation_purchases[pack] = TRUE
 								var/quantity = cargo_manifest.orders[pack] || 0
-								var/rep_cost = calculate_reputation_cost_for_processing(pack)
+								var/rep_cost = pack.calculate_reputation_cost()
 								total_reputation_cost += rep_cost * quantity
 
 					qdel(inside)
@@ -798,21 +798,6 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 	if(spent_amount)
 		record_round_statistic(STATS_TRADE_VALUE_IMPORTED, spent_amount)
 		add_abstract_elastic_data(ELASCAT_ECONOMY, ELASDATA_MAMMONS_SPENT, spent_amount, 1)
-
-/datum/lift_master/tram/proc/calculate_reputation_cost_for_processing(datum/supply_pack/pack)
-	var/datum/world_faction/faction = SSmerchant.active_faction
-	if(!faction)
-		return 50
-
-	var/base_cost = pack.cost
-	var/tier = faction.get_reputation_tier()
-
-	// Base reputation cost scales with item value
-	// Higher tier = lower reputation costs (better relations = better deals)
-	var/reputation_multiplier = max(0.5, 1.5 - (tier * 0.15)) // 15% reduction per tier
-	var/reputation_cost = max(10, round(base_cost * reputation_multiplier))
-
-	return reputation_cost
 
 /datum/lift_master/tram/proc/get_valid_turfs(obj/structure/industrial_lift/tram/platform)
 	var/list/valid_turfs = list()

--- a/code/game/objects/items/books.dm
+++ b/code/game/objects/items/books.dm
@@ -723,7 +723,7 @@
 
 		// Calculate reputation cost for out-of-stock items
 		if(!is_available && allow_reputation_purchase)
-			var/reputation_cost = calculate_reputation_cost(pack)
+			var/reputation_cost = pack.calculate_reputation_cost()
 			reputation_class = "reputation-purchase"
 			reputation_cost_text = " <span class='reputation-cost'>([reputation_cost] rep)</span>"
 
@@ -757,7 +757,7 @@
 
 			if(is_reputation_purchase)
 				item_cost *= 2 // Double mammon cost for reputation purchases
-				reputation_cost = calculate_reputation_cost(pack) * item_quantity
+				reputation_cost = pack.calculate_reputation_cost() * item_quantity
 				total_reputation_cost += reputation_cost
 
 			total_cost += item_cost
@@ -977,21 +977,6 @@
 	var/hours = round(minutes / 60)
 	return "[hours]h [minutes % 60]m"
 
-/obj/item/book/secret/ledger/proc/calculate_reputation_cost(datum/supply_pack/pack)
-	var/datum/world_faction/faction = SSmerchant.active_faction
-	if(!faction)
-		return 50
-
-	var/base_cost = pack.cost
-	var/tier = faction.get_reputation_tier()
-
-	// Base reputation cost scales with item value
-	// Higher tier = lower reputation costs (better relations = better deals)
-	var/reputation_multiplier = max(0.5, 1.5 - (tier * 0.15)) // 15% reduction per tier
-	var/reputation_cost = max(10, round(base_cost * reputation_multiplier))
-
-	return reputation_cost
-
 /obj/item/book/secret/ledger/Topic(href, href_list)
 	..()
 
@@ -1016,7 +1001,7 @@
 					to_chat(usr, "<span class='warning'>No active faction found!</span>")
 					return
 
-				var/reputation_cost = calculate_reputation_cost(pack)
+				var/reputation_cost = pack.calculate_reputation_cost()
 
 				// Check if they have enough reputation
 				if(faction.faction_reputation < reputation_cost)
@@ -1092,7 +1077,7 @@
 	var/total_reputation_cost = 0
 	for(var/datum/supply_pack/pack in cart)
 		if(pack in reputation_cart)
-			var/reputation_cost = calculate_reputation_cost(pack)
+			var/reputation_cost = pack.calculate_reputation_cost()
 			var/quantity = cart[pack]
 			total_reputation_cost += reputation_cost * quantity
 

--- a/code/modules/cargo/supply_packs/_pack.dm
+++ b/code/modules/cargo/supply_packs/_pack.dm
@@ -58,3 +58,18 @@
 	else
 		for(var/item in contains)
 			new item(C)
+
+/datum/supply_pack/proc/calculate_reputation_cost()
+	var/datum/world_faction/faction = SSmerchant.active_faction
+	if(!faction)
+		return 50
+
+	var/base_cost = cost
+	var/tier = faction.get_reputation_tier()
+
+	// Base reputation cost scales with item value
+	// Higher tier = lower reputation costs (better relations = better deals)
+	var/reputation_multiplier = max(0.5, 1.5 - (tier * 0.15)) // 15% reduction per tier
+	var/reputation_cost = max(10, round(base_cost * reputation_multiplier))
+
+	return reputation_cost


### PR DESCRIPTION
moves this duplicated code to a proc on supply packs instead of just repeating it over and over
untested, but it's pretty simple.