### PR TITLE
remove kobold magic from eating rocks

### DIFF
--- a/code/game/objects/items/natural/stones.dm
+++ b/code/game/objects/items/natural/stones.dm
@@ -154,9 +154,8 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 /obj/item/natural/stone/on_consume(mob/living/eater)
 	if(!magic_power)
 		return
-	eater.adjust_spell_points(magic_power * 0.1)
 	eater.mana_pool?.adjust_mana(magic_power * 25)
-	to_chat(eater, span_warning("I feel magic flowing from my stomach."))
+	to_chat(eater, span_warning("I feel energy flowing from my stomach."))
 
 /*
 	This right here is stone lore,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes kobolds getting spell points from eating rocks


## Why It's Good For The Game
I just wanna put this PR out here, I really really dislike magical kobolds, arcane magic is a practice that takes a lifetime to get within the setting and is considered a really difficult and rare practice. (Vanderlin is supposed to be a low magic setting too I believe)

Why do kobolds, that live up to 15 years and are known to have the intelligence of a child the best mages in game?

I really do not like magical kobolds, it makes no sense that you can gain arcane magic by eating **rocks** when magic is supposed to be locked to Noccites and Zizites, its silly seeing a tide of kobolds come to the mines roundstart so they can game their magic up. 

Its silly seeing almost every kobold spamming the fire brazier spell so they can get more arcane skill, and its pretty abhorrent that every kobold knows how to cast lightning bolt..

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: Removed getting spell points from stone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
