### PR TITLE
Rope/Chain Resize to 1x2

### DIFF
--- a/code/game/objects/items/ropechainbola.dm
+++ b/code/game/objects/items/ropechainbola.dm
@@ -15,6 +15,8 @@
 	possible_item_intents = list(/datum/intent/tie)
 	firefuel = 5 MINUTES
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
+	grid_height = 64
+	grid_width = 32
 	item_weight = 300 GRAMS
 	var/legcuff_multiplicative_slowdown = 3
 


### PR DESCRIPTION
## About The Pull Request
This PR changes the grid size of ropes and chains from 2x2 to 1x2

## Why It's Good For The Game
I am of the opinion that being able to restrain someone leads to more RP compared to the alternative, which is often killing the person. Decreasing the grid size of rope/chains allows players to sacrifice less of their backpack/satchel, but they are still limited by the weight of these items in the encumbrance system.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/19f3ebd8-9326-4c22-9b39-678920bbec23" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Rope/Chain grid size 2x2->1x2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
