### PR TITLE
Fixes devotion meter not appearing round start

### DIFF
--- a/code/datums/faith/_devotion.dm
+++ b/code/datums/faith/_devotion.dm
@@ -65,7 +65,7 @@
 /datum/devotion/proc/initialize_hud()
 	holder_mob?.hud_used?.initialize_bloodpool()
 	holder_mob?.hud_used?.bloodpool.set_fill_color(devotion_color)
-	update_devotion(0)
+	update_devotion(0) //hack to force meter to reflect the starting devotion
 
 /datum/devotion/proc/initialize_tasks()
 	if(!holder_mob?.patron)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The problem stems from the devotion meter needing hud_used to be assigned before initializing. For round start jobs devotion gets granted before hud_used is assigned (when mind is transfered to the mob).
Adds a check for HasRoundStarted() before initializing devotion HUD, otherwise sets an OnRoundstart callback.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Devotion meter should now appear round start
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
