### PR TITLE
Swordsman MAA

### DIFF
--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -218,7 +218,7 @@
 	category_tags = list(CTAG_MENATARMS)
 
 	jobstats = list(
-		STATKEY_STR = 1,
+		STATKEY_STR = 2,
 		STATKEY_END = 1,
 		STATKEY_CON = 1,
 	)


### PR DESCRIPTION
## About The Pull Request
Adds a Swordsman MAA that gets the same equipment as pikeman, but with the sole difference of a heater shield instead of a pike (this is because the arming sword was already something pikemen got and [Ook said to give them a heater shield and an arming sword](https://discord.com/channels/748354466335686736/1309303420661792801/1459132607236280546)) entirely because Fencer was the sword MAA and now there is no sword MAA.
They get skilled Swords and Shields and marginally worse stats than Pikeman.
## Why It's Good For The Game
Fencer, despite being kind of weird for a professional soldier, did fill a *kind* of niche, that being the guy with a sword. I think that's something a group of professional soldiers ought to have, and considering the fact the heater shield is made of wood and the arming sword was something the Pikeman already got, it shouldn't be unbalanced either.
## Changelog
:cl:
add: Added a Swordsman Men-At-Arms subclass. They get the same equipment as Pikeman, but with a heater shield instead of a pike, skilled Swords and Shields, and marginally worse stats.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.