### PR TITLE
Fixes counting single coins multiple times

### DIFF
--- a/code/game/objects/items/coins.dm
+++ b/code/game/objects/items/coins.dm
@@ -352,8 +352,10 @@
 	. = ..()
 	if(quantity == 1)
 		name = initial(name)
+		gender = NEUTER
 	else
 		name = plural_name
+		gender = PLURAL
 
 /obj/item/coin/update_desc()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Single coins have a hardcoded interaction for displaying value that isn't separated from the intelligence check for counting. This adds a return following the single coin count.

Additionally sets the gender accordingly between single coins and piles so the examine text is less awkward.
<img width="483" height="315" alt="zencount" src="https://github.com/user-attachments/assets/5e55f24c-f46b-48b9-8a38-d03db208d343" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: You will no longer count single coin values multiple times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
