### PR TITLE
Euphorbia field change

### DIFF
--- a/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
+++ b/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
@@ -353,7 +353,7 @@
 	var/mob/living/L = owner
 	if (!L) return
 	check_field_presence()
-	L.adjustBruteLoss(5)
+	L.adjustBruteLoss(2)
 
 	if (locate(/obj/structure/flora/field/euphorbia) in get_turf(L))
 		to_chat(L, span_warning("The spines hurt your feet"))

--- a/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
+++ b/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
@@ -171,7 +171,7 @@
 				L.emote("agony")
 			L.Stun(2 SECONDS)
 	if (!HAS_TRAIT(L, TRAIT_PIERCEIMMUNE))
-		L.adjustBruteLoss(40)
+		L.adjustBruteLoss(35)
 		if (prob(25) && ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/obj/item/bodypart/BP = pick(H.bodyparts)

--- a/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
+++ b/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
@@ -171,7 +171,13 @@
 				L.emote("agony")
 			L.Stun(2 SECONDS)
 	if (!HAS_TRAIT(L, TRAIT_PIERCEIMMUNE))
-		L.adjustBruteLoss(10)
+		L.adjustBruteLoss(40)
+		if (prob(25) && ishuman(L))
+			var/mob/living/carbon/human/H = L
+			var/obj/item/bodypart/BP = pick(H.bodyparts)
+			var/obj/item/natural/thorn/TH = new(get_turf(H))
+			BP.add_embedded_object(TH, silent = TRUE)
+			to_chat(H, span_danger("A thorn embeds into your [BP.name]!"))
 		to_chat(L, span_danger("Thorns rip into you as you push through!"))
 	apply_flower_effect(L, /datum/status_effect/debuff/euphorbia_thorns)
 
@@ -347,17 +353,10 @@
 	var/mob/living/L = owner
 	if (!L) return
 	check_field_presence()
-	L.adjustBruteLoss(10)
+	L.adjustBruteLoss(5)
 
 	if (locate(/obj/structure/flora/field/euphorbia) in get_turf(L))
 		to_chat(L, span_warning("The spines hurt your feet"))
-
-	if (prob(20) && ishuman(L))
-		var/mob/living/carbon/human/H = L
-		var/obj/item/bodypart/BP = pick(H.bodyparts)
-		var/obj/item/natural/thorn/TH = new(get_turf(H))
-		BP.add_embedded_object(TH, silent = TRUE)
-		to_chat(H, span_danger("A thorn embeds into your [BP.name]!"))
 
 /atom/movable/screen/alert/status_effect/debuff/euphorbia_thorns
 	name = "Spiny Terrain"

--- a/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
+++ b/code/modules/spells/spell_types/pointed/aoe/on_turf/flower_field.dm
@@ -171,7 +171,7 @@
 				L.emote("agony")
 			L.Stun(2 SECONDS)
 	if (!HAS_TRAIT(L, TRAIT_PIERCEIMMUNE))
-		L.adjustBruteLoss(35)
+		L.adjustBruteLoss(30)
 		if (prob(25) && ishuman(L))
 			var/mob/living/carbon/human/H = L
 			var/obj/item/bodypart/BP = pick(H.bodyparts)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives more weight to euphorbia field's active damage (walking through it) than passive damage (standing in it)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The previous euphoboria field would spam you both with damage and thorns for just standing in it. Passive damage got halved, thorns are now embedded for passing through it with bigger damage from movement than before

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Euphorbia field rebalance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
