### PR TITLE
Fix incorrect usage of pick() instead of rand()

### DIFF
--- a/code/game/objects/structures/cannon/cannon.dm
+++ b/code/game/objects/structures/cannon/cannon.dm
@@ -67,7 +67,7 @@
 		seer.apply_effect(15, EFFECT_KNOCKDOWN)
 		var/target_turf = get_turf(seer)
 		if(get_turf(seer) == get_turf(src))
-			for(var/i in 1 to pick(3, 7))
+			for(var/i in 1 to rand(3, 7))
 				target_turf = get_step(target_turf, pick(ALL_CARDINALS))
 		else
 			for(var/i in 1 to pick(1, 2))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -622,9 +622,9 @@
 		return
 	// Make toxins and blazaam vomit look different
 	if(toxvomit == VOMIT_PURPLE)
-		V.icon_state = "vomitpurp_[pick(1,4)]"
+		V.icon_state = "vomitpurp_[rand(1,4)]"
 	else if (toxvomit == VOMIT_TOXIC)
-		V.icon_state = "vomittox_[pick(1,4)]"
+		V.icon_state = "vomittox_[rand(1,4)]"
 	if (iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.reagents)

--- a/code/modules/jobs/job_types/other/skeleton.dm
+++ b/code/modules/jobs/job_types/other/skeleton.dm
@@ -148,7 +148,7 @@
 		armor = /obj/item/clothing/armor/cuirass/iron/rust
 
 	// Randomized headgear
-	switch(pick(1,9))
+	switch(rand(1,9))
 		if (1) head = /obj/item/clothing/head/helmet/kettle
 		if (2) head = /obj/item/clothing/head/helmet/winged
 		if (3) head = /obj/item/clothing/head/helmet/leather/conical
@@ -164,7 +164,7 @@
 		backr = /obj/item/weapon/shield/wood
 
 	// Randomized weapons
-	switch(pick(1,6))
+	switch(rand(1,6))
 		if (1)
 			var/obj/item/weapon/sword/short/iron/P = new()
 			equipped_human.put_in_hands(P, forced = TRUE)

--- a/code/modules/jobs/job_types/serfs/alchemist.dm
+++ b/code/modules/jobs/job_types/serfs/alchemist.dm
@@ -28,9 +28,9 @@
 
 /datum/job/alchemist/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
-	spawned.adjust_skillrank(/datum/skill/craft/alchemy,pick(0,3), TRUE)
+	spawned.adjust_skillrank(/datum/skill/craft/alchemy, rand(0,3), TRUE)
 	if(spawned.age == AGE_OLD)
-		spawned.adjust_skillrank(/datum/skill/craft/alchemy, pick(4,6), TRUE)
+		spawned.adjust_skillrank(/datum/skill/craft/alchemy, rand(4,6), TRUE)
 
 /datum/outfit/alchemist
 	name = "Alchemist"

--- a/code/modules/jobs/job_types/serfs/artificer.dm
+++ b/code/modules/jobs/job_types/serfs/artificer.dm
@@ -48,9 +48,9 @@
 
 /datum/job/artificer/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
-	spawned.adjust_skillrank(/datum/skill/combat/wrestling, pick(1,3), TRUE)
-	spawned.adjust_skillrank(/datum/skill/combat/unarmed, pick(1,3), TRUE)
-	spawned.adjust_skillrank(/datum/skill/labor/lumberjacking, pick(1,3), TRUE)
+	spawned.adjust_skillrank(/datum/skill/combat/wrestling, rand(1,3), TRUE)
+	spawned.adjust_skillrank(/datum/skill/combat/unarmed, rand(1,3), TRUE)
+	spawned.adjust_skillrank(/datum/skill/labor/lumberjacking, rand(1,3), TRUE)
 
 /datum/outfit/artificer
 	name = "Artificer"

--- a/code/modules/spells/spell_types/pointed/status/infestation.dm
+++ b/code/modules/spells/spell_types/pointed/status/infestation.dm
@@ -72,7 +72,7 @@
 
 	if(prob(33) && iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.add_nausea(pick(10,20))
+		C.add_nausea(rand(10,20))
 		to_chat(C, span_warning(pick(messages)))
 
 /atom/movable/screen/alert/status_effect/debuff/infestation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
In some cases `pick()` was used when `rand()` was intended. For example, skeleton raider NPCs getting only an iron shortsword (option 1) or a militia flail (option 6) with options 2-5 never rolling, because `pick(1, 6)` was used instead of `rand(1,6)`. This fixes that.

## Why It's Good For The Game
Actual random values rather than just a 50% chance of picking the upper or lower bound.