### PR TITLE
Fixes Surrender Canceling and False Yielding

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1293,10 +1293,10 @@
 	changeNext_move(CLICK_CD_EXHAUSTED)
 	var/mutable_appearance/flaggy = mutable_appearance('icons/effects/effects.dmi', "surrender", ABOVE_MOB_LAYER, appearance_flags = RESET_TRANSFORM|KEEP_APART)
 	flaggy.pixel_y = 12
-	flick_overlay_view(flaggy, 150)
+	flick_overlay_view(flaggy, 15 SECONDS)
 	drop_all_held_items()
 	Stun(15 SECONDS)
-	visible_message(span_bignotice("[src] yields!"), span_boldwarning("I yield!"))
+	visible_message(span_bignotice("<span class='bold'>[src]</span> yields!"), span_boldwarning("I yield!"))
 	playsound(src, 'sound/misc/surrender.ogg', 100, FALSE, -1)
 	toggle_cmode()
 	addtimer(VARSET_CALLBACK(src, surrendering, FALSE), 15 SECONDS)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1281,6 +1281,7 @@
 
 	if(surrendering)
 		return FALSE
+	
 	if(stat)
 		return FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1280,12 +1280,14 @@
 	set category = "IC.Interaction"
 
 	if(surrendering)
-		return
+		return FALSE
 	if(stat)
-		return
-	surrendering = 1
-	if(!tgui_alert(src, "Yield in surrender?","Yield", list("YES","NO")) == "YES")
-		return
+		return FALSE
+
+	if(tgui_alert(src, "Yield in surrender?","Beg for Mercy", list("YES","NO"), 15 SECONDS) != "YES" || surrendering) // Additional surrender check in case they try to hold multiple TGUI
+		return FALSE
+
+	surrendering = TRUE
 
 	record_round_statistic(STATS_YIELDS)
 	changeNext_move(CLICK_CD_EXHAUSTED)
@@ -1294,10 +1296,11 @@
 	flick_overlay_view(flaggy, 150)
 	drop_all_held_items()
 	Stun(15 SECONDS)
-	visible_message("<span class='notice'>[src] yields!</span>")
+	visible_message(span_bignotice("[src] yields!"), span_boldwarning("I yield!"))
 	playsound(src, 'sound/misc/surrender.ogg', 100, FALSE, -1)
 	toggle_cmode()
 	addtimer(VARSET_CALLBACK(src, surrendering, FALSE), 15 SECONDS)
+	return TRUE
 
 /mob/proc/stop_attack(message = FALSE)
 	if(atkswinging)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1284,8 +1284,11 @@
 	if(stat)
 		return FALSE
 
-	if(tgui_alert(src, "Yield in surrender?","Beg for Mercy", list("YES","NO"), 15 SECONDS) != "YES" || surrendering) // Additional surrender check in case they try to hold multiple TGUI
+	if(tgui_alert(src, "Yield in surrender?","Beg for Mercy", list("YES","NO"), 15 SECONDS) != "YES") // Additional surrender check in case they try to hold multiple TGUI
 		return FALSE
+		
+	if(surrendering)
+		return
 
 	surrendering = TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1280,15 +1280,15 @@
 	set category = "IC.Interaction"
 
 	if(surrendering)
-		return FALSE
-	
-	if(stat)
-		return FALSE
+		return
 
-	if(tgui_alert(src, "Yield in surrender?","Beg for Mercy", list("YES","NO"), 15 SECONDS) != "YES") // Additional surrender check in case they try to hold multiple TGUI
-		return FALSE
-		
-	if(surrendering)
+	if(stat)
+		return
+
+	if(tgui_alert(src, "Yield in surrender?","Beg for Mercy", list("YES","NO"), 15 SECONDS) != "YES")
+		return
+
+	if(surrendering)  // Additional surrender check in case they try to hold multiple TGUI
 		return
 
 	surrendering = TRUE
@@ -1304,7 +1304,6 @@
 	playsound(src, 'sound/misc/surrender.ogg', 100, FALSE, -1)
 	toggle_cmode()
 	addtimer(VARSET_CALLBACK(src, surrendering, FALSE), 15 SECONDS)
-	return TRUE
 
 /mob/proc/stop_attack(message = FALSE)
 	if(atkswinging)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Remake of https://github.com/Monkestation/Vanderlin/pull/5698

Fixes https://github.com/Monkestation/Vanderlin/issues/5689
Fixes https://github.com/Monkestation/Vanderlin/issues/6119

## Why It's Good For The Game

Pressing the surrender button now correctly surrenders only if they click yes, handling multi tgui wierdness also good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Yielding message more obvious
fix: Surrender prompt now cares about if you accept to surrender
fix: You can no longer stack tgui prompts to bypass surrender cooldowns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
