### PR TITLE
More things to call kobolds

### DIFF
--- a/strings/slurs.json
+++ b/strings/slurs.json
@@ -125,6 +125,11 @@
 			"forked tongue",
 			"dragon refuse",
 			"troglodyte",
+			"termite",
+			"cave dweller",
+			"dirt dog",
+			"pack rat",
+			"cave hound",
 			"scale skin",
 			"rock rodent",
 			"rock rat"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Some more things to call kobolds that give some influence to Astrata.
<img width="118" height="105" alt="bild" src="https://github.com/user-attachments/assets/8bea6a01-d526-40d2-88e4-da36966f16e9" />


## Why It's Good For The Game
For when you get shanked to death by a kobold the previous game.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: More kobold slurs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
