### PR TITLE
add more checks to hollow curse ritual

### DIFF
--- a/code/modules/antagonists/villain/zizo_cult/rituals.dm
+++ b/code/modules/antagonists/villain/zizo_cult/rituals.dm
@@ -518,21 +518,36 @@ GLOBAL_LIST_INIT(ritualslist, build_zizo_rituals())
 	if(target.mind.has_antag_datum(/datum/antagonist/werewolf))
 		to_chat(target, span_warning("The curse doesn't take hold!"))
 		return
+	if(target.get_lux_status() != LUX_HAS_LUX)
+		to_chat(target, span_warning("The curse requires lux!"))
+		return
 	if(target.stat == DEAD)
 		return
 	to_chat(target, span_warning("My very being, body, soul, and mind is contorted and twisted violently into a ball of flesh and fur, until I am reshaped anew as an abomination!"))
 	addtimer(CALLBACK(src, PROC_REF(get_hollowed), target, center), 5 SECONDS)
 
 /datum/ritual/fleshcrafting/curse/proc/get_hollowed(mob/living/victim, turf/place)
-    if(QDELETED(victim))
-        return
-    if(place != get_turf(victim))
-        return
-    if(!victim.mind)
-        return
-    var/mob/living/wll = new /mob/living/carbon/human/species/demihuman(place)
-    victim.mind.transfer_to(wll)
-    victim.gib()
+	if(QDELETED(victim))
+		return
+	if(place != get_turf(victim))
+		return
+	if(!victim.mind)
+		return
+	if(victim.mob_biotypes & MOB_UNDEAD)
+		to_chat(victim, span_warning("The curse doesn't take hold!"))
+		return
+	if(victim.mind.has_antag_datum(/datum/antagonist/werewolf))
+		to_chat(victim, span_warning("The curse doesn't take hold!"))
+		return
+	if(victim.get_lux_status() != LUX_HAS_LUX)
+		to_chat(victim, span_warning("The curse requires lux!"))
+		return
+	if(victim.stat == DEAD)
+		return
+
+	var/mob/living/wll = new /mob/living/carbon/human/species/demihuman(place)
+	victim.mind.transfer_to(wll)
+	victim.gib()
 
 /datum/ritual/fleshcrafting/nopain
 	name = "Painless Battle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Hollow curse ritual now checks if they are dead.
Hollow curse ritual checks if they have lux

## Why It's Good For The Game
Forgot to put a dead check when first making it, this fixes the oversight

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: hollow curse ritual checks if the target is dead, hollow ritual checks if target has lux
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
