### PR TITLE
Adds Remembrance, a Relic Psydonian Longsword to replace the Forgotten Blade for both Ordinator and Inspector

### DIFF
--- a/code/game/objects/items/weapons/melee/swords.dm
+++ b/code/game/objects/items/weapons/melee/swords.dm
@@ -923,6 +923,15 @@
 	. = ..()
 	AddComponent(/datum/component/psyblessed, FALSE, 3, FALSE, 50, 1, TRUE)
 
+/obj/item/weapon/sword/long/psydon/relic
+	name = "Rememberance"
+	desc = "A balanced silver blade, favoured by both the Ordo Benetarus and the Ordo Venetari. May it carve a path through the Unholy, in honour and rememberance of Psydon's sacrifice."
+
+/obj/item/weapon/sword/long/psydon/relic/Initialize(mapload)
+	. = ..()
+	//Pre-blessed, +5 force +100 Blade int, +100 int, +1 def, make it silver
+	AddComponent(/datum/component/psyblessed, TRUE, 5, 100, 100, 1, TRUE)
+
 /obj/item/weapon/sword/long/decorated
 	name = "decorated silver longsword"
 	desc = "A finely crafted silver longsword with a decorated golden hilt."

--- a/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
+++ b/code/modules/jobs/job_types/inquistion/puritian/inspector.dm
@@ -49,7 +49,7 @@
 		"Retribution (Rapier)",
 		"Daybreak (Whip)",
 		"Sanctum (Halberd)",
-		"The Forgotten Blade",
+		"Remembrance (Long Sword)",
 	)
 	var/weapon_choice = browser_input_list(spawned, "CHOOSE YOUR RELIQUARY PIECE.", "WIELD THEM IN HIS NAME.", gear)
 	switch(weapon_choice)
@@ -70,8 +70,8 @@
 			if(spawned.age == AGE_OLD)
 				spawned.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 				spawned.adjust_stat_modifier(STATMOD_JOB, STATKEY_STR, 1) //So they don't have a 33% chance if being unable to wield their weapon.
-		if("The Forgotten Blade")
-			spawned.put_in_hands(new /obj/item/weapon/sword/long/forgotten(spawned), TRUE)
+		if("Remembrance (Long Sword)")
+			spawned.put_in_hands(new /obj/item/weapon/sword/long/psydon/relic(spawned), TRUE)
 			spawned.clamped_adjust_skillrank(/datum/skill/combat/swords, 4, 4, TRUE)
 			if(spawned.age == AGE_OLD)
 				spawned.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)

--- a/code/modules/jobs/job_types/inquistion/puritian/ordinator.dm
+++ b/code/modules/jobs/job_types/inquistion/puritian/ordinator.dm
@@ -44,7 +44,7 @@
 		"Covenant And Creed (Broadsword + Shield)",
 		"Covenant and Consecratia (Flail + Shield)",
 		"Crusade (Greatsword) and a Silver Dagger",
-		"The Forgotten Blade",
+		"Remembrance (Long Sword)",
 	)
 	var/gear_choice = browser_input_list(spawned, "CHOOSE YOUR RELIQUARY PIECE.", "WIELD THEM IN HIS NAME.", gear)
 	switch(gear_choice)
@@ -73,8 +73,8 @@
 			if(spawned.age == AGE_OLD)
 				spawned.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 				spawned.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		if("The Forgotten Blade")
-			spawned.put_in_hands(new /obj/item/weapon/sword/long/forgotten(get_turf(spawned)), TRUE)
+		if("Remembrance (Long Sword)")
+			spawned.put_in_hands(new /obj/item/weapon/sword/long/psydon/relic(spawned), TRUE)
 			spawned.clamped_adjust_skillrank(/datum/skill/combat/swords, 4, 4, TRUE)
 			if(spawned.age == AGE_OLD)
 				spawned.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds Remembrance as a new weapon that can be selected by the Ordinator and Inspector. This replaces the Forgotten Blade that was originally able to be selected. The Longsword comes pre-blessed, and has a stronger blessing than a regular Psydonian Longsword that Templars can get.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Forgotten Blade is my child. It is my go to weapon when playing Prafekt due to nostalgia and legacy, however it is vastly outclassed by the other options because it cannot be blessed, and it shall remain unable to be blessed due to it being craftable.

This new longsword is unique to the Inquisition, fits the relic name theme, and fits their weapon stylings more than the Forgotten Blade.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Remembrance, a Psydonian Longsword Relic for Ordinator and Inspector
del: Removed the Forgotten Blade from being able to be selected by Ordinator and Inspector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
