### PR TITLE
Gives tritons a bioluminescence ability

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -176,9 +176,10 @@
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
 	C.remove_language(/datum/language/deepspeak)
-	for(var/datum/action/innate/bioluminescence/action in C.actions)
-		action.Remove(C)
-		break
+	var/datum/action/innate/bioluminescence/action = locate() in C.actions
+	if(action)
+		qdel(action)
+		
 /datum/species/triton/check_roundstart_eligible()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -227,12 +227,13 @@
 	. = ..()
 	if(!owner)
 		return FALSE
-	if(our_light && !QDELETED(our_light)) {
+		
+	if(!QDELETED(our_light))
 		our_light.set_light_on(TRUE)
 		our_light.update_light()
-	} else {
+	else
 		our_light = new /obj/effect/dummy/lighting_obj/moblight(owner, "#66ddff", 7, 1)
-	}
+		
 	owner.visible_message(span_notice("[owner]'s body begins to glow with a deep blue bioluminescent light!"))
 	active = TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -224,6 +224,9 @@
 
 	var/obj/effect/dummy/lighting_obj/moblight/our_light
 
+/datum/action/innate/bioluminescence/Destroy(force)
+	QDEL_NULL(our_light)
+	return ..()
 /datum/action/innate/bioluminescence/Activate()
 	. = ..()
 	if(!owner)

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -241,4 +241,3 @@
 	owner.visible_message(span_notice("[owner]'s bioluminescent glow fades away."))
 	active = FALSE
 
-

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -164,6 +164,8 @@
 
 	var/obj/item/bodypart/mouth/jaw = C.get_bodypart(BODY_ZONE_PRECISE_MOUTH)
 	jaw.replace_teeth(/obj/item/natural/bundle/teeth/fang)
+	var/datum/action/innate/bioluminescence/action = new(C)
+	action.Grant(C)
 
 /datum/species/triton/after_creation(mob/living/carbon/C)
 	. = ..()
@@ -211,4 +213,32 @@
 		"Photic" = HAIR_COLOR_PHOTIC,
 		"Turtle Egg" = HAIR_COLOR_TURTLE,
 	)
+
+/datum/action/innate/bioluminescence
+	name = "Bioluminescence"
+	desc = "Toggle a bright bioluminescent light from your body, moving with you."
+	button_icon_state = "shieldsparkles"
+
+	var/obj/effect/dummy/lighting_obj/moblight/our_light
+
+/datum/action/innate/bioluminescence/Activate()
+	. = ..()
+	if(!owner)
+		return FALSE
+	if(our_light)
+		return FALSE
+	our_light = new /obj/effect/dummy/lighting_obj/moblight(owner, "#66ddff", 7, 1)
+	owner.visible_message(span_notice("[owner]'s body begins to glow with a deep blue bioluminescent light!"))
+	active = TRUE
+
+/datum/action/innate/bioluminescence/Deactivate()
+	. = ..()
+	if(!owner)
+		return FALSE
+	if(our_light)
+		qdel(our_light)
+		our_light = null
+	owner.visible_message(span_notice("[owner]'s bioluminescent glow fades away."))
+	active = FALSE
+
 

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -247,7 +247,3 @@
 	owner.visible_message(span_notice("[owner]'s bioluminescent glow fades away."))
 	active = FALSE
 
-/datum/action/innate/bioluminescence/Remove(mob/removed_from)
-	qdel(our_light)
-	active = FALSE
-	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -176,7 +176,9 @@
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
 	C.remove_language(/datum/language/deepspeak)
-
+	for(var/datum/action/innate/bioluminescence/action in C.actions)
+		action.Remove(C)
+		break
 /datum/species/triton/check_roundstart_eligible()
 	return TRUE
 
@@ -205,15 +207,6 @@
 		"Sea Foam" = HAIR_COLOR_SEA_FOAM,
 	)
 
-/datum/species/triton/get_oldhc_list()
-	return list(
-		"Fog" = HAIR_COLOR_SEA_FOG,
-		"Gravel" = HAIR_COLOR_GRAVEL,
-		"Mist" = HAIR_COLOR_MIST,
-		"Photic" = HAIR_COLOR_PHOTIC,
-		"Turtle Egg" = HAIR_COLOR_TURTLE,
-	)
-
 /datum/action/innate/bioluminescence
 	name = "Bioluminescence"
 	desc = "Toggle a bright bioluminescent light from your body, moving with you."
@@ -225,9 +218,12 @@
 	. = ..()
 	if(!owner)
 		return FALSE
-	if(our_light)
-		return FALSE
-	our_light = new /obj/effect/dummy/lighting_obj/moblight(owner, "#66ddff", 7, 1)
+	if(our_light && !QDELETED(our_light)) {
+		our_light.set_light_on(TRUE)
+		our_light.update_light()
+	} else {
+		our_light = new /obj/effect/dummy/lighting_obj/moblight(owner, "#66ddff", 7, 1)
+	}
 	owner.visible_message(span_notice("[owner]'s body begins to glow with a deep blue bioluminescent light!"))
 	active = TRUE
 
@@ -236,9 +232,12 @@
 	if(!owner)
 		return FALSE
 	if(our_light)
-		qdel(our_light)
-		our_light = null
+		our_light.set_light_on(FALSE)
+		our_light.update_light()
 	owner.visible_message(span_notice("[owner]'s bioluminescent glow fades away."))
 	active = FALSE
 
-
+/datum/action/innate/bioluminescence/Remove(mob/removed_from)
+	qdel(our_light)
+	active = FALSE
+	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -227,6 +227,7 @@
 /datum/action/innate/bioluminescence/Destroy(force)
 	QDEL_NULL(our_light)
 	return ..()
+
 /datum/action/innate/bioluminescence/Activate()
 	. = ..()
 	if(!owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Tritons get a toggleable weak light-blue bioluminescent light.
<img width="582" height="534" alt="Screenshot 2026-04-28 142409" src="https://github.com/user-attachments/assets/fcb363c4-9bab-46db-9f5d-d5ccbdecb68d" />
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tritons are fish and their whole thing is being good swimmers. There are few locations where the water is under the sun, and even then its only bright during the day. They dont have night vision, so they need to either get a bronze lamp or just stumble around in the water blindly.  Also a bit more unique differences between species.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added an ability that makes triton glow with a blue color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
