### PR TITLE
Small inquisition tweaks. 

### DIFF
--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/confessor.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/confessor.dm
@@ -130,7 +130,7 @@
 	mask = /obj/item/clothing/face/facemask/steel/confessor
 	ring = /obj/item/clothing/ring/signet/silver
 	backpack_contents = list(
-		/obj/item/key/inquisition = 1,
+		/obj/item/storage/keyring/inquisitor = 1,
 		/obj/item/rope/inqarticles/inquirycord = 1,
 		/obj/item/lockpickring/mundane = 1,
 		/obj/item/clothing/head/inqarticles/blackbag = 1,

--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/disciple.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/disciple.dm
@@ -94,7 +94,7 @@
 	mask = /obj/item/clothing/head/helmet/blacksteel/psythorns
 	head = /obj/item/clothing/head/roguehood/psydon
 	backpack_contents = list(
-		/obj/item/key/inquisition = 1,
+		/obj/item/storage/keyring/inquisitor = 1,
 		/obj/item/paper/inqslip/arrival/ortho = 1,
 		/obj/item/collar_detonator = 1,
 	)

--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/psyaltrist.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/psyaltrist.dm
@@ -3,7 +3,6 @@
 		STAT_ENDURANCE = 1,
 		STAT_SPEED = 3,
 		/datum/attribute/skill/misc/music = 50,
-		/datum/attribute/skill/magic/holy = 40,
 		/datum/attribute/skill/combat/knives = 30,
 		/datum/attribute/skill/combat/wrestling = 20,
 		/datum/attribute/skill/combat/unarmed = 20,
@@ -40,7 +39,6 @@
 
 	spells = list(/datum/action/cooldown/spell/projectile/vicious_mockery)
 
-	cmode_music = 'sound/music/cmode/adventurer/CombatOutlander3.ogg'
 
 /datum/job/advclass/sacrestant/psyaltrist/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
@@ -79,7 +77,7 @@
 	beltl = /obj/item/storage/belt/pouch/coins/mid
 	ring = /obj/item/clothing/ring/signet/silver
 	backpack_contents = list(
-		/obj/item/key/inquisition = 1,
+		/obj/item/storage/keyring/inquisitor = 1,
 		/obj/item/paper/inqslip/arrival/ortho = 1,
 		/obj/item/collar_detonator = 1,
 	)


### PR DESCRIPTION
## About The Pull Request

This PR gives the Psyaltrist it's propper combat theme, Trinity, same as the other sacrestants. It also gives confessors, disciples and psyaltrists an inquisitorial keychain, same as the templar. The keychain only contains the inquisition key, but it means they can add extra keys to their inventory without having to deal with RE4 inventory optimization. 

Finally, this removes the expert-level Miracles skill the psyaltrist had, since the class can't use it + it's thematically weird for a psydonian to have that. 

## Why It's Good For The Game

Small QoL for everyone, removes a bit of skill bloat, Mortem Obire does not fit the Psyaltrist. 
## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:

qol: all sacrestant classes now have a keyring.
balance: Psyaltrists no longer have expert Miracle skill, since they can't use the damned thing. 
sound: The Psyaltrist now uses the sacrestant Cmode theme. 

/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

