### PR TITLE
clamping maniac skills

### DIFF
--- a/code/modules/antagonists/villain/maniac/_maniac.dm
+++ b/code/modules/antagonists/villain/maniac/_maniac.dm
@@ -7,15 +7,15 @@
 	raw_attribute_list = list(
 		STAT_STRENGTH = 6,
 		STAT_CONSTITUTION = 6,
-		STAT_ENDURANCE = 6,
-
-		/datum/attribute/skill/combat/knives = 60,
-		/datum/attribute/skill/combat/wrestling = 50,
-		/datum/attribute/skill/combat/unarmed = 50,
-		/datum/attribute/skill/misc/climbing = 50,
-		/datum/attribute/skill/misc/athletics = 40,
-		/datum/attribute/skill/misc/medicine = 40
-
+		STAT_ENDURANCE = 6
+	)
+	clamped_adjustment = list(
+		/datum/attribute/skill/combat/knives = list(60, 60),
+		/datum/attribute/skill/combat/wrestling = list(50, 50),
+		/datum/attribute/skill/combat/unarmed = list(50, 50),
+		/datum/attribute/skill/misc/climbing = list(50, 50),
+		/datum/attribute/skill/misc/athletics = list(40, 40),
+		/datum/attribute/skill/misc/medicine = list(40, 40)
 	)
 
 /datum/antagonist/maniac


### PR DESCRIPTION
## About The Pull Request

This PR just moves maniac skills from raw_attributes to clamped_adjustmen, like they probably should be done in the first place.

## Why It's Good For The Game

It will prevent maniac from going to some ABSURD skill levels that makes even the skilled folks in town be unable to parry or hit them.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: maniac skills now being given via "clamped_adjustment" to avoid them getting 100+ skill level, that should not be possible
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
