### PR TITLE
Fix (potential) indexer harddel

### DIFF
--- a/code/game/objects/structures/fake_machines/mail.dm
+++ b/code/game/objects/structures/fake_machines/mail.dm
@@ -531,8 +531,8 @@ GLOBAL_LIST_EMPTY(letters_sent)
 
 	// Handle rejections
 	if(is_duplicate || is_selfreport)
-		qdel(accusation.paired)
-		qdel(accusation)
+		QDEL_NULL(accusation.paired) // do this before the paper so it isn't cleared
+		QDEL_NULL(accusation)
 		visible_message(span_warning("[user] sends something."))
 		playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -219,6 +219,10 @@
 	var/sliptype = 1
 	var/obj/item/inqarticles/indexer/paired
 
+/obj/item/paper/inqslip/Destroy()
+	paired = null
+	return ..()
+
 /obj/item/paper/inqslip/read(mob/user)
 	if(!user.client || !user.hud_used)
 		return


### PR DESCRIPTION
fixes a potential harddel with indexers, where `paired` would never be cleared so a reference was left hanging.
untested