### PR TITLE
Martyr Weapons Respect Excommunication

### DIFF
--- a/code/datums/components/martyrweapon.dm
+++ b/code/datums/components/martyrweapon.dm
@@ -147,7 +147,7 @@
 			H.dropItemToGround(parent)
 			return
 
-		if((H.real_name in GLOB.excommunicated_players))
+		if(H.real_name in GLOB.excommunicated_players)
 			// Check if person's patron is a tennite, if so, the weapon will not work!
 			if(ispath(H.patron.type, /datum/patron/divine) && !HAS_TRAIT(H, TRAIT_FANATICAL))
 				to_chat(H, span_warning("It slips from my grasp. I can't get a hold."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Tennite martyr weapons (like GMT's weapons) now respects excommunication. If they are excommunicated (and not fanatical), the weapon considers them no longer worthy

## Why It's Good For The Game

Makes sense for if the Gods turn against you, their weapons do so as well. GMTs that draw the ire of the Priest may find their weapon (and by extension their **Oath**), no longer available to them...

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Tennite holy weapons, such as the GMT's, now respects excommunication, and will not be equippable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
