### PR TITLE
Makes Leprosy vice give NOPAIN like the Triumph buy does.

### DIFF
--- a/code/datums/quirks/vices/physical_vice.dm
+++ b/code/datums/quirks/vices/physical_vice.dm
@@ -130,6 +130,7 @@
 	var/mob/living/carbon/human/H = owner
 
 	ADD_TRAIT(H, TRAIT_LEPROSY, TRAIT_GENERIC)
+    ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 
 	// Equip iron mask - remove existing mask if present
 	if(H.wear_mask)
@@ -147,6 +148,7 @@
 
 	// Remove traits when quirk is removed
 	REMOVE_TRAIT(H, TRAIT_LEPROSY, TRAIT_GENERIC)
+    REMOVE_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 
 /datum/quirk/vice/crippled_arm
 	name = "Missing Arm"


### PR DESCRIPTION
Noticed the Leprosy vice from the new quirk menu doesn't give NOPAIN like the triumph buy one does, so this fixes that! It wasn't ported over before.

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Leprosy quirk stops pain just like the triumph buy one now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
