### PR TITLE
Remove Cultist Data from Dark Itinerant Knight

### DIFF
--- a/code/datums/migrants/waves/antagonist/dark_itinerant_knight_wave.dm
+++ b/code/datums/migrants/waves/antagonist/dark_itinerant_knight_wave.dm
@@ -7,7 +7,6 @@
 	title = "Drow Knight"
 	tutorial = "You are an evil itinerant Knight, you have embarked alongside your squire on a voyage to engulf chaos within these lands."
 	outfit = /datum/outfit/dark_itinerant_knight
-	antag_role = /datum/antagonist/zizocultist/zizo_knight
 	allowed_sexes = list(FEMALE)
 	allowed_races = list(SPEC_ID_DROW)
 
@@ -64,7 +63,6 @@
 	title = "Underling Squire"
 	tutorial = "You are the squire of an evil knight, they have taken you under their custody as you were the only one who didn't object to their dubious ethics."
 	outfit = /datum/outfit/dark_itinerant_squire
-	antag_role = /datum/antagonist/zizocultist/zizo_knight
 	allowed_sexes = list(FEMALE)
 	allowed_races = list(SPEC_ID_DROW, SPEC_ID_HALF_DROW)
 
@@ -137,3 +135,4 @@
 		/datum/migrant_role/dark_itinerant_knight = 1,
 	)
 	greet_text = "These lands have insulted once more Zizo, you are here to remind them of her prowess."
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

See title. Removes Cultist Antagonist Data from Dark Itinerant Knight

## Why It's Good For The Game

As it stands, the Dark Itinerant Knight is currently a triumph buy-able "free cult" migrant wave, as despite it not being a leader, they can still convert people to the cult. This results in rounds where on top of already existing antagonists, someone triumph buys the wave and makes it a cult round. This can lead to massive headaches for admins, and a less enjoyable experience for players. While the idea of the Dark Itinerant Knight having cultists spells is good, it shouldn't be added until someone better at coding than me can remove the conversion ability.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: removed cult data from zizo knight
code: removed cult data from zizo knight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
