### PR TITLE
Automaton Commands

### DIFF
--- a/code/datums/components/command_listener/_component.dm
+++ b/code/datums/components/command_listener/_component.dm
@@ -38,7 +38,7 @@
 		/datum/follower_command/protect,
 		/datum/follower_command/kill,
 		/datum/follower_command/guard_position,
-		/datum/follower_command/follow,
+	//	/datum/follower_command/follow,
 	)
 
 /datum/component/command_follower/Initialize(list/command_typepaths = list())

--- a/code/datums/components/command_listener/commands/guard.dm
+++ b/code/datums/components/command_listener/commands/guard.dm
@@ -11,7 +11,7 @@
 	bound_component = automaton.AddComponent(/datum/component/bounded, \
 		guard_location, \
 		0, \
-		3, \
+		5, \
 		null, \
 		null, \
 		FALSE, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Comments out the follow command for now as it is very buggy. Custom command should be used in its stead. 

Additionally, I do not believe a follow command is needed as it removes player agency and freedom to act out a command. 

Upped the max distance for guard to 5 from 3. Not a full screen but inbetween.

## Why It's Good For The Game

Follow was causing Automatons to teleport due to max dist being 2. Command additionally removes player agency. 

Guard has now more tiles it covers to Automatons aren't stuck to a small space.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Guard command on Automaton is now 5 tiles instead of 3.
fix: Follow command removed. Use Custom command instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
