### PR TITLE
Reduces number of tabs

### DIFF
--- a/code/datums/faith/_devotion.dm
+++ b/code/datums/faith/_devotion.dm
@@ -183,7 +183,7 @@
 
 /mob/living/carbon/human/proc/devotionreport()
 	set name = "Check Devotion"
-	set category = "Cleric"
+	set category = "RoleUnique"
 
 	if(!ishuman(src))
 		return
@@ -194,7 +194,7 @@
 
 /mob/living/carbon/human/proc/clericpray()
 	set name = "Give Prayer"
-	set category = "Cleric"
+	set category = "RoleUnique"
 
 	if(!ishuman(src))
 		return

--- a/code/datums/faith/penance/_penance.dm
+++ b/code/datums/faith/penance/_penance.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_EMPTY(active_penances) // List of all active penances
 
 /mob/living/carbon/human/proc/assign_penance_verb()
 	set name = "Assign Penance"
-	set category = "Cleric"
+	set category = "RoleUnique"
 
 	var/list/targets = list()
 	for(var/mob/living/carbon/human/H in view(7, src))
@@ -157,7 +157,7 @@ GLOBAL_LIST_EMPTY(active_penances) // List of all active penances
 
 /mob/living/carbon/human/proc/absolve_penance_verb()
 	set name = "Absolve Penance"
-	set category = "Cleric"
+	set category = "RoleUnique"
 
 	var/list/penitents = list()
 	for(var/mob/living/carbon/human/H in view(7, src))
@@ -181,7 +181,7 @@ GLOBAL_LIST_EMPTY(active_penances) // List of all active penances
 
 /mob/living/carbon/human/proc/check_penance_verb()
 	set name = "Check Penance"
-	set category = "Cleric"
+	set category = "RoleUnique"
 
 	var/datum/penance/P = get_penance(src)
 	if(!P)

--- a/code/modules/antagonists/villain/assassin.dm
+++ b/code/modules/antagonists/villain/assassin.dm
@@ -44,7 +44,7 @@
 
 /mob/living/carbon/human/proc/who_targets() // Verb for the assassin to remember their targets.
 	set name = "Remember Targets"
-	set category = "Assassin"
+	set category = "RoleUnique"
 	if(!mind)
 		return
 	mind.recall_targets(src)

--- a/code/modules/antagonists/villain/zomble.dm
+++ b/code/modules/antagonists/villain/zomble.dm
@@ -275,7 +275,7 @@
 
 /mob/living/carbon/human/proc/zombie_seek()
 	set name = "Seek Brains"
-	set category = "ZOMBIE"
+	set category = "ZIZO"
 
 	if(!mind.has_antag_datum(/datum/antagonist/zombie))
 		return FALSE

--- a/code/modules/jobs/job_types/church/priest.dm
+++ b/code/modules/jobs/job_types/church/priest.dm
@@ -113,7 +113,7 @@
 
 /mob/living/carbon/human/proc/coronate_lord()
 	set name = "Coronate"
-	set category = "Priest"
+	set category = "RoleUnique"
 	if(!mind)
 		return
 	if(!istype(get_area(src), /area/indoors/town/church/chapel))
@@ -164,7 +164,7 @@
 
 /mob/living/carbon/human/proc/churchexcommunicate()
 	set name = "Excommunicate"
-	set category = "Priest"
+	set category = "RoleUnique"
 	if(stat)
 		return
 	var/inputty = input("Excommunicate someone, cutting off their connection to the Ten. (excommunicate them again to remove it)", "Sinner Name") as text|null
@@ -195,7 +195,7 @@
 
 /mob/living/carbon/human/proc/churchcurse()
 	set name = "Curse"
-	set category = "Priest"
+	set category = "RoleUnique"
 	if(stat)
 		return
 	var/inputty = input("Curse someone as a heretic. (curse them again to remove it)", "Sinner Name") as text|null
@@ -224,8 +224,8 @@
 				break
 
 /mob/living/carbon/human/proc/churchannouncement()
-	set name = "Announcement"
-	set category = "Priest"
+	set name = "Priest Announcement"
+	set category = "RoleUnique"
 	if(stat)
 		return
 	var/inputty = input("Make an announcement", "VANDERLIN") as text|null

--- a/code/modules/jobs/job_types/garrison/town_elder.dm
+++ b/code/modules/jobs/job_types/garrison/town_elder.dm
@@ -56,8 +56,8 @@
 	spawned.add_quirk(/datum/quirk/boon/folk_hero)
 
 /mob/living/carbon/human/proc/townannouncement()
-	set name = "Announcement"
-	set category = "Town Elder"
+	set name = "Elder Announcement"
+	set category = "RoleUnique"
 	if(stat)
 		return
 

--- a/code/modules/jobs/job_types/inquistion/inquisitor.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor.dm
@@ -76,7 +76,7 @@
 
 /mob/living/carbon/human/proc/torture_victim()
 	set name = "Extract Confession"
-	set category = "Inquisition"
+	set category = "RoleUnique"
 
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H
@@ -131,7 +131,7 @@
 
 /mob/living/carbon/human/proc/faith_test()
 	set name = "Test Faith"
-	set category = "Inquisition"
+	set category = "RoleUnique"
 
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H

--- a/code/modules/jobs/job_types/inquistion/oratorium/human_stuff.dm
+++ b/code/modules/jobs/job_types/inquistion/oratorium/human_stuff.dm
@@ -7,7 +7,7 @@ GLOBAL_DATUM_INIT(inquisition, /datum/oratorium, new)
 
 /mob/living/carbon/human/proc/view_inquisition()
 	set name = "View Inquisition"
-	set category = "Inquisition"
+	set category = "RoleUnique"
 
 	if(!hierarchy_interface)
 		hierarchy_interface = new /datum/inquisition_hierarchy_interface(src)

--- a/code/modules/jobs/job_types/peasants/jester.dm
+++ b/code/modules/jobs/job_types/peasants/jester.dm
@@ -99,7 +99,7 @@
 
 /mob/living/carbon/human/proc/ventriloquate()
 	set name = "Ventriloquism"
-	set category = "Japes"
+	set category = "RoleUnique"
 
 	var/obj/item/grabbing/I = get_active_held_item()
 	if(!I)
@@ -115,7 +115,7 @@
 
 /mob/living/carbon/human/proc/ear_trick()
 	set name = "Ear Trick"
-	set category = "Japes"
+	set category = "RoleUnique"
 
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -41,14 +41,14 @@
 	/mob/living/simple_animal/hostile/retaliate/bat/proc/bat_down)
 
 /mob/living/simple_animal/hostile/retaliate/bat/proc/bat_up()
-	set category = "Bat Form"
+	set category = "VAMPIRE"
 	set name = "Move Up"
 
 	if(zMove(UP, TRUE))
 		to_chat(src, "<span class='notice'>I fly upwards.</span>")
 
 /mob/living/simple_animal/hostile/retaliate/bat/proc/bat_down()
-	set category = "Bat Form"
+	set category = "VAMPIRE"
 	set name = "Move Down"
 
 	if(zMove(DOWN, TRUE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Attempts to reduce the number of verb tabs by consolidating things that are only in one place.
For example Town Elder as a Heart Acolyte gets two new tabs for only three new verbs. Now it'll be one tab.

Whilst I would do this for more of the unique tabs, it's not currently practical to do it in a way that makes it easy to read.

## Why It's Good For The Game

Quality of Life baby! It's alot to manage, especially when they move around from ActiveTab

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Role-Unique verbs are now all in one tab (where practical to do so).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
