### PR TITLE
Gives the Werewolf it's combat theme back

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/other/werewolf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/werewolf.dm
@@ -9,7 +9,7 @@
 	var/datum/language_holder/stored_language
 	var/list/stored_skills
 	var/list/stored_experience
-
+	cmode_music = 'sound/music/cmode/antag/combat_werewolf.ogg'
 /mob/living/carbon/human/species/werewolf/death(gibbed, nocutscene)
 	. = ..()
 	if(stored_mob)


### PR DESCRIPTION
## About The Pull Request
Gives werewolf mobs the "werewolf_combat" theme. This means they once again use "Archetype of the dark star" as their CMode music.

## Why It's Good For The Game

Music! Fixes unintended behaviour.

## Changelog

:cl:

fix: Werewolves got their combat mode track back. 

/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

