### PR TITLE
Fix of Blood Pact dark attunement 

### DIFF
--- a/code/modules/spells/_spell_tree/circular_tree.dm
+++ b/code/modules/spells/_spell_tree/circular_tree.dm
@@ -123,7 +123,7 @@
 	is_passive = TRUE
 
 /datum/spell_node/blood_pact/on_node_buy(mob/user)
-	user.mana_pool?.adjust_attunement(/datum/attunement/death, 0.12)
+	user.mana_pool?.adjust_attunement(/datum/attunement/dark, 0.12)
 	user.mana_pool?.adjust_attunement(/datum/attunement/blood, 0.12)
 	to_chat(user, span_notice("Dark power flows through your lifeblood."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Somehow, learning of Blood Pact provided DEATH attunement instead of DARK attunement, while Blood Pact requires Dark and Electric affinities to be learned

## Why It's Good For The Game

If we learning hybrid branch of spells, we must get attunements of parent affinities, not attunements of another discipline, which we may not learn or use at all 

## Changelog

:cl:
fix: now Blood Pact provides DARK attunement, instead of DEATH attunement, as intended
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.