### PR TITLE
Removes wretch vampire

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/wretch/bloodsucker.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/bloodsucker.dm
@@ -1,4 +1,4 @@
-/datum/job/advclass/wretch/bloodsucker
+/*/datum/job/advclass/wretch/bloodsucker
 	title = "Bloodsucker"
 	tutorial = "You have recently been embraced as a vampire. You do not know whom your sire is, strange urges, unnatural strength, a thirst you can barely control. You were outed as a monster and are now on the run"
 	allowed_sexes = list(MALE, FEMALE)
@@ -286,4 +286,4 @@
 
 /datum/job_pack/bloodsucker_vagrant/pick_pack(mob/living/carbon/human/picker)
 	. = ..()
-	picker.cmode_music = 'sound/music/cmode/antag/CombatBeest.ogg'
+	picker.cmode_music = 'sound/music/cmode/antag/CombatBeest.ogg' */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Comments out wretch vampire until it can be replaced with something better or balanced properly.
In its current state it is WAY too overpowered for a wretch class, and should either be nerfed or put into its own antag, the combination of their vampire abilities, sunlight immunity, and their stats/combat skills makes them nigh unkillable and one of our most problematic gamer classes, probably even on the same level/more powerful than stage one vampire lord.

## Why It's Good For The Game

<img width="605" height="40" alt="image" src="https://github.com/user-attachments/assets/72614297-d2d9-4b95-b6e3-4614a427149d" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: Wretch Vampire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
