### PR TITLE
More Stress Fixes

### DIFF
--- a/code/datums/rage/werewolf_rage.dm
+++ b/code/datums/rage/werewolf_rage.dm
@@ -70,7 +70,7 @@
 	if(!holder_mob || holder_mob.stat >= DEAD)
 		return
 
-	var/new_stress_amount = new_stress.stress_change
+	var/new_stress_amount = new_stress.get_stress(holder_mob)
 	// Calculate rage gain based on total stress - global multiplier
 	// At 0 stress: 1x multiplier, at 5 stress: 1.33x, at 10 stress: 1.67x, at 15 stress: 2x
 	// Negative stress reduces rage gain

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -791,15 +791,32 @@
 	max_stacks = 3
 	stress_change_per_extra_stack = 1
 	quality_modifier = -2
-	hidden = TRUE
-	desc = span_red("I feel the malaguero of another.")
+	desc = span_red("The Hellspawn is making things worse...")
+	hidden = TRUE // until 2nd stack
 
 /datum/stress_event/malaguero/on_apply(mob/living/user)
 	. = ..()
 	if(istiefling(user))
 		max_stacks = 1
 		stress_change = 0
+		stress_change_per_extra_stack = 0
 		quality_modifier = 0
 
 /datum/stress_event/malaguero/can_show(mob/living/user)
-	return istiefling(user) || ..()
+	if(istiefling(user))
+		return TRUE
+	if(stacks > 1)
+		return TRUE
+	return ..()
+
+/datum/stress_event/malaguero/get_desc(mob/living/user)
+	if(istiefling(user))
+		return span_red("I feel the Malaguero of another.")
+	if(HAS_TRAIT(user, TRAIT_TOLERANT))
+		return span_red("The misfortune of the Tiefling becomes my own.")
+	return ..()
+
+/datum/stress_event/malaguero/get_stress(mob/living/user)
+	if(istiefling(user))
+		return 0
+	return ..()

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -105,7 +105,7 @@
 				INVOKE_ASYNC(src, PROC_REF(play_stress_indicator))
 
 		else
-			if(event && last_event.stress_change <= 0)
+			if(event && last_event.get_stress(src) <= 0)
 				if(last_announced_event_type != event_type)
 					to_chat(src, "[event] [span_green(" I gain PEACE.")]")
 					last_announced_event_type = event_type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes some issues where stress values were not getting properly acquired. Also fixes a few things with Malaguero applying to tieflings.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Stress value fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
