### PR TITLE
Remove enscribed runes from ambush mob gear.

### DIFF
--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -145,7 +145,6 @@ GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 2 MINUTES) // Cooldown for each ind
 			H.del_on_deaggro = 44 SECONDS
 			H.last_aggro_loss = world.time
 			H.add_faction("ambush")
-			addtimer(CALLBACK(H, PROC_REF(setup_equip_block)), 3 SECONDS)
 			mustype = 2
 	if(!spawns)
 		return
@@ -154,6 +153,10 @@ GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 2 MINUTES) // Cooldown for each ind
 	else
 		playsound_local(src, pick('sound/misc/jumphumans (1).ogg','sound/misc/jumphumans (2).ogg','sound/misc/jumphumans (3).ogg'), 100)
 	shake_camera(src, 2, 2)
+
+/mob/living/proc/setup_equip_block()
+	for(var/obj/item/clothing/clothing in contents)
+		clothing.AddElement(/datum/element/faction_restricted_equip)
 
 // Return whether a mob is blocked from being ambushed
 /mob/living/proc/get_will_block_ambush()

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -155,10 +155,6 @@ GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 2 MINUTES) // Cooldown for each ind
 		playsound_local(src, pick('sound/misc/jumphumans (1).ogg','sound/misc/jumphumans (2).ogg','sound/misc/jumphumans (3).ogg'), 100)
 	shake_camera(src, 2, 2)
 
-/mob/living/proc/setup_equip_block()
-	for(var/obj/item/clothing/clothing in contents)
-		clothing.AddElement(/datum/element/faction_restricted_equip)
-
 // Return whether a mob is blocked from being ambushed
 /mob/living/proc/get_will_block_ambush()
 	if(!ambushable())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ambush mob armor no longer is blocked from being worn, allowing people to properly loot and wear the equipment they get from corpses.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The vast majority of ambush mob gear is fairly bad to begin with, much worse than you'd get from the Blacksmith, the Tailor, or even what you would start with as a combat role, and there are plenty of spawns of much better armor in the wilderness for Adventurers and Mercenaries anyway. This mostly allows for emergency armor or outfitting Towners and other folks with scavenged leather (they can already take the weapons), and it makes more sense than having this gear be inexplicably unwearable. Most of it is going to be in bad condition after the people wearing it are dealt with anyway so it'll open a market for refurbishing it, and it can still be salvaged by the Blacksmith and Tailor as it is currently.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Ambush spawns no longer have rune-locked armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
