### PR TITLE
Improve code duplication in patron checks

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -439,3 +439,14 @@ GLOBAL_LIST_INIT(oldhc, sortList(list(
 		sleep(1)
 	if(set_original_dir)
 		AM.setDir(originaldir)
+
+/// Returns a list of all human mobs, with clients, that have the given patron.
+/// Takes a patron TYPEPATH as an argument. Not an instance.
+/proc/player_humans_by_patron(datum/patron/which_patron_type, exclude_dead = TRUE)
+	. = list()
+	for(var/mob/living/carbon/human/victim in GLOB.player_list)
+		if(!istype(victim) || (exclude_dead && (victim.stat == DEAD)) || !victim.client)
+			continue
+		if(!istype(victim.patron, which_patron_type))
+			continue
+		. += victim

--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -316,7 +316,7 @@
 		possible_item_intents = list(/datum/intent/weep)
 		user.update_a_intents()
 		for(var/mob/living/carbon/human/H in view(get_turf(src)))
-			if(H.patron?.type == /datum/patron/psydon)	//Psydonites get VERY depressed seeing an artifact get turned into an ulapool caber.
+			if(istype(H.patron, /datum/patron/psydon)) //Psydonites get VERY depressed seeing an artifact get turned into an ulapool caber.
 				H.add_stress(/datum/stress_event/syoncalamity)
 	if(isitem(A) && on && user.used_intent.type == /datum/intent/bless)
 		var/datum/component/psyblessed/CP = A.GetComponent(/datum/component/psyblessed)

--- a/code/modules/antagonists/villain/vampire/objects/necrobook.dm
+++ b/code/modules/antagonists/villain/vampire/objects/necrobook.dm
@@ -60,9 +60,7 @@
 				sunstolen = FALSE
 			priority_announce("The Sun is torn from the sky!", "Terrible Omen", 'sound/misc/gods/astrata_scream.ogg')
 			addomen(OMEN_SUNSTEAL)
-			for(var/mob/living/carbon/human/astrater as anything in GLOB.human_list)
-				if(!istype(astrater.patron, /datum/patron/divine/astrata))
-					continue
+			for(var/mob/living/carbon/human/astrater as anything in player_humans_by_patron(/datum/patron/divine/astrata))
 				to_chat(astrater, span_userdanger("You feel the pain of [astrater.patron]!"))
 				astrater.emote("painscream", intentional = FALSE)
 

--- a/code/modules/events/god_intervention/astrata.dm
+++ b/code/modules/events/god_intervention/astrata.dm
@@ -22,13 +22,7 @@
 		return FALSE
 
 /datum/round_event/astrata_grandeur/start()
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/astrata))
-			continue
-
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/astrata))
 		// Only for astratan clergy and nobles unless ascendant
 		if(!is_ascendant(ASTRATA) && (!(human_mob.mind?.assigned_role.title in GLOB.church_positions) && !human_mob.is_noble()))
 			continue

--- a/code/modules/events/god_intervention/ravox.dm
+++ b/code/modules/events/god_intervention/ravox.dm
@@ -23,13 +23,7 @@
 /datum/round_event/ravox_resolve/start()
 	var/mob/living/carbon/human/weakest
 	var/weakest_stat
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/ravox))
-			continue
-
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/ravox))
 		if(!weakest)
 			weakest_stat = human_mob.get_stat_level(STATKEY_STR)
 			weakest = human_mob

--- a/code/modules/events/god_intervention/schism.dm
+++ b/code/modules/events/god_intervention/schism.dm
@@ -159,8 +159,8 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 
 	// If no supporter found, fall back to any clergy member who has the challenger as his patron
 	if(!selected_priest)
-		for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-			if(human_mob.stat != DEAD && human_mob.client && (human_mob.mind?.assigned_role.title in GLOB.church_positions) && human_mob.patron == challenger)
+		for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(challenger.type))
+			if(human_mob.mind?.assigned_role.title in GLOB.church_positions)
 				selected_priest = human_mob
 				break
 
@@ -387,14 +387,14 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	var/highest_influence = 0
 	var/astrata_influence = get_storyteller_influence(ASTRATA) || 0
 
-	for(var/type in subtypesof(/datum/patron/divine) - list(/datum/patron/divine/astrata, /datum/patron/divine/eora))
-		var/datum/patron/divine/god = GLOB.patronlist[type]
+	for(var/patron_type in subtypesof(/datum/patron/divine) - list(/datum/patron/divine/astrata, /datum/patron/divine/eora))
+		var/datum/patron/divine/god = GLOB.patronlist[patron_type]
 		if(!god)
 			continue
 
 		var/has_clergy = FALSE
-		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			if(H.stat != DEAD && H.client && H.patron == god && (H.mind?.assigned_role.title in GLOB.church_positions))
+		for(var/mob/living/carbon/human/H in player_humans_by_patron(patron_type))
+			if((H.mind?.assigned_role.title in GLOB.church_positions))
 				has_clergy = TRUE
 				break
 

--- a/code/modules/events/personal/abyssor/abyssoid_creation.dm
+++ b/code/modules/events/personal/abyssor/abyssoid_creation.dm
@@ -17,27 +17,11 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/abyssor))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/abyssor::name] > 0
 
 /datum/round_event/create_abyssoids/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/abyssor))
-			continue
-		valid_targets += H
-
-	if(!length(valid_targets))
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/abyssor)
+	if(!length(valid_targets)) // shouldn't happen but better safe than sorry, clients can vanish anytime after all
 		return
 
 	var/mob/living/carbon/human/chosen_one = pick(valid_targets)

--- a/code/modules/events/personal/abyssor/release_fish.dm
+++ b/code/modules/events/personal/abyssor/release_fish.dm
@@ -18,11 +18,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/abyssor))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/abyssor))
 		if(H.get_skill_level(/datum/skill/labor/fishing) < 2)
 			continue
 		return TRUE
@@ -32,11 +28,7 @@
 /datum/round_event/fish_release/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/abyssor))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/abyssor))
 		if(H.get_skill_level(/datum/skill/labor/fishing) < 2)
 			continue
 		valid_targets += H

--- a/code/modules/events/personal/abyssor/temperament.dm
+++ b/code/modules/events/personal/abyssor/temperament.dm
@@ -17,25 +17,10 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/abyssor))
-			continue
-		return TRUE
-
-	return FALSE
+	return player_humans_by_patron(/datum/patron/divine/abyssor) > 0
 
 /datum/round_event/abyssors_temperament/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/abyssor))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/abyssor)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/astrata/inhumen_scorn.dm
+++ b/code/modules/events/personal/astrata/inhumen_scorn.dm
@@ -16,11 +16,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(!(H.dna?.species.id in RACES_PLAYER_NONHERETICAL))
 			continue
 		return TRUE
@@ -30,11 +26,7 @@
 /datum/round_event/inhumen_scorn/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(!(human_mob.dna?.species.id in RACES_PLAYER_NONHERETICAL))
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/astrata/nobility_aspiration.dm
+++ b/code/modules/events/personal/astrata/nobility_aspiration.dm
@@ -16,11 +16,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(H.is_noble() || (H.mind?.assigned_role.title in GLOB.church_positions))
 			continue
 		if(!(H.dna?.species.id in RACES_PLAYER_NONHERETICAL))
@@ -32,11 +28,7 @@
 /datum/round_event/astrata_nobility/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(human_mob.is_noble() || (human_mob.mind?.assigned_role.title in GLOB.church_positions))
 			continue
 		if(!(human_mob.dna?.species.id in RACES_PLAYER_NONHERETICAL))

--- a/code/modules/events/personal/astrata/recruit_retainer.dm
+++ b/code/modules/events/personal/astrata/recruit_retainer.dm
@@ -16,11 +16,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(!human_mob.is_noble() || (human_mob.mind?.assigned_role.title in GLOB.church_positions))
 			continue
 		if(human_mob.get_spell(/datum/action/cooldown/spell/undirected/list_target/convert_role))
@@ -33,11 +29,7 @@
 	var/list/valid_targets = list()
 	var/list/minor_nobles = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/astrata))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/astrata))
 		if(!human_mob.is_noble() || (human_mob.mind?.assigned_role.title in GLOB.church_positions))
 			continue
 		if(human_mob.get_spell(/datum/action/cooldown/spell/undirected/list_target/convert_role))

--- a/code/modules/events/personal/dendor/butcher_animals.dm
+++ b/code/modules/events/personal/dendor/butcher_animals.dm
@@ -17,26 +17,10 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/dendor))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/dendor::name] > 0
 
 /datum/round_event/butcher_animals/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/dendor))
-			continue
-		valid_targets += human_mob
-
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/dendor)
 	if(!length(valid_targets))
 		return
 

--- a/code/modules/events/personal/dendor/make_wise_trees.dm
+++ b/code/modules/events/personal/dendor/make_wise_trees.dm
@@ -18,11 +18,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/dendor))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/dendor))
 		if(H.get_spell(/datum/action/cooldown/spell/transfrom_tree))
 			continue
 		return TRUE
@@ -32,11 +28,7 @@
 /datum/round_event/dendor_trees/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/dendor))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/dendor))
 		if(human_mob.get_spell(/datum/action/cooldown/spell/transfrom_tree))
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/dendor/tame_animals.dm
+++ b/code/modules/events/personal/dendor/tame_animals.dm
@@ -17,24 +17,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/dendor))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/dendor::name] > 0
 
 /datum/round_event/dendor_taming/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/dendor))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/dendor)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/eora/adopt_orphan.dm
+++ b/code/modules/events/personal/eora/adopt_orphan.dm
@@ -20,11 +20,7 @@
 	var/recipient_found = FALSE
 	var/orphans = 0
 	var/potential_orphans = 0
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/eora))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/eora))
 		if(H.age == AGE_CHILD)
 			continue
 		recipient_found = TRUE
@@ -48,11 +44,7 @@
 	var/orphans = 0
 	var/potential_orphans = 0
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/eora))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/eora))
 		if(H.age == AGE_CHILD)
 			continue
 		valid_targets += H

--- a/code/modules/events/personal/eora/matchmake_couple.dm
+++ b/code/modules/events/personal/eora/matchmake_couple.dm
@@ -18,24 +18,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/eora))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/eora::name] > 0
 
 /datum/round_event/eora_marriage/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/eora))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/eora)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/malum/crafting_request.dm
+++ b/code/modules/events/personal/malum/crafting_request.dm
@@ -17,11 +17,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/malum))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/malum))
 		if(H.get_skill_level(/datum/skill/craft/crafting) < 3)
 			continue
 		return TRUE
@@ -31,11 +27,7 @@
 /datum/round_event/malum_crafting/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/malum))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/malum))
 		if(human_mob.get_skill_level(/datum/skill/craft/crafting) < 3)
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/malum/improve_craft_skills.dm
+++ b/code/modules/events/personal/malum/improve_craft_skills.dm
@@ -17,24 +17,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/malum))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/malum::name] > 0
 
 /datum/round_event/malum_craft_skills/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/malum))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/malum)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/malum/spend_energy.dm
+++ b/code/modules/events/personal/malum/spend_energy.dm
@@ -17,24 +17,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/malum))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/malum::name] > 0
 
 /datum/round_event/spend_energy/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/malum))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/malum)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/necra/burial_required.dm
+++ b/code/modules/events/personal/necra/burial_required.dm
@@ -17,11 +17,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/necra))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/necra))
 		if(H.is_noble())
 			continue
 		return TRUE
@@ -31,11 +27,7 @@
 /datum/round_event/necra_burials/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/necra))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/necra))
 		if(human_mob.is_noble())
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/necra/hear_cries.dm
+++ b/code/modules/events/personal/necra/hear_cries.dm
@@ -20,26 +20,13 @@
 	if(length(GLOB.last_words) < 6)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/necra))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/necra::name] > 0
 
 /datum/round_event/dead_whispers/start()
 	if(length(GLOB.last_words) < 6)
 		return FALSE
 
-	var/list/valid_targets = list()
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/necra))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/necra)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/noc/baptism_desire.dm
+++ b/code/modules/events/personal/noc/baptism_desire.dm
@@ -20,11 +20,7 @@
 	if(!length(GLOB.mana_fountains) || SSmapping.config.map_name == "Vanderlin")
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/noc))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/noc))
 		if(!H.is_noble())
 			continue
 		if(H.mana_pool && H.mana_pool.intrinsic_recharge_sources == NONE)
@@ -37,11 +33,7 @@
 
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/noc))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/noc))
 		if(!human_mob.is_noble())
 			continue
 		if(human_mob.mana_pool && human_mob.mana_pool.intrinsic_recharge_sources == NONE)

--- a/code/modules/events/personal/noc/get_apprentice.dm
+++ b/code/modules/events/personal/noc/get_apprentice.dm
@@ -19,11 +19,7 @@
 
 	var/recipient_found = FALSE
 	var/potential_apprentices = 0
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/noc))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/noc))
 		if(length(H.return_apprentices()) >= H.return_max_apprentices())
 			continue
 		recipient_found = TRUE
@@ -43,11 +39,7 @@
 	var/list/valid_targets = list()
 
 	var/potential_apprentices = 0
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/noc))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/noc))
 		if(length(H.return_apprentices()) >= H.return_max_apprentices())
 			continue
 		valid_targets += H

--- a/code/modules/events/personal/pestra/eat_rotten_food.dm
+++ b/code/modules/events/personal/pestra/eat_rotten_food.dm
@@ -16,24 +16,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/pestra))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/pestra::name] > 0
 
 /datum/round_event/pestra_rotten_feast/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/pestra))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/pestra)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/pestra/lux_extraction_request.dm
+++ b/code/modules/events/personal/pestra/lux_extraction_request.dm
@@ -17,11 +17,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/pestra))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/pestra))
 		if(H.get_skill_level(/datum/skill/misc/medicine) < 3)
 			continue
 		return TRUE
@@ -31,11 +27,7 @@
 /datum/round_event/pestra_lux/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/pestra))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/pestra))
 		if(human_mob.get_skill_level(/datum/skill/misc/medicine) < 3)
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/pestra/take_pain.dm
+++ b/code/modules/events/personal/pestra/take_pain.dm
@@ -18,11 +18,7 @@
 		return FALSE
 
 	var/recipient_found = FALSE
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/pestra))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/pestra))
 		recipient_found = TRUE
 
 	if(recipient_found)
@@ -31,17 +27,7 @@
 	return FALSE
 
 /datum/round_event/pain_relief/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/pestra))
-			continue
-		valid_targets += H
-
-	if(!length(valid_targets))
-		return
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/pestra)
 
 	var/mob/living/carbon/human/chosen_one = pick(valid_targets)
 

--- a/code/modules/events/personal/ravox/honor_duels.dm
+++ b/code/modules/events/personal/ravox/honor_duels.dm
@@ -17,24 +17,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/ravox))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/ravox::name] > 0
 
 /datum/round_event/ravox_duel/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/ravox))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/ravox)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/ravox/improve_combat_skills.dm
+++ b/code/modules/events/personal/ravox/improve_combat_skills.dm
@@ -16,24 +16,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/ravox))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/ravox::name] > 0
 
 /datum/round_event/ravox_combat/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/ravox))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/ravox)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/ravox/ultimate_sacrifice.dm
+++ b/code/modules/events/personal/ravox/ultimate_sacrifice.dm
@@ -17,11 +17,7 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/ravox))
-			continue
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/ravox))
 		if(H.age == AGE_CHILD)
 			continue
 		return TRUE
@@ -31,11 +27,7 @@
 /datum/round_event/ultimate_sacrifice/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/ravox))
-			continue
+	for(var/mob/living/carbon/human/human_mob in player_humans_by_patron(/datum/patron/divine/ravox))
 		if(human_mob.age == AGE_CHILD)
 			continue
 		valid_targets += human_mob

--- a/code/modules/events/personal/xylix/coin_flip.dm
+++ b/code/modules/events/personal/xylix/coin_flip.dm
@@ -18,24 +18,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client)
-			continue
-		if(!H.patron || !istype(H.patron, /datum/patron/divine/xylix))
-			continue
-		return TRUE
-
-	return FALSE
+	return GLOB.patron_follower_counts[/datum/patron/divine/xylix::name] > 0
 
 /datum/round_event/xylix_gamble/start()
-	var/list/valid_targets = list()
-
-	for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-		if(!istype(human_mob) || human_mob.stat == DEAD || !human_mob.client)
-			continue
-		if(!human_mob.patron || !istype(human_mob.patron, /datum/patron/divine/xylix))
-			continue
-		valid_targets += human_mob
+	var/list/valid_targets = player_humans_by_patron(/datum/patron/divine/xylix)
 
 	if(!length(valid_targets))
 		return

--- a/code/modules/events/personal/xylix/nobles_mockery.dm
+++ b/code/modules/events/personal/xylix/nobles_mockery.dm
@@ -17,8 +17,8 @@
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client || !istype(H.patron, /datum/patron/divine/xylix) || H.is_noble())
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/xylix))
+		if(H.is_noble())
 			continue
 		if(H.get_spell(/datum/action/cooldown/spell/vicious_mockery))
 			return TRUE
@@ -27,8 +27,8 @@
 /datum/round_event/xylix_mocking_nobles/start()
 	var/list/valid_targets = list()
 
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!istype(H) || H.stat == DEAD || !H.client || !istype(H.patron, /datum/patron/divine/xylix) || H.is_noble())
+	for(var/mob/living/carbon/human/H in player_humans_by_patron(/datum/patron/divine/xylix))
+		if(H.is_noble())
 			continue
 		if(H.get_spell(/datum/action/cooldown/spell/vicious_mockery))
 			valid_targets += H


### PR DESCRIPTION
creates a `player_humans_by_patron` that gets all humans with clients (e.g. in the player list) with a given patron. this was repeated a lot in event code so i figured i'd make a helper for it. by default it excludes dead mobs.
this lets us replace some loops entirely and in others we use it to filter before applying additional checks (like nobility, species, etc).
also makes follower count checks use `GLOB.patron_follower_counts`. technically that only updates every two seconds but it should by synchronised with the event stuff so that'll be fiiiiine probably maybe
untested