### PR TITLE
Adds prompt to join Graggar when transformed

### DIFF
--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -418,7 +418,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 					graggar_lover.spawn_gibs(TRUE)
 					graggar_lover.emote("agony")
 					graggar_lover.visible_message(span_danger("[graggar_lover]'s skin bursts!"), span_userdanger("MY SKIN BURSTS!!"))
-					graggar_baptize(graggar_lover)
+					INVOKE_ASYNC(graggar_lover, TYPE_PROC_REF(/mob/living/carbon/human, graggar_baptize))
 					H.graggometer = 0
 	return ..()
 

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -418,15 +418,18 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 					graggar_lover.spawn_gibs(TRUE)
 					graggar_lover.emote("agony")
 					graggar_lover.visible_message(span_danger("[graggar_lover]'s skin bursts!"), span_userdanger("MY SKIN BURSTS!!"))
-					if(alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", "YES", "NO") != "NO") {
-						graggar_lover.set_patron(/datum/patron/inhumen/graggar)
-						to_chat(graggar_lover, span_boldnotice("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
-					}
-					else {
-						to_chat(graggar_lover, span_boldnotice("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
-					}
+    graggar_baptize(graggar_lover)
 					H.graggometer = 0
 	return ..()
+
+/proc/graggar_baptize(mob/living/carbon/human/graggar_lover)
+	set waitfor = FALSE
+	if(tgui_alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS) == CHOICE_YES)
+		graggar_lover.set_patron(/datum/patron/inhumen/graggar)
+		to_chat(graggar_lover, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
+		return
+	if(!QDELETED(graggar_lover))
+		to_chat(graggar_lover, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -422,14 +422,17 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 					H.graggometer = 0
 	return ..()
 
-/proc/graggar_baptize(mob/living/carbon/human/graggar_lover)
-    set waitfor = FALSE
-    if(tgui_alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS) == CHOICE_YES)
-        graggar_lover.set_patron(/datum/patron/inhumen/graggar)
-        to_chat(graggar_lover, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
-        return
-    if(!QDELETED(graggar_lover))
-        to_chat(graggar_lover, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
+/mob/living/carbon/human/proc/graggar_baptize()
+	var/answer = tgui_alert(src, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS)
+	if(!answer || QDELETED(src))
+		return
+		
+	if(answer != CHOICE_YES)
+		to_chat(src, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
+	 	return
+	 	
+	set_patron(/datum/patron/inhumen/graggar)
+	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar! 
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -426,13 +426,13 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	var/answer = tgui_alert(src, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS)
 	if(!answer || QDELETED(src))
 		return
-		
+
 	if(answer != CHOICE_YES)
 		to_chat(src, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
 	 	return
-	 	
+
 	set_patron(/datum/patron/inhumen/graggar)
-	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar! 
+	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!)
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -432,7 +432,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	 	return
 
 	set_patron(/datum/patron/inhumen/graggar)
-	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!)
+	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!))
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -426,8 +426,11 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	var/answer = tgui_alert(src, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS)
 	if(!answer || QDELETED(src))
 		return
+
 	if(answer != CHOICE_YES)
 		to_chat(src, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
+		return
+
 	set_patron(/datum/patron/inhumen/graggar)
 	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!"))
 

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -426,11 +426,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	var/answer = tgui_alert(src, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS)
 	if(!answer || QDELETED(src))
 		return
-
 	if(answer != CHOICE_YES)
 		to_chat(src, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
-	 	return
-
 	set_patron(/datum/patron/inhumen/graggar)
 	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!"))
 

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -418,15 +418,18 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 					graggar_lover.spawn_gibs(TRUE)
 					graggar_lover.emote("agony")
 					graggar_lover.visible_message(span_danger("[graggar_lover]'s skin bursts!"), span_userdanger("MY SKIN BURSTS!!"))
-					if(alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", "YES", "NO") != "NO") {
-						graggar_lover.set_patron(/datum/patron/inhumen/graggar)
-						to_chat(graggar_lover, span_boldnotice("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
-					}
-					else {
-						to_chat(graggar_lover, span_boldnotice("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
-					}
+					graggar_baptize(graggar_lover)
 					H.graggometer = 0
 	return ..()
+
+/proc/graggar_baptize(mob/living/carbon/human/graggar_lover)
+    set waitfor = FALSE
+    if(tgui_alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", DEFAULT_INPUT_CHOICES, 10 SECONDS) == CHOICE_YES)
+        graggar_lover.set_patron(/datum/patron/inhumen/graggar)
+        to_chat(graggar_lover, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
+        return
+    if(!QDELETED(graggar_lover))
+        to_chat(graggar_lover, span_bloody("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -432,7 +432,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	 	return
 
 	set_patron(/datum/patron/inhumen/graggar)
-	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!))
+	to_chat(src, SPAN_GOD_GRAGGAR("The Beast's teeth close around your heart! Devour! Conquer! Graggar!"))
 
 /datum/reagent/organpoison/human
 	name = "Humen Organ Poison"

--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -418,6 +418,13 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 					graggar_lover.spawn_gibs(TRUE)
 					graggar_lover.emote("agony")
 					graggar_lover.visible_message(span_danger("[graggar_lover]'s skin bursts!"), span_userdanger("MY SKIN BURSTS!!"))
+					if(alert(graggar_lover, "Kneel before Graggar?", "BAPTIZE", "YES", "NO") != "NO") {
+						graggar_lover.set_patron(/datum/patron/inhumen/graggar)
+						to_chat(graggar_lover, span_boldnotice("The Beast's teeth close around your heart! Devour! Conquer! Graggar! Graggar! Graggar!"))
+					}
+					else {
+						to_chat(graggar_lover, span_boldnotice("You reject Graggar's offer of power. The Beast recedes, your stomach growls..."))
+					}
 					H.graggometer = 0
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Grants the option to convert to Graggar once you've eaten enough organs to transform into a half-orc

## Why It's Good For The Game

If you were intentionally cannibalising with cooked manflesh  (e.g. as a great hunt follower or otherwise) then you really want the option to be able to start eating it raw once you turn into a horc with extra hunger rate. 

If you were converted by graggarites, you'd be stuck with a group of allies who only carry raw food that you're unable to eat without preparing it first despite having undergone a monstrous transformation.

But if the change was unwilling/you cannibalised out of desperation/etc. then you can still refuse to convert & cling to your old patron.

Attached pictures show the offer and the results of choosing yes & no in that order

## Changelog

:cl:
add: You may now optionally convert to Graggar if you are transformed into a half-orc.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.


<img width="1913" height="1036" alt="graggarmaxx1" src="https://github.com/user-attachments/assets/b3c06f6a-8867-47c9-8ff1-dcf20c2b0ae6" />
<img width="506" height="94" alt="Graggarmaxx2" src="https://github.com/user-attachments/assets/6b6a29b2-0242-4a33-bcba-a9905472dfa0" />
<img width="511" height="248" alt="graggarmaxx3" src="https://github.com/user-attachments/assets/26b39e6d-6aae-4cb0-94c5-91b539bdbec6" />
