### PR TITLE
Fixes rare classes not appearing in triumph buy menu

### DIFF
--- a/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
+++ b/code/controllers/subsystem/triumph/buy_datums/character/pick_any_class.dm
@@ -35,7 +35,7 @@
 			continue
 		if(length(invalid_ctags & CHECKS.category_tags) && !length(parent_job?.advclass_cat_rolls & CHECKS.category_tags))
 			continue
-		if(!CHECKS.check_requirements(spawned))
+		if(!CHECKS.check_requirements(spawned, TRUE))
 			continue
 		possible_classes += CHECKS
 

--- a/code/modules/jobs/job_types/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/adventurer/types/_advclass.dm
@@ -31,8 +31,8 @@
 
 	apply_character_post_equipment(spawned)
 
-/datum/job/advclass/proc/check_requirements(mob/living/carbon/human/to_check)
-	if(!prob(roll_chance))
+/datum/job/advclass/proc/check_requirements(mob/living/carbon/human/to_check, var/triumph_restriction_lift = FALSE)
+	if(!prob(roll_chance) && !triumph_restriction_lift)
 		return FALSE
 
 	var/datum/preferences/player_prefs = to_check.client.prefs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Rare classes wouldn't appear due to the rng check.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If you paid triumphs for this you shouldn't pray for good rng. Other checks still stay

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Rare subclasses now appear in triumph buy classes menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
