### PR TITLE
Cautery fixes

### DIFF
--- a/code/modules/surgery/surgeries/cure_rot.dm
+++ b/code/modules/surgery/surgeries/cure_rot.dm
@@ -12,7 +12,7 @@
 	name = "burn rot"
 	implements = list(
 		TOOL_CAUTERY = 85,
-		/obj/item/clothing/neck/psycross = 85,
+		/obj/item/clothing/neck/psycross/silver = 85,
 		TOOL_WELDER = 70,
 		TOOL_HOT = 35,
 	)
@@ -40,7 +40,7 @@
 	if(!has_rot && iscarbon(target))
 		var/mob/living/carbon/stinky = target
 		for(var/obj/item/bodypart/bodypart as anything in stinky.bodyparts)
-			if(bodypart.rotted || bodypart.skeletonized)
+			if(bodypart.rotted)
 				has_rot = TRUE
 				break
 	if(was_zombie)
@@ -54,7 +54,6 @@
 		var/mob/living/carbon/stinky = target
 		for(var/obj/item/bodypart/rotty in stinky.bodyparts)
 			rotty.rotted = FALSE
-			rotty.skeletonized = FALSE
 			rotty.update_limb()
 			if(rotty.can_be_disabled)
 				rotty.update_disabled()

--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -116,6 +116,7 @@
 	sharpness = IS_BLUNT
 	w_class = WEIGHT_CLASS_NORMAL
 	thrown_bclass = BCLASS_BLUNT
+	tool_behaviour = TOOL_CAUTERY
 	/// Timer to cool down
 	var/cool_timer
 	/// Whether or not we are heated up


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Cautery now properly uses the TOOL_CAUTERY define so that it gets it's proper cauterization chance. (It was losing 50% cauterization chance.)

Wooden psycrosses can no longer be used to cauterize, silver psycrosses can still be used.

You can no longer de-skeletonize people and give liches complete skin and flesh makeovers by cauterizing them.

## Why It's Good For The Game

Makes the cautery actually useful, and so that people won't just use wooden psycrosses to heal people.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: You can no longer de-skeletonize people by cauterizing them.
balance: You can no longer use a wooden psycross to cauterize people, it is wood. Silver still works.
fix: Makes it so the cautery actually gets the cauterization bonus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
