### PR TITLE
Revert "Emergency slur removal"

### DIFF
--- a/strings/accents/zalad_replacement.json
+++ b/strings/accents/zalad_replacement.json
@@ -50,6 +50,7 @@
 		"monarch": "aeli",
 		"princess": "emira",
 		"prince": "emir",
+		"heretic": "kafir",
 		"soup": "shouraba",
 		"water": "wateir",
 		"bread": "khubz",


### PR DESCRIPTION
Reverts Monkestation/Vanderlin#5475

This is not "Kaffir" it's "Kafir" they are two different words and we use it correctly