### PR TITLE
Removes seed name obscuring.

### DIFF
--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SEEPRICES = "I can tell the prices of things down to the zenny.",
 	TRAIT_STRONGBITE = "Stronger bites, critical bite attacks.",
 	TRAIT_HATEWOMEN = "Double damage against female mobs.",
-	TRAIT_SEEDKNOW = span_info("I know which seeds grow which crops."),
+	TRAIT_SEEDKNOW = span_info("I am intimately aware of seed properties."),
 	TRAIT_NOBLE = span_blue("I'm of noble blood."),
 	TRAIT_EMPATH = "I can notice when people are stressed.",
 	TRAIT_BREADY = "Defensive stance does not passively fatigue me.",

--- a/code/modules/farming/items/seeds.dm
+++ b/code/modules/farming/items/seeds.dm
@@ -43,25 +43,14 @@
 
 /obj/item/neuFarm/seed/examine(mob/user)
 	. = ..()
-	var/show_real_identity = FALSE
-	if(isliving(user))
-		var/mob/living/living = user
-		// Seed knowers, know the seeds (druids and such)
-		if(HAS_TRAIT(living, TRAIT_SEEDKNOW))
-			show_real_identity = TRUE
-		// Journeyman farmers know them too
-		else if(living.get_skill_level(/datum/skill/labor/farming) >= 2)
-			show_real_identity = TRUE
-	else
-		show_real_identity = TRUE
-	if(show_real_identity)
-		var/datum/plant_def/plant_def_instance = GLOB.plant_defs[plant_def_type]
-		if(plant_def_instance)
-			var/examine_name = "[plant_def_instance.seed_identity]"
-			var/datum/plant_genetics/seed_genetics_instance = seed_genetics
-			if(seed_genetics_instance.seed_identity_modifier)
-				examine_name = "[seed_genetics_instance.seed_identity_modifier] " + examine_name
-			. += span_notice("I can tell these are [examine_name].")
+	var/datum/plant_def/plant_def_instance = GLOB.plant_defs[plant_def_type]
+	if(plant_def_instance)
+		var/examine_name = "[plant_def_instance.seed_identity]"
+		var/datum/plant_genetics/seed_genetics_instance = seed_genetics
+		if(seed_genetics_instance.seed_identity_modifier)
+			examine_name = "[seed_genetics_instance.seed_identity_modifier] " + examine_name
+		. += span_info("I can tell these are [examine_name].")
+		if(HAS_TRAIT(user, TRAIT_SEEDKNOW) || user.get_skill_level(/datum/skill/labor/farming) >= 2)
 			. += plant_def_instance.get_examine_details()
 
 /obj/item/neuFarm/seed/attack_atom(atom/attacked_atom, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Anyone can examine seeds to see what it plant it is. Old `TRAIT_SEEDKNOWER` and skill level check changed to be for crop information.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Requested by players.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: You can see see types without the trait, trait gives crop information
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
