### PR TITLE
Two Bugs That Hound Me

### DIFF
--- a/code/modules/antagonists/villain/wretch.dm
+++ b/code/modules/antagonists/villain/wretch.dm
@@ -17,7 +17,6 @@
 	var/mob/living/carbon/human/W = owner.current
 	W.delete_equipment()
 	W.purge_combat_knowledge()
-	W.remove_all_languages()
 	owner.forget_and_be_forgotten()
 	move_to_spawnpoint()
 	. = ..()

--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/disciple.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/disciple.dm
@@ -59,16 +59,15 @@
 
 	// I Hate
 	var/static/list/weapons = list(
-		"Discipline - Unarmed" = null,
+		"Discipline - Unarmed" = /obj/item/clothing/gloves/bandages/pugilist,
 		"Katar" = /obj/item/weapon/katar/psydon,
 		"Knuckledusters" = /obj/item/weapon/knuckles/psydon,
 		"Quarterstaff" = /obj/item/weapon/polearm/woodstaff/quarterstaff,
 	)
 	var/weapon_choice = spawned.select_equippable(player_client, weapons, message = "TAKE UP PSYDON'S ARMS!")
-	var/obj/item/clothing/gloves/gloves_to_wear = /obj/item/clothing/gloves/bandages/weighted
+	spawned.equip_to_slot_or_del(new /obj/item/clothing/gloves/bandages/weighted, ITEM_SLOT_GLOVES, TRUE) // this will fail on the unarmed discipline
 	switch(weapon_choice)
 		if("Discipline - Unarmed")
-			gloves_to_wear = /obj/item/clothing/gloves/bandages/pugilist
 			spawned.clamped_adjust_skill_level(/datum/attribute/skill/combat/unarmed, 10, 40)
 			ADD_TRAIT(spawned, TRAIT_CRITICAL_RESISTANCE, JOB_TRAIT)
 			ADD_TRAIT(spawned, TRAIT_IGNOREDAMAGESLOWDOWN, JOB_TRAIT)
@@ -78,7 +77,7 @@
 			ADD_TRAIT(spawned, TRAIT_CRITICAL_RESISTANCE, JOB_TRAIT)
 		if("Quarterstaff")
 			spawned.attributes?.add_sheet(/datum/attribute_holder/sheet/job/disciple/quarterstaff)
-	spawned.equip_to_slot_or_del(new gloves_to_wear, ITEM_SLOT_GLOVES, TRUE)
+
 
 /datum/outfit/disciple
 	name = "Disciple (Sacrestants)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl: KevinfromHP
fix: Fixes Wretches losing all languages on creation. Will have unintended side effects but they're better than this
fix: Unarmed Discipline not receiving their benefits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
