### PR TITLE
Assign proper tetris grid dimensions to bedsheets

### DIFF
--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -16,7 +16,9 @@ LINEN BINS
 	throwforce = 0
 	throw_speed = 1
 	throw_range = 2
-	w_class = WEIGHT_CLASS_TINY
+	w_class = WEIGHT_CLASS_SMALL
+	grid_width = 64
+	grid_height = 64
 	resistance_flags = FLAMMABLE
 	dying_key = DYE_REGISTRY_BEDSHEET
 


### PR DESCRIPTION
The `/obj/item/bedsheet` definition in `code/game/objects/items/bedsheets.dm` had its `w_class` set to `WEIGHT_CLASS_TINY` and was missing `grid_width` / `grid_height` entirely. In the tetris-style inventory system, items without explicit grid dimensions inherit defaults from their weight class, so a TINY bedsheet ended up occupying a single cell — clearly too small for something you drape over an entire bed. This surfaced in Voyage round 4982 where players noticed the oddly compact footprint.

The change bumps `w_class` from `WEIGHT_CLASS_TINY` to `WEIGHT_CLASS_SMALL` and explicitly sets `grid_width = 64` and `grid_height = 64` on the base `/obj/item/bedsheet` type. This gives bedsheets a 2×2 tetris grid presence, which is a reasonable physical footprint — large enough to feel like fabric you'd actually fold up, but not so large that carrying one becomes punishing. Because these vars are on the base type, every bedsheet subtype (colored, patterned, etc.) inherits the corrected values automatically without any additional per-subtype edits.

The scope is intentionally narrow: one file, three lines, no behavioral side-effects beyond inventory sizing. I verified locally by spawning several bedsheet variants in-game and confirming they render as 2×2 tiles in the tetris inventory grid, stack and drag correctly, and do not clip or overflow adjacent slots.

Closes https://github.com/Monkestation/Vanderlin/issues/5815