### PR TITLE
Clean up scabbard equipment code to fix warnings

### DIFF
--- a/code/datums/migrants/waves/nomad_migration.dm
+++ b/code/datums/migrants/waves/nomad_migration.dm
@@ -61,7 +61,7 @@
 	belt = /obj/item/storage/belt/leather/steel
 	wrists = /obj/item/clothing/wrists/bracers/leather
 	beltr = /obj/item/weapon/sword/long/rider/steppe // dual wielder warlord
-	beltl= /obj/item/weapon/sword/long/rider/steppe
+	beltl = /obj/item/weapon/sword/long/rider/steppe
 	shirt = /obj/item/clothing/armor/gambeson/light/steppe
 	pants = /obj/item/clothing/pants/tights/colored/red
 	neck = /obj/item/storage/belt/pouch/coins/rich
@@ -69,7 +69,7 @@
 	backr = /obj/item/storage/backpack/satchel
 	armor = /obj/item/clothing/armor/medium/scale/steppe
 	head = /obj/item/clothing/head/helmet/bascinet/steppe
-	scabbards = list(/obj/item/weapon/scabbard/sword, /obj/item/weapon/scabbard/sword)
+	scabbards = list(/obj/item/weapon/sword/long/rider/steppe::associated_scabbard_type, /obj/item/weapon/sword/long/rider/steppe::associated_scabbard_type)
 	backpack_contents = list(/obj/item/weapon/knife/hunting = 1, /obj/item/tent_kit = 1, /obj/item/clothing/face/facemask/steel/steppe = 1, /obj/item/reagent_containers/glass/bottle/avarmead = 1)
 
 /datum/migrant_role/nomadrider

--- a/code/game/objects/items/weapons/melee/knives.dm
+++ b/code/game/objects/items/weapons/melee/knives.dm
@@ -28,6 +28,7 @@
 	melt_amount = 50
 	sharpness = IS_SHARP
 	sellprice = 30
+	associated_scabbard_type = /obj/item/weapon/scabbard/knife
 
 	grid_height = 64
 	grid_width = 32

--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -31,6 +31,7 @@
 	minstr = 7
 	sellprice = 30
 	wdefense = GREAT_PARRY
+	associated_scabbard_type = /obj/item/weapon/scabbard/sword
 
 /obj/item/weapon/sword/getonmobprop(tag)
 	. = ..()
@@ -201,6 +202,7 @@
 	minstr = 6
 	wbalance = VERY_HARD_TO_DODGE
 	bigboy = FALSE
+	associated_scabbard_type = /obj/item/weapon/scabbard/cane
 	SET_BASE_PIXEL(0, 0)
 
 /*-------\
@@ -1024,6 +1026,7 @@
 	minstr = 11
 	wbalance = EASY_TO_DODGE
 	sellprice = 90
+	associated_scabbard_type = null // no scabbards fit this
 
 /obj/item/weapon/sword/long/greatsword/getonmobprop(tag)
 	. = ..()
@@ -1315,6 +1318,7 @@
 	desc = "An ancient blade of ginormous stature, with a round ended tip. The pride and joy of Vanderlin's greatest pastime, executions."
 	minstr = 10
 	slot_flags = ITEM_SLOT_BACK
+	associated_scabbard_type = null // no scabbards fit this currently
 
 /obj/item/weapon/sword/long/exe/getonmobprop(tag)
 	. = ..()
@@ -1574,6 +1578,7 @@
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_HIP
 	melt_amount = 75
 	melting_material = /datum/material/steel
+	associated_scabbard_type = /obj/item/weapon/scabbard/kazengun // the katana scabbard!
 
 
 /obj/item/weapon/sword/katana/mulyeog

--- a/code/game/objects/items/weapons/rogueweapon.dm
+++ b/code/game/objects/items/weapons/rogueweapon.dm
@@ -32,6 +32,8 @@
 	var/list/possible_enhancements
 	var/renamed_name
 	var/axe_cut = 0
+	// If we want to spawn a scabbard for this weapon, what type should we use?
+	var/obj/item/weapon/scabbard/associated_scabbard_type = null
 	istrainable = TRUE // You can train weapon skills on a dummy with these.
 
 /obj/item/weapon/Initialize(mapload)

--- a/code/game/objects/items/weapons/scabbard.dm
+++ b/code/game/objects/items/weapons/scabbard.dm
@@ -10,6 +10,9 @@
 	wdefense = BAD_PARRY
 	max_integrity = INTEGRITY_WORST
 	possible_item_intents = list(SHIELD_BASH)
+	// If it exists, the typepath of a fancy (often nobility or leadership) variant of this scabbard.
+	// Sometimes that variant may have its own fancy variant.
+	var/obj/item/weapon/scabbard/fancy_variant = null
 
 /obj/item/weapon/scabbard/Initialize()
 	. = ..()
@@ -51,6 +54,7 @@
 	associated_skill = /datum/skill/combat/knives
 	sewrepair = TRUE
 	sellprice = 10
+	fancy_variant = /obj/item/weapon/scabbard/knife/noble
 
 	grid_width = 32
 	grid_height = 64
@@ -77,12 +81,14 @@
 	desc = "A slingable sheath made of leather, enamored with elaborate silver decorations, often seen on the hips of nobles"
 	sellprice = 50
 	icon_state = "nsheath"
+	fancy_variant = /obj/item/weapon/scabbard/knife/royal
 
 /obj/item/weapon/scabbard/knife/royal
 	name = "gold decorated knife sheath"
 	desc = "A slingable sheath made of leather, enamored with exquisite golden decorations, often seen on the hips of royalty"
 	sellprice = 100
 	icon_state = "rsheath"
+	fancy_variant = null // as fancy as it comes!
 
 /obj/item/weapon/scabbard/sword
 	name = "scabbard"
@@ -98,6 +104,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	anvilrepair = /datum/skill/craft/carpentry
 	associated_skill = /datum/skill/combat/swords
+	fancy_variant = /obj/item/weapon/scabbard/sword/noble
 
 /obj/item/weapon/scabbard/sword/apply_components()
 	. = ..()
@@ -121,12 +128,14 @@
 	desc = "A scabbard designed to hold a sword. This one is decorated on a silver platter."
 	sellprice = 50
 	icon_state = "nscabbard"
+	fancy_variant = /obj/item/weapon/scabbard/sword/royal
 
 /obj/item/weapon/scabbard/sword/royal
 	name = "gold decorated scabbard"
 	desc = "A scabbard designed to hold a sword. This one is lined with golden fittings, fit for a royal."
 	sellprice = 100
 	icon_state = "rscabbard"
+	fancy_variant = null // as fancy as it comes!
 
 /obj/item/weapon/scabbard/cane
 	name = "fancy cane"
@@ -142,6 +151,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	anvilrepair = /datum/skill/craft/carpentry
 	associated_skill = /datum/skill/combat/swords
+	fancy_variant = null // as fancy as it comes!
 
 /obj/item/weapon/scabbard/cane/apply_components()
 	. = ..()
@@ -220,6 +230,7 @@
 	anvilrepair = /datum/skill/craft/carpentry
 	associated_skill = /datum/skill/combat/shields
 	max_integrity = INTEGRITY_STANDARD
+	fancy_variant = /obj/item/weapon/scabbard/kazengun/steel
 
 /obj/item/weapon/scabbard/kazengun/apply_components()
 	. = ..()
@@ -232,6 +243,7 @@
 	icon_state = "kazscab_steel"
 	item_state = "kazscab_steel"
 	max_integrity = INTEGRITY_STRONG
+	fancy_variant = /obj/item/weapon/scabbard/kazengun/gold
 
 /obj/item/weapon/scabbard/kazengun/gold
 	name = "gold-stained Xinyi scabbard"
@@ -239,3 +251,4 @@
 	icon_state = "kazscab_gold"
 	item_state = "kazscab_gold"
 	max_integrity = INTEGRITY_STRONGEST
+	fancy_variant = null // as fancy as it comes!

--- a/code/modules/jobs/job_types/adventurer/types/pilgrim/noble.dm
+++ b/code/modules/jobs/job_types/adventurer/types/pilgrim/noble.dm
@@ -68,23 +68,15 @@
 		"Cane Blade" = /obj/item/weapon/sword/rapier/caneblade, \
 		)
 	var/choice = H.select_equippable(H, selectable, time_limit = 1 MINUTES, message = "Choose your weapon", title = "NOBLE")
-	if(!choice)
+	if(!choice || !selectable[choice])
 		return
-		//Yeah this is copied from how lieutenant does it which in turn was copied from how rk does it lmao
-	var/shield_type = null
-	switch(choice)
-		if("Dagger")
-			H.clamped_adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/knife/noble()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
-		if("Rapier")
-			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/sword/noble()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
-		if("Cane Blade")
-			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/cane()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
+	var/obj/item/weapon/chosen_weapon_type = selectable[choice]
+	var/used_skill = chosen_weapon_type::associated_skill // get us up to apprentice in our chosen weapon's skill
+	if(used_skill)
+		H.clamped_adjust_skillrank(used_skill, 2, 2, TRUE)
+	var/obj/item/weapon/scabbard/used_scabbard_type = chosen_weapon_type::associated_scabbard_type
+	if(used_scabbard_type::fancy_variant) // upgrade from base -> noble, if available
+		used_scabbard_type = used_scabbard_type::fancy_variant
+	if(used_scabbard_type)
+		var/obj/item/weapon/scabbard/scabbard = new used_scabbard_type()
+		H.equip_to_appropriate_slot(scabbard, delete_on_fail = TRUE)

--- a/code/modules/jobs/job_types/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/berserker.dm
@@ -18,12 +18,13 @@
 	belt = /obj/item/storage/belt/leather
 	neck =	/obj/item/clothing/neck/chaincoif/iron
 	armor = /obj/item/clothing/armor/leather/advanced
+	var/const/obj/item/weapon/knife_type = /obj/item/weapon/knife/hunting
 	backpack_contents = list(
-		/obj/item/weapon/knife/hunting = 1,
+		(knife_type) = 1,
 		/obj/item/flashlight/flare/torch/lantern = 1,
 		/obj/item/storage/belt/pouch/coins/poor = 1,
 		/obj/item/rope/chain = 1,
-		/obj/item/weapon/scabbard/knife = 1,
+		knife_type::associated_scabbard_type = 1,
 		/obj/item/reagent_containers/glass/bottle/stronghealthpot = 1,	//Small health vial
 	)
 	H.add_spell(/datum/action/cooldown/spell/undirected/barbrage)

--- a/code/modules/jobs/job_types/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/deserter.dm
@@ -29,8 +29,9 @@
 	gloves = /obj/item/clothing/gloves/plate
 	shoes = /obj/item/clothing/shoes/boots/armor
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/sword/arming
-	scabbards = list(/obj/item/weapon/scabbard/sword/noble)
+	var/const/obj/item/weapon/sword/sword_type = /obj/item/weapon/sword/arming
+	beltr = sword_type
+	scabbards = list(sword_type::associated_scabbard_type::fancy_variant) // noble variant of sword scabbard. fancy!
 	H.add_spell(/datum/action/cooldown/spell/undirected/list_target/convert_role/brotherhood)
 	if(H.dna?.species?.id == SPEC_ID_HUMEN)
 		H.dna.species.soundpack_m = new /datum/voicepack/male/knight()

--- a/code/modules/jobs/job_types/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/heretic.dm
@@ -250,7 +250,7 @@
 		if(/datum/patron/psydon, /datum/patron/psydon/extremist)
 			var/obj/item/weapon/sword/long/psydon/P = new(get_turf(src))
 			H.equip_to_appropriate_slot(P)
-			var/obj/item/weapon/scabbard/sword/L = new(get_turf(src))
+			var/obj/item/weapon/scabbard/L = new P.associated_scabbard_type(get_turf(src))
 			H.equip_to_appropriate_slot(L)
 		else
 			var/obj/item/weapon/sword/long/decorated/P = new(get_turf(src))

--- a/code/modules/jobs/job_types/garrison/garrisonguard.dm
+++ b/code/modules/jobs/job_types/garrison/garrisonguard.dm
@@ -64,9 +64,10 @@
 	shirt = /obj/item/clothing/armor/gambeson
 	backr = /obj/item/weapon/shield/heater
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/sword/short/iron
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/short/iron
+	beltr = sword_type
 	beltl = /obj/item/weapon/mace/cudgel
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/rope/chain)
 
 
@@ -143,9 +144,10 @@
 	neck = /obj/item/clothing/neck/gorget
 	backl = /obj/item/storage/backpack/satchel
 	backr = /obj/item/weapon/polearm/spear
-	beltl = /obj/item/weapon/sword/short/iron
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/short/iron
+	beltl = sword_type
 	beltr = /obj/item/weapon/mace/cudgel
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/rope/chain)
 
 	//Stats for class

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -70,10 +70,11 @@
 	shirt = /obj/item/clothing/armor/gambeson/arming
 	neck = /obj/item/clothing/neck/bevor
 	gloves = /obj/item/clothing/gloves/leather
-	beltr = /obj/item/weapon/sword/arming
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/arming
+	beltr = sword_type
 	backr = /obj/item/weapon/polearm/spear/billhook
 	backl = /obj/item/storage/backpack/satchel
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel/special)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -52,9 +52,10 @@
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard  // Wear the King's colors
 	shirt = /obj/item/clothing/armor/gambeson/arming
 	belt = /obj/item/storage/belt/leather
-	beltr = /obj/item/weapon/sword/arming
+	var/const/obj/item/weapon/sword/sword_type = /obj/item/weapon/sword/arming
+	beltr = sword_type
 	backl = /obj/item/storage/backpack/satchel
-	scabbards = list(/obj/item/weapon/scabbard/sword/noble)
+	scabbards = list(sword_type::associated_scabbard_type::fancy_variant) // noble variant of sword scabbard. fancy!
 	backpack_contents = list(/obj/item/storage/keyring/manorguard = 1)
 
 	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)

--- a/code/modules/jobs/job_types/garrison/town_elder.dm
+++ b/code/modules/jobs/job_types/garrison/town_elder.dm
@@ -378,8 +378,9 @@
 	armor = /obj/item/clothing/armor/leather/jacket/silk_coat
 	cloak = /obj/item/clothing/cloak/half
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/sword/arming
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/arming
+	beltr = sword_type
+	scabbards = list(sword_type::associated_scabbard_type)
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/mid = 1, /obj/item/storage/keyring/elder = 1, /obj/item/paper/scroll = 5, /obj/item/natural/feather = 1)
 

--- a/code/modules/jobs/job_types/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/garrison/veteran.dm
@@ -62,10 +62,11 @@
 	shirt = /obj/item/clothing/armor/chainmail
 	pants = /obj/item/clothing/pants/chainlegs
 	shoes = /obj/item/clothing/shoes/boots/armor
-	beltl = /obj/item/weapon/sword/sabre
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/sabre
+	beltl = sword_type
 	beltr = /obj/item/storage/keyring/veteran
 	backr = /obj/item/storage/backpack/satchel/black
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/leather/black
 	H.cmode_music = 'sound/music/cmode/adventurer/CombatWarrior.ogg'

--- a/code/modules/jobs/job_types/garrison/watchlieutenant.dm
+++ b/code/modules/jobs/job_types/garrison/watchlieutenant.dm
@@ -96,24 +96,23 @@
 		"Sword" = /obj/item/weapon/sword/iron, \
 		)
 	var/choice = H.select_equippable(H, selectable, time_limit = 1 MINUTES, message = "Choose your secondary weapon", title = "LIEUTENANT")
-	if(!choice)
+	if(!choice || !selectable[choice])
 		return
+	var/obj/item/weapon/chosen_weapon_type = selectable[choice] // only gets the compiled in skill so you better hope it isnt changed at runtime
+	H.clamped_adjust_skillrank(chosen_weapon_type::associated_skill, 3, 3, TRUE) // get us up to expert in our chosen weapon's skill
 	//yeah this is copied from how royal knights do it
-	var/shield_type = null
+	var/obj/item/weapon/shield/shield_type = null
 	switch(choice)
 		if("Flail")
-			H.clamped_adjust_skillrank(/datum/skill/combat/whipsflails, 2, 3, TRUE)
 			shield_type = new /obj/item/weapon/shield/wood()
 		if("Spear")
-			H.clamped_adjust_skillrank(/datum/skill/combat/polearms, 2, 3, TRUE)
 			shield_type = new /obj/item/weapon/shield/tower/buckleriron()
 		if("Sword")
-			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, 3, TRUE)
 			shield_type = new /obj/item/weapon/shield/heater()
-			var/scabbard = new /obj/item/weapon/scabbard/sword()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
+	var/scabbard_type = chosen_weapon_type::associated_scabbard_type
+	if(scabbard_type) // not all weapons get scabbards, mostly just swords/knives
+		var/obj/item/weapon/scabbard/scabbard = new scabbard_type()
+		H.equip_to_appropriate_slot(scabbard, delete_on_fail = TRUE)
 	if(shield_type)//just incase
-		H.clamped_adjust_skillrank(/datum/skill/combat/shields, 3, 3, TRUE)
-		if(!H.equip_to_appropriate_slot(shield_type))
-			qdel(shield_type)
+		H.clamped_adjust_skillrank(shield_type::associated_skill, 3, 3, TRUE) // future-proofed in case shields ever get different skill types or something
+		H.equip_to_appropriate_slot(shield_type, delete_on_fail = TRUE)

--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/confessor.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/confessor.dm
@@ -47,14 +47,14 @@
 		switch(weapon_choice)
 			if("Blessed Psydonic Dagger")
 				l_hand = /obj/item/weapon/knife/dagger/silver/psydon
-				r_hand = /obj/item/weapon/scabbard/knife
+				r_hand = /obj/item/weapon/knife/dagger/silver/psydon::associated_scabbard_type
 				H.clamped_adjust_skillrank(/datum/skill/combat/knives, 4, 4, TRUE)
 			if("Psydonic Handmace")
 				l_hand = /obj/item/weapon/mace/cudgel/psy
 				H.clamped_adjust_skillrank(/datum/skill/combat/axesmaces, 4, 4, TRUE)
 			if("Psydonic Shortsword")
 				l_hand = /obj/item/weapon/sword/short/psy
-				r_hand = /obj/item/weapon/scabbard/sword
+				r_hand = /obj/item/weapon/sword/short/psy::associated_scabbard_type
 				H.clamped_adjust_skillrank(/datum/skill/combat/swords, 4, 4, TRUE)
 		var/armors = list("Confessor - Slurbow, Leather Maillecoat", "Arbalist - Crossbow, Lightweight Brigandine")
 		var/armor_choice = input(H, "Choose your ARCHETYPE.", "TAKE UP PSYDON'S DUTY.") as anything in armors

--- a/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
+++ b/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
@@ -54,8 +54,9 @@
 	var/weapon_choice = browser_input_list(spawned, "CHOOSE YOUR RELIQUARY PIECE.", "WIELD THEM IN HIS NAME.", gear)
 	switch(weapon_choice)
 		if("Retribution (Rapier)")
-			spawned.put_in_hands(new /obj/item/weapon/sword/rapier/psy/relic(spawned), TRUE)
-			spawned.equip_to_slot_or_del(new /obj/item/weapon/scabbard/sword, ITEM_SLOT_BELT_L, TRUE)
+			var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/rapier/psy/relic
+			spawned.put_in_hands(new sword_type(spawned), TRUE)
+			spawned.equip_to_slot_or_del(new sword_type:associated_scabbard_type, ITEM_SLOT_BELT_L, TRUE)
 			spawned.clamped_adjust_skillrank(/datum/skill/combat/swords, 4, 4, TRUE)
 		if("Daybreak (Whip)")
 			spawned.put_in_hands(new /obj/item/weapon/whip/psydon/relic(spawned), TRUE)

--- a/code/modules/jobs/job_types/inquistion/puritian/ordinator.dm
+++ b/code/modules/jobs/job_types/inquistion/puritian/ordinator.dm
@@ -62,8 +62,9 @@
 				spawned.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		if("Crusade (Greatsword) and a Silver Dagger")
 			spawned.put_in_hands(new /obj/item/weapon/sword/long/greatsword/psydon/relic(get_turf(spawned)), TRUE)
-			spawned.put_in_hands(new /obj/item/weapon/knife/dagger/silver/psydon(get_turf(spawned)), TRUE)
-			spawned.equip_to_slot_or_del(new /obj/item/weapon/scabbard/knife, ITEM_SLOT_BACK_L, TRUE)
+			var/const/obj/item/weapon/dagger_type = /obj/item/weapon/knife/dagger/silver/psydon
+			spawned.put_in_hands(new dagger_type(get_turf(spawned)), TRUE)
+			spawned.equip_to_slot_or_del(new dagger_type::associated_scabbard_type, ITEM_SLOT_BACK_L, TRUE)
 			spawned.clamped_adjust_skillrank(/datum/skill/combat/swords, 4, 4, TRUE)
 			spawned.clamped_adjust_skillrank(/datum/skill/combat/knives, 4, 4, TRUE)
 			if(spawned.age == AGE_OLD)

--- a/code/modules/jobs/job_types/nobility/captain.dm
+++ b/code/modules/jobs/job_types/nobility/captain.dm
@@ -53,10 +53,11 @@
 	backl = /obj/item/storage/backpack/satchel
 	backr = /obj/item/weapon/shield/tower/metal
 	belt = /obj/item/storage/belt/leather/plaquesilver
-	beltl = /obj/item/weapon/sword/sabre/dec
+	var/const/obj/item/weapon/sword/sword_type = /obj/item/weapon/sword/sabre/dec
+	beltl = sword_type
 	beltr = /obj/item/weapon/mace/cudgel
 	cloak = /obj/item/clothing/cloak/captain
-	scabbards = list(/obj/item/weapon/scabbard/sword/noble)
+	scabbards = list(sword_type::associated_scabbard_type::fancy_variant) // noble variant of sword scabbard. fancy!
 	backpack_contents = list(/obj/item/storage/keyring/captain = 1, /obj/item/signal_horn = 1)
 	H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)

--- a/code/modules/jobs/job_types/nobility/hand.dm
+++ b/code/modules/jobs/job_types/nobility/hand.dm
@@ -80,8 +80,9 @@
 	backpack_contents = list(/obj/item/weapon/knife/dagger/steel = 1, /obj/item/storage/keyring/hand = 1, /obj/item/paper/scroll/frumentarii/roundstart = 1)
 	armor = /obj/item/clothing/armor/leather/jacket/handjacket
 	pants = /obj/item/clothing/pants/tights/colored/black
-	beltr = /obj/item/weapon/sword/rapier/dec
-	scabbards = list(/obj/item/weapon/scabbard/sword/royal)
+	var/const/obj/item/weapon/sword/sword_type = /obj/item/weapon/sword/rapier/dec
+	beltr = sword_type
+	scabbards = list(sword_type::associated_scabbard_type::fancy_variant::fancy_variant) // royal variant of sword scabbard. twice as fancy!
 	H.adjust_skillrank(/datum/skill/combat/axesmaces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)

--- a/code/modules/jobs/job_types/nobility/lord.dm
+++ b/code/modules/jobs/job_types/nobility/lord.dm
@@ -83,9 +83,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	head = /obj/item/clothing/head/crown/serpcrown
 	backr = /obj/item/storage/backpack/satchel
 	belt = /obj/item/storage/belt/leather/plaquegold
-	beltl = /obj/item/weapon/knife/dagger/steel/special
-	beltr = /obj/item/weapon/sword/rapier
-	scabbards = list(/obj/item/weapon/scabbard/knife/royal, /obj/item/weapon/scabbard/sword/royal)
+	var/const/obj/item/weapon/dagger_type = /obj/item/weapon/knife/dagger/steel/special
+	beltl = dagger_type
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/rapier
+	beltr = sword_type
+	// royalty gets double fancy scabbards!
+	scabbards = list(dagger_type::associated_scabbard_type::fancy_variant::fancy_variant, sword_type::associated_scabbard_type::fancy_variant::fancy_variant)
 	ring = /obj/item/clothing/ring/active/nomag
 	l_hand = /obj/item/weapon/lordscepter
 

--- a/code/modules/jobs/job_types/nobility/merchant.dm
+++ b/code/modules/jobs/job_types/nobility/merchant.dm
@@ -31,14 +31,15 @@
 	neck = /obj/item/clothing/neck/mercator
 	backr = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/veryrich = 1, /obj/item/merctoken = 1)
-	beltr = /obj/item/weapon/sword/rapier
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/rapier
+	beltr = sword_type
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltl = /obj/item/weapon/mace/cane/merchant
 	wrists = /obj/item/storage/keyring/merchant
 	armor = /obj/item/clothing/shirt/robe/merchant
 	head = /obj/item/clothing/head/chaperon/colored/greyscale/silk/random
 	ring = /obj/item/clothing/ring/gold/guild_mercator
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 
 	if(H.gender == MALE)
 		shirt = /obj/item/clothing/shirt/undershirt/sailor

--- a/code/modules/jobs/job_types/nobility/minor_noble.dm
+++ b/code/modules/jobs/job_types/nobility/minor_noble.dm
@@ -82,23 +82,15 @@
 		"Cane Blade" = /obj/item/weapon/sword/rapier/caneblade, \
 		)
 	var/choice = H.select_equippable(H, selectable, time_limit = 1 MINUTES, message = "Choose your weapon", title = "NOBLE")
-	if(!choice)
+	if(!choice || !selectable[choice])
 		return
-		//Yeah this is copied from how lieutenant does it which in turn was copied from how rk does it lmao
-	var/shield_type = null
-	switch(choice)
-		if("Dagger")
-			H.clamped_adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/knife/noble()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
-		if("Rapier")
-			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/sword/noble()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
-		if("Cane Blade")
-			H.clamped_adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-			var/scabbard = new /obj/item/weapon/scabbard/cane()
-			if(!H.equip_to_appropriate_slot(scabbard))
-				qdel(scabbard)
+	var/obj/item/weapon/chosen_weapon_type = selectable[choice]
+	var/used_skill = chosen_weapon_type::associated_skill // get us up to apprentice in our chosen weapon's skill
+	if(used_skill)
+		H.clamped_adjust_skillrank(used_skill, 2, 2, TRUE)
+	var/obj/item/weapon/scabbard/used_scabbard = chosen_weapon_type::associated_scabbard_type
+	if(used_scabbard::fancy_variant) // upgrade from base -> noble, if available
+		used_scabbard = used_scabbard::fancy_variant
+	if(used_scabbard)
+		var/obj/item/weapon/scabbard/scabbard = new used_scabbard()
+		H.equip_to_appropriate_slot(scabbard, delete_on_fail = TRUE)

--- a/code/modules/jobs/job_types/nobility/steward.dm
+++ b/code/modules/jobs/job_types/nobility/steward.dm
@@ -44,9 +44,10 @@
 	armor = /obj/item/clothing/armor/gambeson/steward
 	belt = /obj/item/storage/belt/leather/plaquesilver
 	beltr = /obj/item/storage/keyring/steward
-	beltl = /obj/item/weapon/knife/dagger/steel
+	var/const/obj/item/weapon/knife_type = /obj/item/weapon/knife/dagger/steel
+	beltl = knife_type
 	backr = /obj/item/storage/backpack/satchel
-	scabbards = list(/obj/item/weapon/scabbard/knife)
+	scabbards = list(knife_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/rich = 1, /obj/item/lockpickring/mundane = 1)
 
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/abyssal.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/abyssal.dm
@@ -16,8 +16,9 @@
 	armor = /obj/item/clothing/armor/medium/scale
 	head = /obj/item/clothing/head/helmet/winged
 	neck = /obj/item/clothing/neck/chaincoif/iron
-	beltl = /obj/item/weapon/sword/sabre/cutlass
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/sabre/cutlass
+	beltl = sword_type
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/key/mercenary, /obj/item/storage/belt/pouch/coins/poor, /obj/item/reagent_containers/food/snacks/fish/swordfish) //soul
 
 	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/anthrax.dm
@@ -59,8 +59,9 @@
 			neck = /obj/item/clothing/neck/chaincoif/iron
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/short //Coupled with the racial PER malus, abysmal damage, but good for poison arrows.
 			beltr = /obj/item/ammo_holder/quiver/arrows
-			beltl = /obj/item/weapon/sword/sabre/stalker
-			scabbards = list(/obj/item/weapon/scabbard/sword)
+			var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/sabre/stalker
+			beltl = sword_type
+			scabbards = list(sword_type::associated_scabbard_type)
 
 			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/blackoak.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/blackoak.dm
@@ -15,8 +15,9 @@
 	belt = /obj/item/storage/belt/leather/mercenary/black
 	armor = /obj/item/clothing/armor/cuirass/rare/elven
 	backl = /obj/item/storage/backpack/satchel
-	beltl = /obj/item/weapon/knife/dagger/steel/special
-	scabbards = list(/obj/item/weapon/scabbard/knife)
+	var/const/obj/item/weapon/knife_type = /obj/item/weapon/knife/dagger/steel/special
+	beltl = knife_type
+	scabbards = list(knife_type::associated_scabbard_type)
 	shirt = /obj/item/clothing/shirt/undershirt/colored/black
 	pants = /obj/item/clothing/pants/trou/leather
 	neck = /obj/item/clothing/neck/chaincoif

--- a/code/modules/jobs/job_types/other/merc_classes/boltslinger.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/boltslinger.dm
@@ -15,14 +15,15 @@
 	gloves = /obj/item/clothing/gloves/angle
 	belt = /obj/item/storage/belt/leather/mercenary
 	armor = /obj/item/clothing/armor/cuirass
-	beltr = /obj/item/weapon/sword/iron
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/iron
+	beltr = sword_type
 	beltl = /obj/item/ammo_holder/quiver/bolts
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 	backl = /obj/item/storage/backpack/satchel
 	shirt = /obj/item/clothing/shirt/undershirt/colored/black
 	pants = /obj/item/clothing/pants/tights/colored/black
 	neck = /obj/item/clothing/neck/chaincoif
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor, /obj/item/weapon/knife/hunting)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/corsair.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/corsair.dm
@@ -17,7 +17,7 @@
 	backr = /obj/item/fishingrod/fisher
 	beltl = /obj/item/weapon/sword/sabre/cutlass
 	beltr = /obj/item/weapon/knife/dagger
-	scabbards = list(/obj/item/weapon/scabbard/sword, /obj/item/weapon/scabbard/knife)
+	scabbards = list(/obj/item/weapon/sword/sabre/cutlass::associated_scabbard_type, /obj/item/weapon/knife/dagger::associated_scabbard_type)
 	shoes = /obj/item/clothing/shoes/boots
 
 /datum/outfit/adventurer/corsair/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/other/merc_classes/duelist.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/duelist.dm
@@ -41,15 +41,17 @@
 		H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
+	var/obj/item/weapon/sword_type = null
 	var/rando = rand(1,6)
 	switch(rando)
 		if(1 to 2)
-			beltl = /obj/item/weapon/sword/rapier
+			sword_type = /obj/item/weapon/sword/rapier
 		if(3 to 4)
-			beltl = /obj/item/weapon/sword/rapier/silver //Correct, They have a chance to receive a silver rapier, due to them being from Valoria.
+			sword_type = /obj/item/weapon/sword/rapier/silver //Correct, They have a chance to receive a silver rapier, due to them being from Valoria.
 		if(5 to 6)
-			beltl = /obj/item/weapon/sword/rapier/dec
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+			sword_type = /obj/item/weapon/sword/rapier/dec
+	beltl = sword_type
+	scabbards = list(sword_type::associated_scabbard_type)
 	H.merctype = 8
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	H.change_stat(STATKEY_END, 2)

--- a/code/modules/jobs/job_types/other/merc_classes/enforcer.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/enforcer.dm
@@ -44,7 +44,6 @@
 
 /datum/outfit/mercenary/enforcer
 	name = "Gun-In"
-	var/is_leader = FALSE //does nothing except give you a cooler blade.
 
 /datum/outfit/mercenary/enforcer/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/shirt/undershirt/easttats
@@ -63,14 +62,15 @@
 
 /datum/outfit/mercenary/enforcer/post_equip(mob/living/carbon/human/H, visuals_only)
 	. = ..()
-	if(prob(10) && !is_leader)
+	var/obj/item/weapon/sword/katana/mulyeog/sword_type = /obj/item/weapon/sword/katana/mulyeog/rumahench
+	var/is_leader = FALSE
+	if(prob(10)) // 10% chance of cool leader sword
+		sword_type = /obj/item/weapon/sword/katana/mulyeog/rumacaptain
 		is_leader = TRUE
-		var/obj/item/weapon/sword/katana/mulyeog/rumacaptain/P = new(get_turf(src))
-		H.equip_to_appropriate_slot(P)
-		var/obj/item/weapon/scabbard/kazengun/gold/L = new(get_turf(src))
-		H.equip_to_appropriate_slot(L)
-	else
-		var/obj/item/weapon/sword/katana/mulyeog/rumahench/P = new(get_turf(src))
-		H.equip_to_appropriate_slot(P)
-		var/obj/item/weapon/scabbard/kazengun/steel/L = new(get_turf(src))
-		H.equip_to_appropriate_slot(L)
+	var/obj/item/weapon/sword/katana/mulyeog/P = new sword_type(get_turf(src))
+	H.equip_to_appropriate_slot(P)
+	var/obj/item/weapon/scabbard/scabbard_type = P.associated_scabbard_type::fancy_variant // give us the steel variant instead of wood
+	if(is_leader)
+		scabbard_type = scabbard_type::fancy_variant // leader gets gold
+	var/obj/item/weapon/scabbard/kazengun/L = new scabbard_type(get_turf(src))
+	H.equip_to_appropriate_slot(L)

--- a/code/modules/jobs/job_types/other/merc_classes/hollowdragoon.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/hollowdragoon.dm
@@ -26,7 +26,7 @@
 	beltl = /obj/item/weapon/sword
 	backl = /obj/item/storage/backpack/satchel
 	backr = /obj/item/weapon/polearm/spear
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(/obj/item/weapon/sword::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor, /obj/item/weapon/knife/dagger)
 
 /datum/outfit/mercenary/dragoon/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/other/merc_classes/pirakshari.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/pirakshari.dm
@@ -29,7 +29,8 @@
 
 
 	pants = /obj/item/clothing/pants/trou/leather
-	beltr = /obj/item/weapon/sword/sabre
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/sabre
+	beltr = sword_type
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/short
 	beltl= /obj/item/ammo_holder/quiver/arrows
 	shoes = /obj/item/clothing/shoes/ridingboots
@@ -40,7 +41,7 @@
 	armor = /obj/item/clothing/armor/leather/splint
 	backr = /obj/item/storage/backpack/satchel
 	head = /obj/item/clothing/neck/keffiyeh/colored/uncolored
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor, /obj/item/weapon/knife/dagger)
 
 	H.merctype = 1 //Desert Rider chain, 0 for Desert Rider Medal

--- a/code/modules/jobs/job_types/other/merc_classes/spellsword.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/spellsword.dm
@@ -23,7 +23,7 @@
 	beltr = /obj/item/weapon/sword
 	beltl = /obj/item/storage/magebag/poor
 	backl = /obj/item/storage/backpack/satchel
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(/obj/item/weapon/sword::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor, /obj/item/weapon/knife/dagger, /obj/item/reagent_containers/glass/bottle/manapot, /obj/item/book/granter/spellbook/apprentice, /obj/item/chalk)
 
 // Just a better adventurer warrior

--- a/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/steppesman.dm
@@ -49,7 +49,7 @@
 	belt = /obj/item/storage/belt/leather/mercenary/black
 	wrists = /obj/item/clothing/wrists/bracers/leather
 	beltr = /obj/item/weapon/sword/long/rider/steppe
-	beltl= /obj/item/ammo_holder/quiver/arrows
+	beltl = /obj/item/ammo_holder/quiver/arrows
 	shirt = /obj/item/clothing/armor/gambeson/light/steppe
 	pants = /obj/item/clothing/pants/tights/colored/red
 	neck = /obj/item/storage/belt/pouch/coins/poor
@@ -58,7 +58,7 @@
 	armor = /obj/item/clothing/armor/medium/scale/steppe
 	head = /obj/item/clothing/head/helmet/bascinet/steppe
 	mask = /obj/item/clothing/face/facemask/steel/steppe
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(/obj/item/weapon/sword/long/rider/steppe::associated_scabbard_type)
 	backpack_contents = list(/obj/item/weapon/knife/hunting = 1, /obj/item/tent_kit = 1)
 
 /datum/outfit/mercenary/steppesman/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/underdweller.dm
@@ -24,10 +24,11 @@
 	shirt = shirt_type
 	shoes = /obj/item/clothing/shoes/boots/armor/light
 	belt = /obj/item/storage/belt/leather/mercenary
-	beltr = /obj/item/weapon/knife/hunting
+	var/const/obj/item/weapon/knife_type = /obj/item/weapon/knife/hunting
+	beltr = knife_type
 	neck = /obj/item/clothing/neck/chaincoif/iron
 	backl = /obj/item/storage/backpack/backpack
-	scabbards = list(/obj/item/weapon/scabbard/knife)
+	scabbards = list(knife_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor=1)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/labor/mining, 3, TRUE)

--- a/code/modules/jobs/job_types/other/merc_classes/zalad.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/zalad.dm
@@ -25,13 +25,14 @@
 	gloves = /obj/item/clothing/gloves/angle
 	belt = /obj/item/storage/belt/leather/mercenary/shalal
 	armor = /obj/item/clothing/armor/brigandine/coatplates
-	beltr = /obj/item/weapon/sword/long/rider
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/long/rider
+	beltr = sword_type
 	beltl= /obj/item/flashlight/flare/torch/lantern
 	shirt = /obj/item/clothing/shirt/undershirt/colored/black
 	pants = /obj/item/clothing/pants/tights/colored/red
 	neck = /obj/item/clothing/neck/keffiyeh/colored/red
 	backl = /obj/item/storage/backpack/satchel
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/belt/pouch/coins/poor)
 	if(!H.has_language(/datum/language/zalad))
 		H.grant_language(/datum/language/zalad)

--- a/code/modules/jobs/job_types/peasants/bard.dm
+++ b/code/modules/jobs/job_types/peasants/bard.dm
@@ -48,10 +48,11 @@
 	if(prob(50))
 		cloak = /obj/item/clothing/cloak/raincloak/colored/red
 	backl = /obj/item/storage/backpack/satchel
-	beltr = /obj/item/weapon/knife/dagger/steel/special
+	var/const/obj/item/weapon/knife_type = /obj/item/weapon/knife/dagger/steel/special
+	beltr = knife_type
 	beltl = /obj/item/storage/belt/pouch/coins/poor
 	backpack_contents = list(/obj/item/flint)
-	scabbards = list(/obj/item/weapon/scabbard/knife)
+	scabbards = list(knife_type::associated_scabbard_type)
 	if(H.dna?.species?.id == SPEC_ID_DWARF)
 		H.cmode_music = 'sound/music/cmode/combat_dwarf.ogg'
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/peasants/grabber.dm
+++ b/code/modules/jobs/job_types/peasants/grabber.dm
@@ -48,8 +48,9 @@
 	pants = /obj/item/clothing/pants/tights/sailor
 	belt = /obj/item/storage/belt/leather/rope
 	beltr = /obj/item/weapon/mace/cudgel
-	beltl = /obj/item/weapon/sword/sabre/cutlass
-	scabbards = list(/obj/item/weapon/scabbard/sword)
+	var/const/obj/item/weapon/sword_type = /obj/item/weapon/sword/sabre/cutlass
+	beltl = sword_type
+	scabbards = list(sword_type::associated_scabbard_type)
 	backpack_contents = list(/obj/item/storage/keyring/stevedore)
 	if(H.gender == MALE)
 		shoes = /obj/item/clothing/shoes/boots/leather


### PR DESCRIPTION
## About The Pull Request
removes unused shield_type variable
rewrites noble adventurer scabbard code to give the scabbard and skills based on what you pick
does the same for watch lieutenant
also makes a bunch of scabbard code use the new `associated_scabbard_type` var

## Why It's Good For The Game
makes scabbard code more reliable, standardizes standard/noble/royal/etc tiering of scabbards.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
