### PR TITLE
Fixes Fish Tamto Plate Typo

### DIFF
--- a/code/modules/cooking/raw/NeuFood_dough.dm
+++ b/code/modules/cooking/raw/NeuFood_dough.dm
@@ -2708,7 +2708,7 @@
 	item_weight = 450 GRAMS
 
 /obj/item/reagent_containers/food/snacks/tamtoplate/fish
-	name = "sausage tamto plate"
+	name = "fish tamto plate"
 	desc = "A deliciously greasy fish half-pie originating from the trade-capital of Vanderlin, long may it reign!"
 	slice_path = /obj/item/reagent_containers/food/snacks/tamtoplate_slice/fish
 	icon_state = "fish_pizza"


### PR DESCRIPTION
## About The Pull Request
The tamto plate made with fish mince was, for some reason, named a sausage tamto plate, despite not being made with sausage. This PR changes the name to reflect the use of fish mince as an ingredient.

## Why It's Good For The Game
This PR should hopefully allow for easier differentiation between tamto plates containing fish and other, non-fish-containing tamto plates.

## Changelog
:cl:
spellcheck: Fish tamto plates are now properly named
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
