### PR TITLE
Shovel, Godendag, Psydon Mace Sharpness Fixes

### DIFF
--- a/code/game/objects/items/tools/gravetools.dm
+++ b/code/game/objects/items/tools/gravetools.dm
@@ -18,7 +18,7 @@
 	experimental_onhip = FALSE
 	experimental_onback = FALSE
 	max_integrity = INTEGRITY_STRONG
-	sharpness = IS_BLUNT
+	sharpness = IS_SHARP
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
@@ -236,6 +236,7 @@
 	wdefense = BAD_PARRY
 	wlength = WLENGTH_SHORT
 	possible_item_intents = list(SHOVEL_SCOOP, SHOVEL_IRRIGATE, SHOVEL_STRIKE)
+	sharpness = IS_BLUNT
 	max_blade_int = 0
 
 	dropshrink = 1

--- a/code/game/objects/items/weapons/melee/blunt.dm
+++ b/code/game/objects/items/weapons/melee/blunt.dm
@@ -438,6 +438,8 @@
 	wlength = WLENGTH_LONG
 	possible_item_intents = list(MACE_HVYSTRIKE)
 	gripped_intents = list(MACE_HVYSMASH, MACE_THRUST)
+	sharpness = IS_SHARP
+	max_blade_int = 300
 	max_integrity = INTEGRITY_STRONG
 	minstr = 10
 
@@ -486,6 +488,7 @@
 	icon_state = "polemace"
 	gripped_intents = list(MACE_HVYSMASH) // It's a 2h flanged mace, not a goedendag.
 	wbalance = DODGE_CHANCE_NORMAL
+	sharpness = IS_BLUNT
 	max_integrity = INTEGRITY_STRONGEST
 
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
## About The Pull Request
Fixes the blade integrity/sharpness class of the shovel, godendag, and psydonian greatmace so their chop/slash intents work again.

## Why It's Good For The Game
You can now chop and trees again with the shovel, and you can stab for actual damage with the godendag and psydonian greatmace.

## Changelog

:cl:
fix: Shovel, Godendag, and Psydonian Greatmace intents that required sharpness work now.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
