### PR TITLE
Let Exiled warrior choose between duel axes and arming sword, Take 2

### DIFF
--- a/code/modules/jobs/job_types/other/merc_classes/exiled.dm
+++ b/code/modules/jobs/job_types/other/merc_classes/exiled.dm
@@ -47,7 +47,7 @@
 	if(spawned.gender == MALE && spawned.dna?.species)
 		spawned.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	var/weapons = list("Sword", "Axes")
-	var/weapon_choice = input(spawned,"CHOOSE YOUR WEAPON.", "SPILL SOME BLOOD.") as anything in weapons
+	var/weapon_choice = tgui_input_list(player_client, "CHOOSE YOUR WEAPON.", "SPILL SOME BLOOD.", weapons)
 	switch(weapon_choice)
 		if("Sword")
 			spawned.equip_to_slot_or_del(new /obj/item/weapon/sword/arming, ITEM_SLOT_BELT_R, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives exiled warrior a choice between arming sword + cudgel or their 2 axes, reuploaded.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Exiled Warrior was originally based off of Conan The Barbarian, who used swords, but exiled warrior was changed into a axe class. Given we now have bogwalker as a axe merc, I think it's fair that the smart horcs can choose between a sword and a axe.. it also says in their description that they got exiled for liking swords. Ook also semi approved of the idea.
Reason for steel sword rather then iron: In my eyes, exiled warrior trades steel gear for utility skills and good stats, hence the 2 iron axes and leather gear. However, 2 iron bars are worth about as much (if not more then) 1 steel bar. I also have bias towards the arming sword since it has a special attack, which no other 'generic' sword has.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Exiled Warrior can choose between arming sword and duel axes
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
