### PR TITLE
Bring FG back up to expert

### DIFF
--- a/code/modules/jobs/job_types/garrison/forestguard.dm
+++ b/code/modules/jobs/job_types/garrison/forestguard.dm
@@ -84,12 +84,12 @@
 		/datum/skill/misc/sewing = 2,
 		/datum/skill/craft/tanning = 1,
 		/datum/skill/combat/axesmaces = 3,
-		/datum/skill/combat/whipsflails = 3,
+		/datum/skill/combat/whipsflails = 4,
 		/datum/skill/combat/swords = 3,
 		/datum/skill/combat/knives = 2,
 		/datum/skill/combat/shields = 3,
 		/datum/skill/combat/bows = 1,
-		/datum/skill/combat/wrestling = 3,
+		/datum/skill/combat/wrestling = 4,
 		/datum/skill/combat/unarmed = 3
 	)
 
@@ -139,7 +139,7 @@
 		/datum/skill/craft/carpentry = 1,
 		/datum/skill/misc/sewing = 2,
 		/datum/skill/craft/tanning = 1,
-		/datum/skill/combat/bows = 3,
+		/datum/skill/combat/bows = 4,
 		/datum/skill/combat/crossbows = 3,
 		/datum/skill/combat/knives = 3,
 		/datum/skill/combat/axesmaces = 1,
@@ -195,7 +195,7 @@
 		/datum/skill/combat/wrestling = 3,
 		/datum/skill/combat/unarmed = 3,
 		/datum/skill/combat/knives = 2,
-		/datum/skill/combat/axesmaces = 3
+		/datum/skill/combat/axesmaces = 4
 	)
 
 	traits = list(


### PR DESCRIPTION

Reaver goes back to axes 4, Footman(or whatchamacallit) to flails 4, Ranger to bows 4.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Reaver goes back to axes 4, Footman(or whatchamacallit) to flails 4, Ranger to bows 4.

## Why It's Good For The Game

They're war veterans and already get shitty gear, for god's sake. There was no need for them to get hit by the big skill wave if they were going to get nothing in return. Hell, they even DIED a lot before, they die even harder now.

## Changelog

Un-nerfed the FG skills.

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: made the FG's skills normal again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
