### PR TITLE
Un-RNGs your barbarian

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/combat/barbarian.dm
+++ b/code/modules/jobs/job_types/adventurer/types/combat/barbarian.dm
@@ -59,7 +59,7 @@
 		"Club" = /obj/item/weapon/mace/woodclub
 	)
 
-	var/choice = spawned.select_equippable(spawned, selectableweapon, message = "Choose Your Specialisation", title = "BARBARIAN")
+	var/choice = spawned.select_equippable(player_client, selectableweapon, message = "Choose Your Specialisation", title = "BARBARIAN")
 	if(!choice)
 		return
 


### PR DESCRIPTION
Paid for by apollovector via bounty on the discord under the title 'Barbarians can pick weapon, Less RNG on what they spawn with'

Changelog:
- Removes the RNG weapon selection for barbarian. The player now chooses between a selection of sword, mace, axe, club or bow and becomes Skilled in the appropriate skill. 
- Removes RNG equipment & armour for barbarian. They now consistently spawn with a satchel, fur cloak & spiked helm.

Previously the barbarian would random-roll between sword, axe and mace. This was very frustrating for the player if they wanted to specialise in a particular weapon and rolled one that they were uninterested in, and an unexplained & irritating deficit compared to other adventurer combat classes such as Fighter which can freely choose their main armament. 

The bow is now an option due to the fear & hunger influence & bounty request
The wooden club remains available despite the superior spiked club option due to bounty request

Barbarians would also roll between having a cloak, spiked helm or hide armour and had a 50/50 chance to spawn with a satchel.  Spawning with the fur cloak & spiked helm keeps barbarians more uniform in starting appearance & capability.

<img width="1919" height="1079" alt="selection" src="https://github.com/user-attachments/assets/db2b1017-0764-4b4f-8c51-1cd70baefdfc" />
<img width="1919" height="1079" alt="function" src="https://github.com/user-attachments/assets/aee0d416-921a-4b38-a299-c57ed1dbb879" />
