### PR TITLE
Herbal Teas In Apothecary Cauldron (Draft)

### DIFF
--- a/code/modules/crafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/crafting/alchemy/cauldron_recipes.dm
@@ -492,3 +492,96 @@ Keep them reasonable to make
 		/datum/thaumaturgical_essence/air = 4,
 		/datum/thaumaturgical_essence/cycle = 2,
 	)
+// Apothecary's Valeriana Sleep Draught (calming/sleep aid) (2 valeriana, 1 mentha)
+/datum/alch_cauldron_recipe/valeriana_draught
+	recipe_name = "Valeriana Sleep Draught"
+	smells_like = "valeriana"
+	output_reagents = list(datum/reagent/medicine/herbal/valeriana_draught = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/fire = 2,
+		/datum/thaumaturgical_essence/life = 1,
+		/datum/thaumaturgical_essence/water = 2,
+		/datum/thaumaturgical_essence/frost = 1,
+	)
+
+// Apothecary's Benedictus Vigor Tea (stamina enhancement)
+/datum/alch_cauldron_recipe/benedictus_vigor
+	recipe_name = "Benedictus Vigor Tea"
+	smells_like = "benedictus"
+	output_reagents = list(/datum/reagent/buff/herbal/benedictus_vigor = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/order = 4,
+		/datum/thaumaturgical_essence/crystal = 2,
+	)
+
+// Paris Numbing Poultice (topical anesthetic)
+/datum/container_craft/cooking/herbal_salve/paris_poultice
+	recipe_name = "Anaesthetic of Paris"
+	smells_like = "paris"
+	output_reagents = list(/datum/reagent/medicine/herbal/paris_poultice = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/water = 4,
+		/datum/thaumaturgical_essence/poison = 2,
+		/datum/thaumaturgical_essence/fire = 2,
+		/datum/thaumaturgical_essence/life = 1,
+	)
+
+// Complex Multi-Herb Recipes
+
+// Herbalist's Panacea (multiple healing herbs)
+/datum/alch_cauldron_recipe/herbalist_panacea
+	recipe_name = "Herbalist's Panacea"
+	smells_like = "strong potpourri"
+	output_reagents = list(/datum/reagent/medicine/herbal/herbalist_panacea = 10)
+		required_essences = list(
+		/datum/thaumaturgical_essence/air = 4,
+		/datum/thaumaturgical_essence/fire = 2,
+		/datum/thaumaturgical_essence/life = 2,
+		/datum/thaumaturgical_essence/void = 1,
+	)
+
+// Witch's Bane (anti-poison blend)
+/datum/alch_cauldron_recipe/witches_bane
+	recipe_name = "Witch's Bane"
+	smells_like = "fresh laundry"
+	output_reagents = list(/datum/reagent/medicine/herbal/witches_bane = 10)
+		required_essences = list(
+		/datum/thaumaturgical_essence/order = 2,
+		/datum/thaumaturgical_essence/life = 1,
+		/datum/thaumaturgical_essence/fire = 2,
+		/datum/thaumaturgical_essence/cycle = 1,
+	)
+
+// Scholar's Focus (mental enhancement)
+/datum/alch_cauldron_recipe/scholar_focus
+	recipe_name = "Scholar's Focus Tea"
+	smells_like = "mint"
+	output_reagents = list(/datum/reagent/buff/herbal/scholar_focus = 10)
+		required_essences = list(
+		/datum/thaumaturgical_essence/air = 2,
+		/datum/thaumaturgical_essence/cycle = 1,
+	)
+
+// Moonwater Elixir (magical enhancement)
+/datum/alch_cauldron_recipe/moonwater_elixir
+	recipe_name = "Moonwater Elixir"
+	smells_like = "fresh water"
+	output_reagents = list(/datum/reagent/buff/herbal/moonwater_elixir = 10)
+		required_essences = list(
+		/datum/thaumaturgical_essence/fire = 2,
+		/datum/thaumaturgical_essence/cycle = 2,
+		/datum/thaumaturgical_essence/water = 2,
+	)
+
+// Battle Stim (combat enhancement)
+/datum/alch_cauldron_recipe/battle_stim
+	name = "Warrior's Battle Broth"
+	smells_like = "dirty socks"
+	output_reagents = list(/datum/reagent/buff/herbal/battle_stim = 10)
+		required_essences = list(
+		/datum/thaumaturgical_essence/order = 4,
+		/datum/thaumaturgical_essence/air = 2,
+		/datum/thaumaturgical_essence/crystal = 1,
+		/datum/thaumaturgical_essence/motion = 1,
+		/datum/thaumaturgical_essence/void = 1,
+	)

--- a/code/modules/crafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/crafting/alchemy/cauldron_recipes.dm
@@ -496,7 +496,7 @@ Keep them reasonable to make
 /datum/alch_cauldron_recipe/valeriana_draught
 	recipe_name = "Valeriana Sleep Draught"
 	smells_like = "valeriana"
-	output_reagents = list(datum/reagent/medicine/herbal/valeriana_draught = 10)
+	output_reagents = list(/datum/reagent/medicine/herbal/valeriana_draught = 10)
 	required_essences = list(
 		/datum/thaumaturgical_essence/fire = 2,
 		/datum/thaumaturgical_essence/life = 1,
@@ -515,7 +515,7 @@ Keep them reasonable to make
 	)
 
 // Paris Numbing Poultice (topical anesthetic)
-/datum/container_craft/cooking/herbal_salve/paris_poultice
+/datum/alch_cauldron_recipe/paris_poultice
 	recipe_name = "Anaesthetic of Paris"
 	smells_like = "paris"
 	output_reagents = list(/datum/reagent/medicine/herbal/paris_poultice = 10)
@@ -575,7 +575,7 @@ Keep them reasonable to make
 
 // Battle Stim (combat enhancement)
 /datum/alch_cauldron_recipe/battle_stim
-	name = "Warrior's Battle Broth"
+	recipe_name = "Warrior's Battle Broth"
 	smells_like = "dirty socks"
 	output_reagents = list(/datum/reagent/buff/herbal/battle_stim = 10)
 	required_essences = list(

--- a/code/modules/crafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/crafting/alchemy/cauldron_recipes.dm
@@ -533,7 +533,7 @@ Keep them reasonable to make
 	recipe_name = "Herbalist's Panacea"
 	smells_like = "strong potpourri"
 	output_reagents = list(/datum/reagent/medicine/herbal/herbalist_panacea = 10)
-		required_essences = list(
+	required_essences = list(
 		/datum/thaumaturgical_essence/air = 4,
 		/datum/thaumaturgical_essence/fire = 2,
 		/datum/thaumaturgical_essence/life = 2,
@@ -545,7 +545,7 @@ Keep them reasonable to make
 	recipe_name = "Witch's Bane"
 	smells_like = "fresh laundry"
 	output_reagents = list(/datum/reagent/medicine/herbal/witches_bane = 10)
-		required_essences = list(
+	required_essences = list(
 		/datum/thaumaturgical_essence/order = 2,
 		/datum/thaumaturgical_essence/life = 1,
 		/datum/thaumaturgical_essence/fire = 2,
@@ -557,7 +557,7 @@ Keep them reasonable to make
 	recipe_name = "Scholar's Focus Tea"
 	smells_like = "mint"
 	output_reagents = list(/datum/reagent/buff/herbal/scholar_focus = 10)
-		required_essences = list(
+	required_essences = list(
 		/datum/thaumaturgical_essence/air = 2,
 		/datum/thaumaturgical_essence/cycle = 1,
 	)
@@ -567,7 +567,7 @@ Keep them reasonable to make
 	recipe_name = "Moonwater Elixir"
 	smells_like = "fresh water"
 	output_reagents = list(/datum/reagent/buff/herbal/moonwater_elixir = 10)
-		required_essences = list(
+	required_essences = list(
 		/datum/thaumaturgical_essence/fire = 2,
 		/datum/thaumaturgical_essence/cycle = 2,
 		/datum/thaumaturgical_essence/water = 2,
@@ -578,7 +578,7 @@ Keep them reasonable to make
 	name = "Warrior's Battle Broth"
 	smells_like = "dirty socks"
 	output_reagents = list(/datum/reagent/buff/herbal/battle_stim = 10)
-		required_essences = list(
+	required_essences = list(
 		/datum/thaumaturgical_essence/order = 4,
 		/datum/thaumaturgical_essence/air = 2,
 		/datum/thaumaturgical_essence/crystal = 1,

--- a/code/modules/crafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/crafting/alchemy/cauldron_recipes.dm
@@ -375,3 +375,120 @@ Keep them reasonable to make
 		/datum/thaumaturgical_essence/light = 3,
 		/datum/thaumaturgical_essence/water = 3,
 	)
+//This is Carolina trying to figure out how basic things work.
+
+// Apothecary's Symphitum Tea Recipe
+/datum/alch_cauldron_recipe/symphitum_tea
+	recipe_name = "Extract of Symphitum"
+	smells_like = "symphitum"
+	output_reagents = list(/datum/reagent/medicine/herbal/symphitum_tea = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/air = 4,
+		/datum/thaumaturgical_essence/life = 2,
+	)
+
+// Apothecary's Taraxacum Extract Recipe
+/datum/alch_cauldron_recipe/taraxacum_extract
+	recipe_name = "Extract of Taraxacum"
+	smells_like = "taraxacum"
+	output_reagents = list(/datum/reagent/medicine/herbal/taraxacum_extract = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/fire = 6,
+		/datum/thaumaturgical_essence/motion = 3,
+	)
+
+// Apothecary's Urtica Brew Recipe
+/datum/alch_cauldron_recipe/urtica_brew
+	recipe_name = "Extract of Urtica"
+	smells_like = "urtica"
+	output_reagents = list(/datum/reagent/medicine/herbal/urtica_brew = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/air = 4,
+		/datum/thaumaturgical_essence/void = 2,
+	)
+
+// Apothecary's Calendula Salve Recipe
+/datum/alch_cauldron_recipe/calendula_salve
+	recipe_name = "Extract of Calendula"
+	smells_like = "calendula"
+	output_reagents = list(/datum/reagent/medicine/herbal/calendula_salve = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/fire = 6,
+		/datum/thaumaturgical_essence/life = 3,
+	)
+
+// Apothecary's Hypericum Tonic Recipe
+/datum/alch_cauldron_recipe/hypericum_tonic
+	recipe_name = "Extract of Hypericum"
+	smells_like = "hypericum"
+	output_reagents = list(/datum/reagent/medicine/herbal/hypericum_tonic = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/fire = 4,
+		/datum/thaumaturgical_essence/cycle = 2,
+	)
+
+// Apothecary's Mentha Tea Recipe
+/datum/alch_cauldron_recipe/mentha_tea
+	recipe_name = "Mentha Tea"
+	smells_like = "mentha"
+	output_reagents = list(/datum/reagent/medicine/herbal/mentha_tea = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/water = 4,
+		/datum/thaumaturgical_essence/frost = 2,
+	)
+
+// Apothecary's Herbal Buff Teas
+/datum/alch_cauldron_recipe/salvia_wisdom
+	recipe_name = "Salvia Wisdom Tea"
+	smells_like = "salvia"
+	output_reagents = list(/datum/reagent/buff/herbal/salvia_wisdom = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/earth = 4,
+		/datum/thaumaturgical_essence/void = 2,
+	)
+
+/datum/alch_cauldron_recipe/artemisia_luck
+	recipe_name = "Artemisia Fortune Tea"
+	smells_like = "artemisia"
+	output_reagents = list(/datum/reagent/buff/herbal/artemisia_luck = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/water = 4,
+		/datum/thaumaturgical_essence/cycle = 2,
+	)
+
+/datum/alch_cauldron_recipe/euphorbia_strength
+	recipe_name = "Euphorbia Strength Tea"
+	smells_like = "euphorbia"
+	output_reagents = list(/datum/reagent/buff/herbal/euphorbia_strength = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/earth = 4,
+		/datum/thaumaturgical_essence/life = 2,
+	)
+
+// Apothecary's Mild Poison Recipes
+/datum/alch_cauldron_recipe/weak_atropa
+	recipe_name = "Diluted Extract of Atropa"
+	smells_like = "atropa"
+	output_reagents = list(/datum/reagent/poison/herbal/weak_atropa = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/earth = 2,
+		/datum/thaumaturgical_essence/poison = 1,
+	)
+
+/datum/alch_cauldron_recipe/matricaria_irritant
+	recipe_name = "Matricaria Irritant"
+	smells_like = "matricaria"
+	output_reagents = list(/datum/reagent/poison/herbal/matricaria_irritant = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/earth = 4,
+		/datum/thaumaturgical_essence/cycle = 2,
+	)
+
+/datum/alch_cauldron_recipe/euphrasia_wash
+	recipe_name = "Euphrasia Eye Wash"
+	smells_like = "euphrasia"
+	output_reagents = list(/datum/reagent/medicine/herbal/euphrasia_eye_wash = 10)
+	required_essences = list(
+		/datum/thaumaturgical_essence/air = 4,
+		/datum/thaumaturgical_essence/cycle = 2,
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows apothecaries to make herbal teas via essences in the same way they do potions.

## Why It's Good For The Game

The apothecary continues to be an underplayed and underutilized class. As herbal teas expand, it is thematically appropriate and useful balance-wise for those apothecaries who wish to research to be able to produce large amounts of herbal teas via essences and cauldrons. Everyone, including apothecaries who are uninterested in research and essence collection, is still able to create herbal teas in the same way as before; this merely adds a convenient alternative for the role that is supposed to be the master of all things alchemical.

## Changelog

:cl:
add: Adds herbal teas to the recipes of the apothecary's essence-based cauldron.
/:cl:


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
