### PR TITLE
Sets Bypass LastClass to True for the remaining jobs.

### DIFF
--- a/code/modules/jobs/job_types/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/garrison/dungeoneer.dm
@@ -12,6 +12,7 @@
 	faction = FACTION_TOWN
 	total_positions = 1
 	spawn_positions = 1
+	bypass_lastclass = TRUE
 
 	allowed_races = RACES_PLAYER_NONEXOTIC
 	blacklisted_species = list(SPEC_ID_HALFLING)

--- a/code/modules/jobs/job_types/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/garrison/veteran.dm
@@ -11,6 +11,7 @@
 	faction = FACTION_TOWN
 	total_positions = 1
 	spawn_positions = 1
+	bypass_lastclass = TRUE
 	spells = list(/datum/action/cooldown/spell/undirected/list_target/convert_role/militia)
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_OLD, AGE_IMMORTAL)

--- a/code/modules/jobs/job_types/nobility/courtphys.dm
+++ b/code/modules/jobs/job_types/nobility/courtphys.dm
@@ -9,6 +9,7 @@
 	faction = FACTION_TOWN
 	total_positions = 1
 	spawn_positions = 1
+	bypass_lastclass = TRUE
 	allowed_races = RACES_PLAYER_NONHERETICAL
 	blacklisted_species = list(SPEC_ID_TRITON, SPEC_ID_HARPY)
 	outfit = /datum/outfit/courtphys/male

--- a/code/modules/jobs/job_types/nobility/minor_noble.dm
+++ b/code/modules/jobs/job_types/nobility/minor_noble.dm
@@ -9,6 +9,7 @@
 	faction = FACTION_TOWN
 	total_positions = 2
 	spawn_positions = 2
+	bypass_lastclass = TRUE
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
 	outfit = /datum/outfit/noble
 	apprentice_name = "Servant"

--- a/code/modules/jobs/job_types/peasants/bard.dm
+++ b/code/modules/jobs/job_types/peasants/bard.dm
@@ -10,6 +10,7 @@
 	faction = FACTION_TOWN
 	total_positions = 4
 	spawn_positions = 4
+	bypass_lastclass = TRUE
 
 	allowed_races = RACES_PLAYER_ALL
 	outfit = /datum/outfit/bard

--- a/code/modules/jobs/job_types/peasants/fisher.dm
+++ b/code/modules/jobs/job_types/peasants/fisher.dm
@@ -9,6 +9,7 @@
 	faction = FACTION_TOWN
 	total_positions = 5
 	spawn_positions = 5
+	bypass_lastclass = TRUE
 
 	allowed_races = RACES_PLAYER_ALL
 

--- a/code/modules/jobs/job_types/serfs/matron.dm
+++ b/code/modules/jobs/job_types/serfs/matron.dm
@@ -10,6 +10,7 @@
 	faction = FACTION_TOWN
 	total_positions = 1
 	spawn_positions = 1
+	bypass_lastclass = TRUE
 
 	allowed_sexes = list(FEMALE)
 	allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD, AGE_IMMORTAL)


### PR DESCRIPTION
## About The Pull Request

Dungeoneer, Noble, Veteran, Matron, Court Physician, Bard, and Fisher can now all be played two(or more) rounds in a row without spending triumphs. "Fixes" #5458

## Why It's Good For The Game

A lot of people encounter this leftover mechanic from Rogue Code and assume their roll bugged, when in reality that's not the case and the game just arbitrarily blocked them from rolling the same thing twice in a row. It makes no sense if a player can roll Monarch or Priest or Templar 10 rounds in a row but the Dungeoneer or even a Fisher can't. This fixes that. I assume there's some reason the mechanic still exists and just isn't applied practically anywhere.

## Changelog

:cl:
add: Dungeoneer, Noble, Veteran, Matron, Court Physician, Bard, and Fisher can now all be played two(or more) rounds in a row without spending triumphs. 
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
