### PR TITLE
Wild drowsbane no sprite fix

### DIFF
--- a/code/game/objects/items/weapons/ranged/flintlock.dm
+++ b/code/game/objects/items/weapons/ranged/flintlock.dm
@@ -240,8 +240,6 @@
 	icon_state = "aflask"
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/pistol/conjured
-	name = "puffer"
-	desc = "A magically conjured copy of a eastern styled wheellock. It looks and functions exactly like the original, but seems to be held together by weak magick, it looks like it will crumble at any moment."
 	sellprice = 0 //Yeah, Let's not sell this.
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/musk/loaded
 
@@ -251,44 +249,15 @@
 	rammed = TRUE
 	powdered = TRUE
 	wound = TRUE
-	rod = null
-	ramrod_inserted = FALSE
-	update_appearance(UPDATE_ICON_STATE)
 
-/obj/item/gun/ballistic/revolver/grenadelauncher/pistol/conjured/process_fire(atom/target, mob/living/user, message = TRUE, list/modifiers, zone_override, bonus_spread = 0)
-	if(!cocked)
-		return
-	if(!rammed)
-		return
-	if(!powdered)
-		return
-	if(wheellock && !wound)
-		return
-	if(user.client)
-		if(user.client.chargedprog >= 100)
-			spread = 0
-		else
-			spread = 150 - (150 * (user.client.chargedprog / 100))
-	else
-		spread = 0
-	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
-		var/obj/projectile/BB = CB.BB
-		if(user.client)
-			if(user.client.chargedprog >= 100)
-				BB.accuracy += 15 //better accuracy for fully aiming
-		if(GET_MOB_ATTRIBUTE_VALUE(user, STAT_PERCEPTION) > 8)
-			BB.accuracy += (GET_MOB_ATTRIBUTE_VALUE(user, STAT_PERCEPTION) - 8) * 4 //each point of perception above 8 increases standard accuracy by 4.
-			BB.bonus_accuracy += (GET_MOB_ATTRIBUTE_VALUE(user, STAT_PERCEPTION) - 8) //Also, increases bonus accuracy by 1, which cannot fall off due to distance.
-		BB.damage = BB.damage * damage_mult // 80 * 1.5 = 130 of damage.
-		BB.bonus_accuracy += (GET_MOB_SKILL_VALUE_OLD(user, /datum/attribute/skill/combat/firearms) * 3) //+3 accuracy per level in firearms
-	playsound(src, 'sound/combat/Ranged/muskclick.ogg', 100, FALSE)
+/obj/item/gun/ballistic/revolver/grenadelauncher/pistol/conjured/afterattack(atom/target, mob/living/user, proximity_flag, list/modifiers)
+	. = ..()
 	atom_integrity = 0
 	atom_break()
 
 	QDEL_IN(src, rand(2 SECONDS, 5 SECONDS)) //Apparently, a puffer being broken can still be shot, because that make sense. so we're qdel'ing it right after.
-	playsound(src, 'sound/foley/breaksound.ogg', 100, TRUE)
 	visible_message(span_warning("The puffer begins to crumble, the enchantment falls!"))
-	..()
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/pistol/musket
 	name = "musket"
 	icon = 'icons/roguetown/weapons/64/guns.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes wild drowsbane that grow inside the anvil actually have a sprite,
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not being able to see mushrooms that should be there is bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Wild drowsbane not having a sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
