### PR TITLE
clamp athletics and climbing quirks + remove woodland hermit background

### DIFF
--- a/code/datums/quirks/boon/backstory.dm
+++ b/code/datums/quirks/boon/backstory.dm
@@ -221,6 +221,18 @@
 	granted_skill = /datum/skill/combat/firearms
 	stat_penalty = STATKEY_PER
 
+/datum/backstory/combat/athlete // under "combat" so they get clamped as well
+	name = "Former Athlete"
+	desc = "You competed in games, testing strength and endurance."
+	granted_skill = /datum/skill/misc/athletics
+	stat_penalty = STATKEY_INT
+
+/datum/backstory/combat/acrobat
+	name = "Retired Acrobat"
+	desc = "You performed daring feats, climbing and leaping."
+	granted_skill = /datum/skill/misc/climbing
+	stat_penalty = STATKEY_INT
+
 /datum/backstory/craft
 	abstract_type = /datum/backstory/craft
 	desc = "A crafting-focused background."
@@ -365,12 +377,6 @@
 	granted_skill = /datum/skill/misc/sneaking
 	stat_penalty = STATKEY_END
 
-/datum/backstory/misc/acrobat
-	name = "Retired Acrobat"
-	desc = "You performed daring feats, climbing and leaping."
-	granted_skill = /datum/skill/misc/climbing
-	stat_penalty = STATKEY_INT
-
 /datum/backstory/misc/locksmith
 	name = "Former Locksmith"
 	desc = "You worked with locks, both making and picking them."
@@ -413,12 +419,6 @@
 	granted_skill = /datum/skill/labor/mathematics
 	stat_penalty = STATKEY_CON
 
-/datum/backstory/misc/athlete
-	name = "Former Athlete"
-	desc = "You competed in games, testing strength and endurance."
-	granted_skill = /datum/skill/misc/athletics
-	stat_penalty = STATKEY_INT
-
 /datum/backstory/magic
 	abstract_type = /datum/backstory/magic
 	desc = "A magical background."
@@ -429,8 +429,3 @@
 	name = "Former Acolyte"
 	desc = "You studied in a temple, learning divine miracles."
 	granted_skill = /datum/skill/magic/holy
-
-/datum/backstory/magic/druid
-	name = "Woodland Hermit"
-	desc = "You lived in the wilds, learning nature's tricks."
-	granted_skill = /datum/skill/magic/druidic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This puts athletics and climbing skills under "combat" so they recieve the same treatment as combat skills and get clamped to average.

Removes woodland hermit backstory

## Why It's Good For The Game
Its not a good idea to be able to get these skills easily, Z falling is huge and athletics is a very good skill for combat. These being available to minmax just leaves room to powergaming.

Woodland hermit background just leaves people confused as it grants you an unused skill. (only like 2 **ARCANE** magic spells use the skill)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
code: athletics and climbing are now clamped to average. 
del: Woodland hermit background removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
