### PR TITLE
Key Resize to 1x1

### DIFF
--- a/code/datums/components/storage/storage_grid_types.dm
+++ b/code/datums/components/storage/storage_grid_types.dm
@@ -45,7 +45,7 @@
 	screen_max_columns = 1
 
 /datum/component/storage/concrete/grid/keyring
-	screen_max_rows = 4
+	screen_max_rows = 2
 	screen_max_columns = 5
 	max_w_class = WEIGHT_CLASS_SMALL
 	allow_dump_out = TRUE

--- a/code/game/objects/items/keys.dm
+++ b/code/game/objects/items/keys.dm
@@ -9,7 +9,7 @@
 	throwforce = 0
 	drop_sound = 'sound/items/gems (1).ogg'
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH|ITEM_SLOT_NECK|ITEM_SLOT_RING
-	grid_height = 64
+	grid_height = 32
 	grid_width = 32
 	slot_equipment_priority = list(
 		ITEM_SLOT_NECK,


### PR DESCRIPTION
## About The Pull Request
This PR changes the grid size of keys from a 1x2 to 1x1.

## Why It's Good For The Game
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8e0c11d4-0d05-4bd8-89f6-07fc3fd758a2" />
Keys are currently twice the size of a key rings which can hold like 8 keys which is strange. The sprites still work in 1x1 grids.

## Changelog

:cl:
balance: Resize keys to 1x1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
