### PR TITLE
Evil Tree Vine Death

### DIFF
--- a/code/modules/events/vines.dm
+++ b/code/modules/events/vines.dm
@@ -322,6 +322,7 @@
 	destroy_sound = 'sound/foley/breaksound.ogg'
 	update_appearance(UPDATE_ICON_STATE)
 	unbuckle_all_mobs(TRUE)
+	qdel(src)
 
 /obj/structure/vine/proc/grow()
 	if(energy < 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Evil trees that spawn crawling thorny vines delete all surrounding vines when chopped down.

I tested it on local and it looks like it works, and it didn't runtime.

## Why It's Good For The Game

The thorny vines being unavoidable in some areas and doing the damage they do is incredibly annoying, and can fuck up the map for that whole round.

<img width="1616" height="1944" alt="image" src="https://github.com/user-attachments/assets/5f3f5990-c649-4a65-9aab-d5b935b99c33" />

## Changelog

:cl:
fix: Evil tree vines delete when the evil tree is killed.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
