### PR TITLE
I hope this fixes hud assets disappearing...

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -21,14 +21,16 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	/// Wounds get sorted from highest severity to lowest severity
 	var/severity = WOUND_SEVERITY_LIGHT
 
+	//these are all turned off for now due to overlay issues
 	var/overlay_on_skeleton = FALSE
-	/// Overlay to use when this wound is applied to a carbon mob
-	var/mob_overlay = "w1"
-	/// an alternative layer to render this on for things above clothing
 	var/layer_override
 	var/armdam_override
 	var/legdam_override
 	var/use_blood_color = TRUE
+
+
+	/// Overlay to use when this wound is applied to a carbon mob
+	var/mob_overlay = "w1"
 	/// Overlay to use when this wound is sewn, and is on a carbon mob
 	var/sewn_overlay = ""
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -164,29 +164,21 @@ GLOBAL_PROTECT(no_child_icons)
 					var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.body_zone]_b", -ARM_DAMAGE_LAYER)
 					armdam_overlay.color = BP.bandage.color
 					armdam_overlays += armdam_overlay
-		wound_overlays = list()
-		for(var/datum/wound/wound as anything in BP.wounds)
-			if(!wound.mob_overlay)
-				continue
-			if(!BP.skeletonized || wound.overlay_on_skeleton)
-				wound_overlays[wound.mob_overlay] = list(
-					isnum(wound.layer_override) ? wound.layer_override : DAMAGE_LAYER,
-					isnum(wound.legdam_override) ? wound.legdam_override : LEG_DAMAGE_LAYER,
-					isnum(wound.armdam_override) ? wound.armdam_override : ARM_DAMAGE_LAYER,
-					wound.use_blood_color
-				)
-		for(var/wound_overlay in wound_overlays)
-			var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.body_zone]_[wound_overlay]", -wound_overlays[wound_overlay][1])
-			damage_overlays += damage_overlay
-			var/mutable_appearance/legdam_overlay = mutable_appearance(limb_icon, "legdam_[BP.body_zone]_[wound_overlay]", -wound_overlays[wound_overlay][2])
-			legdam_overlays += legdam_overlay
-			var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.body_zone]_[wound_overlay]", -wound_overlays[wound_overlay][3])
-			armdam_overlays += armdam_overlay
-			if(wound_overlays[wound_overlay][4])
+			wound_overlays = list()
+			for(var/datum/wound/wound as anything in BP.wounds)
+				if(!wound.mob_overlay)
+					continue
+				wound_overlays |= wound.mob_overlay
+			for(var/wound_overlay in wound_overlays)
+				var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.body_zone]_[wound_overlay]", -DAMAGE_LAYER)
 				damage_overlay.color = bloodcolor
+				damage_overlays += damage_overlay
+				var/mutable_appearance/legdam_overlay = mutable_appearance(limb_icon, "legdam_[BP.body_zone]_[wound_overlay]", -LEG_DAMAGE_LAYER)
 				legdam_overlay.color = bloodcolor
+				legdam_overlays += legdam_overlay
+				var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.body_zone]_[wound_overlay]", -ARM_DAMAGE_LAYER)
 				armdam_overlay.color = bloodcolor
-
+				armdam_overlays += armdam_overlay
 		if(!bleed_checker && BP.bandage)
 			var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.body_zone]_b", -DAMAGE_LAYER)
 			damage_overlay.color = BP.bandage.color
@@ -230,19 +222,17 @@ GLOBAL_PROTECT(no_child_icons)
 						var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.aux_zone]_b", -ARM_DAMAGE_LAYER)
 						armdam_overlay.color = BP.bandage.color
 						armdam_overlays += armdam_overlay
-			//We got the wound overlays before, it's all good
-			for(var/wound_overlay in wound_overlays)
-				var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.aux_zone]_[wound_overlay]", -wound_overlays[wound_overlay][1])
-				damage_overlays += damage_overlay
-				var/mutable_appearance/legdam_overlay = mutable_appearance(limb_icon, "legdam_[BP.aux_zone]_[wound_overlay]", -wound_overlays[wound_overlay][2])
-				legdam_overlays += legdam_overlay
-				var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.aux_zone]_[wound_overlay]", -wound_overlays[wound_overlay][3])
-				armdam_overlays += armdam_overlay
-				if(wound_overlays[wound_overlay][4])
+				//We got the wound overlays before, it's all good
+				for(var/wound_overlay in wound_overlays)
+					var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.aux_zone]_[wound_overlay]", -DAMAGE_LAYER)
 					damage_overlay.color = bloodcolor
-					legdam_overlay.color = bloodcolor
+					damage_overlays += damage_overlay
+					var/mutable_appearance/legdam_overlay = mutable_appearance(limb_icon, "legdam_[BP.aux_zone]_[wound_overlay]", -LEG_DAMAGE_LAYER)
+					legdam_overlay.color =bloodcolor
+					legdam_overlays += legdam_overlay
+					var/mutable_appearance/armdam_overlay = mutable_appearance(limb_icon, "armdam_[BP.aux_zone]_[wound_overlay]", -ARM_DAMAGE_LAYER)
 					armdam_overlay.color = bloodcolor
-
+					armdam_overlays += armdam_overlay
 			if(!bleed_checker && BP.bandage)
 				var/mutable_appearance/damage_overlay = mutable_appearance(limb_icon, "[BP.aux_zone]_b", -DAMAGE_LAYER)
 				damage_overlay.color = BP.bandage.color


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Reverts some wound overlay stuff in black briar in hopes it was related to why people's hud assets were disappearing

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: maybe fixed random hud assets dropping from your game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
