### PR TITLE
put medical book back at its place

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -27591,6 +27591,7 @@
 	pixel_y = 5
 	},
 /obj/item/recipe_book/medical,
+/obj/item/recipe_book/medical,
 /turf/open/floor/churchrough,
 /area/indoors/town/clinic_large)
 "nkk" = (
@@ -35537,10 +35538,6 @@
 /obj/structure/bars/bent,
 /turf/open/floor/carpet/green,
 /area/indoors/town/merc_guild)
-"rjV" = (
-/obj/item/recipe_book/medical,
-/turf/open/floor/cobble,
-/area/outdoors/town)
 "rkq" = (
 /obj/structure/window/solid,
 /turf/open/floor/concrete,
@@ -110221,7 +110218,7 @@ hZn
 hZn
 hZn
 hZn
-rjV
+hZn
 hZn
 hZn
 epY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
One of the medical guides was offset by a few tiles, puts it back to its place.
<img width="447" height="305" alt="image" src="https://github.com/user-attachments/assets/615bf0d0-2e61-4638-9260-87687d2dc475" />


## Why It's Good For The Game
No more bench book.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: medical guide moved a few tiles to its place
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
