### PR TITLE
Makes magic summons all give the same amount of resources when slain.

### DIFF
--- a/code/datums/rituals/ritual_runes.dm
+++ b/code/datums/rituals/ritual_runes.dm
@@ -155,6 +155,7 @@ GLOBAL_LIST(teleport_runes)
 	color = rgb(255, 0, 0)
 	animate(src, color = oldcolor, time = 5)
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 0.5 SECONDS)
+	rune_in_use = FALSE
 
 /obj/effect/decal/cleanable/roguerune/attack_hand(mob/living/user)
 	if(rune_in_use)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/behemoth.dm
@@ -56,7 +56,11 @@
 
 /mob/living/simple_animal/hostile/retaliate/elemental/behemoth/death(gibbed)
 	var/turf/deathspot = get_turf(src)
+	new /obj/item/natural/melded/t1(deathspot)
 	new /obj/item/natural/elementalfragment(deathspot)
+	new /obj/item/natural/elementalfragment(deathspot)
+	new /obj/item/natural/elementalshard(deathspot)
+	new /obj/item/natural/elementalshard(deathspot)
 	new /obj/item/natural/elementalmote(deathspot)
 	new /obj/item/natural/elementalmote(deathspot)
 	spill_embedded_objects()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/collossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/elemental/collossus.dm
@@ -60,6 +60,13 @@
 /mob/living/simple_animal/hostile/retaliate/elemental/collossus/death(gibbed)
 	var/turf/deathspot = get_turf(src)
 	new /obj/item/natural/elementalrelic(deathspot)
+	new /obj/item/natural/melded/t2(deathspot)
+	new /obj/item/natural/elementalfragment(deathspot)
+	new /obj/item/natural/elementalshard(deathspot)
+	new /obj/item/natural/elementalmote(deathspot)
+	new /obj/item/natural/elementalmote(deathspot)
+	new /obj/item/natural/elementalmote(deathspot)
+	new /obj/item/natural/elementalmote(deathspot)
 	spill_embedded_objects()
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sprite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/fae/sprite.dm
@@ -58,6 +58,6 @@
 
 /mob/living/simple_animal/hostile/retaliate/fae/sprite/death(gibbed)
 	var/turf/deathspot = get_turf(src)
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 6)
 		new /obj/item/natural/fairydust(deathspot)
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/fiend.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/fiend.dm
@@ -68,6 +68,8 @@
 	new /obj/item/natural/hellhoundfang(deathspot)
 	new /obj/item/natural/infernalash(deathspot)
 	new /obj/item/natural/infernalash(deathspot)
+	new /obj/item/natural/infernalash(deathspot)
+	new /obj/item/natural/infernalash(deathspot)
 	new /obj/item/natural/melded/t2(deathspot)
 	spill_embedded_objects()
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Makes the various mage summons all give you a similar amount of resources when slain, rather than having things like sprite randomly give you less resources.
Also fixes a bug where Noc's Eye warded summoning matrices would get stuck on "this rune is being used by someone else" if you tried to summon something without at least another mage nearby. 

## Why It's Good For The Game
Mage summons were kind of a pain because their drop rates were really unequal : 
<img width="1560" height="350" alt="image" src="https://github.com/user-attachments/assets/c922d580-dc29-4caa-a0bf-d2d4995f9571" />
Earthen Colossi and Behemoths especially can go eat a brick. 
Now, every single T1, T3 and T4 give the same amount of resources : 
T1 : 6 T1 resource
T3 : 1 Arcyne Meld, 2 T3 resources, 2 T2 resources, 2 T1 resource.
T4 : 1 Dense Meld, 1 T4 resource, 1 T3 resource, 1 T2 Resource, 4 T1 resources. 

This simplifies the mathemagic in a way that I don't get a brain freeze each time I want to get sorcerous weave. 

Also bug fix good. 

## Changelog
:cl:
balance: Made all mage summons give the same amount of resources for their tier. For instance a sprite now drops 6 fairy dust, the same way an imp drops 6 Infernal ashes. 
fix: Noc's Eye warded summoning matrices no longer get bricked if you try to summon something alone. 

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
