### PR TITLE
Minor SScommunication Refactor

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -1,17 +1,11 @@
-#define COMMUNICATION_COOLDOWN 300
-#define COMMUNICATION_COOLDOWN_AI 300
-
 SUBSYSTEM_DEF(communications)
 	name = "Communications"
 	flags = SS_NO_INIT | SS_NO_FIRE
 
-	var/silicon_message_cooldown
-	var/nonsilicon_message_cooldown
+	var/message_cooldown
 
-/datum/controller/subsystem/communications/proc/can_announce(mob/living/user, is_silicon)
-	if(is_silicon && silicon_message_cooldown > world.time)
-		. = FALSE
-	else if(!is_silicon && nonsilicon_message_cooldown > world.time)
+/datum/controller/subsystem/communications/proc/can_announce(mob/living/user)
+	if(message_cooldown > world.time)
 		. = FALSE
 	else
 		. = TRUE
@@ -23,14 +17,11 @@ SUBSYSTEM_DEF(communications)
 		used_title = job ? "The [job.get_informed_title(user)]" : "Someone"
 
 	if(decree)
-		priority_announce(html_decode(user.treat_message(input)), "[user.real_name], The [used_title] Decrees", 'sound/misc/alert.ogg', "Captain")
-		silicon_message_cooldown = world.time + 5 SECONDS
+		priority_announce(html_decode(user.treat_message(input)), "[user.real_name], [used_title] Decrees", 'sound/misc/alert.ogg', "Captain")
+		message_cooldown = world.time + 5 SECONDS
 	else
-		priority_announce(html_decode(user.treat_message(input)), "[used_title] Speaks", 'sound/misc/bell.ogg', "Captain")
-		nonsilicon_message_cooldown = world.time + 5 SECONDS
+		priority_announce(html_decode(user.treat_message(input)), "[user.real_name], [used_title] Speaks", 'sound/misc/alert.ogg', "Captain")
+		message_cooldown = world.time + 5 SECONDS
 
 	user.log_talk(input, LOG_SAY, tag="priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")
-
-#undef COMMUNICATION_COOLDOWN
-#undef COMMUNICATION_COOLDOWN_AI

--- a/code/game/objects/structures/fake_machines/titan.dm
+++ b/code/game/objects/structures/fake_machines/titan.dm
@@ -275,8 +275,8 @@ GLOBAL_LIST_EMPTY(roundstart_court_agents)
 		reset_mode()
 		return FALSE
 
-	message = SANITIZE_HEAR_MESSAGE(html_decode(message)) // Announcement has protections
-	priority_announce(user.treat_message(message), "[user.real_name], The [user.get_role_title()] Speaks", 'sound/misc/alert.ogg', "Captain")
+	message = SANITIZE_HEAR_MESSAGE(message)
+	SScommunications.make_announcement(user, FALSE, message)
 	reset_mode()
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Refactor of SScommunication to remove unused elements + fix 'the the' when making an announcement

It seems currently we bypass SScommunication for most things, for now have it so making an announcement command in THROAT uses it, but it may be best to remove this subsystem entirely, as earlier it was ONLY used for making decrees (THROAT had its cooldown based on this, making it useless)

## Why It's Good For The Game

'The the King Decrees" is bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
spellcheck: Announcement for new decrees no longer uses 'the' twice
refactor: Refactor of SScommunication
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
