### PR TITLE
Fix hardcoded name strings in patron follower count checks

### DIFF
--- a/code/modules/client/round_end_panel.dm
+++ b/code/modules/client/round_end_panel.dm
@@ -884,17 +884,17 @@
 			if(istype(living_user_mob.patron, /datum/patron/psydon))
 				psydonite_user = TRUE
 
-	var/psydon_followers = GLOB.patron_follower_counts["Psydon"] || 0
+	var/psydon_followers = GLOB.patron_follower_counts[/datum/patron/psydon::name] || 0
 	var/largest_religion = (psydon_followers > 0)
 	if(largest_religion)
 		for(var/patron in GLOB.patron_follower_counts)
-			if(patron == "Psydon")
+			if(patron == /datum/patron/psydon::name)
 				continue
 			if(GLOB.patron_follower_counts[patron] >= psydon_followers)
 				largest_religion = FALSE
 				break
-	var/apostasy_followers = GLOB.patron_follower_counts["Godless"] + GLOB.patron_follower_counts["Autotheist"] + GLOB.patron_follower_counts["Defiant"] + GLOB.patron_follower_counts["Dystheist"] + GLOB.patron_follower_counts["Naivety"]|| 0
-	var/psydonite_monarch = GLOB.vanderlin_round_stats[STATS_MONARCH_PATRON] == "Psydon" ? TRUE : FALSE
+	var/apostasy_followers = GLOB.patron_follower_counts[/datum/patron/godless/godless::name] + GLOB.patron_follower_counts[/datum/patron/godless/autotheist::name] + GLOB.patron_follower_counts[/datum/patron/godless/defiant::name] + GLOB.patron_follower_counts[/datum/patron/godless/dystheist::name] + GLOB.patron_follower_counts[/datum/patron/godless/naivety::name]|| 0
+	var/psydonite_monarch = GLOB.vanderlin_round_stats[STATS_MONARCH_PATRON] == /datum/patron/psydon::name ? TRUE : FALSE
 	var/psydon_influence = (psydon_followers * 20) + (GLOB.confessors.len * 20) + (GLOB.vanderlin_round_stats[STATS_HUMEN_DEATHS] * -10) + (GLOB.vanderlin_round_stats[STATS_ALIVE_TIEFLINGS] * -20) + (psydonite_monarch ? (psydonite_monarch * 500) : -250) + (largest_religion? (largest_religion * 500) : -250) + (GLOB.vanderlin_round_stats[STATS_PSYCROSS_USERS] * 10) + (apostasy_followers * -20) + (GLOB.vanderlin_round_stats[STATS_LUX_HARVESTED] * -50) + (psydonite_user ? 10000 : -10000)
 
 	data += "<div style='width: 42.5%; margin: 0 auto 30px; border: 2px solid #99b2b1; background: #47636d; color: #d0d0d0; max-height: 420px;'>"

--- a/code/modules/events/god_intervention/astrata.dm
+++ b/code/modules/events/god_intervention/astrata.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(GLOB.patron_follower_counts["Astrata"] < 3)
+	if(GLOB.patron_follower_counts[/datum/patron/divine/astrata::name] < 3)
 		return FALSE
 
 /datum/round_event/astrata_grandeur/start()

--- a/code/modules/events/god_intervention/graggar.dm
+++ b/code/modules/events/god_intervention/graggar.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_EMPTY(graggar_cullings)
 	. = ..()
 	if(!.)
 		return FALSE
-	if(GLOB.patron_follower_counts["Graggar"] < 2)
+	if(GLOB.patron_follower_counts[/datum/patron/inhumen/graggar::name] < 2)
 		return FALSE
 
 /datum/round_event/graggar_culling/start()

--- a/code/modules/events/god_intervention/ravox.dm
+++ b/code/modules/events/god_intervention/ravox.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(GLOB.patron_follower_counts["Ravox"] < 3)
+	if(GLOB.patron_follower_counts[/datum/patron/divine/ravox::name] < 3)
 		return FALSE
 
 /datum/round_event/ravox_resolve/start()

--- a/code/modules/events/god_intervention/xylix.dm
+++ b/code/modules/events/god_intervention/xylix.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(GLOB.patron_follower_counts["Xylix"] < 2)
+	if(GLOB.patron_follower_counts[/datum/patron/divine/xylix::name] < 2)
 		return FALSE
 
 /datum/round_event/xylix_fortune/start()


### PR DESCRIPTION
uses the new `::` syntax. this resolves at compile-time so there's no cost, it just prevents typos.