### PR TITLE
Jester Stat Randomness Nerf/True Jester Be Special

### DIFF
--- a/code/_globalvars/special_traits/traits.dm
+++ b/code/_globalvars/special_traits/traits.dm
@@ -666,7 +666,7 @@
 /datum/special_trait/truejester
 	name = "True Jester"
 	greet_text = span_notice("My life has been the real joke, Xylix has influenced my body and mind!")
-	req_text = "Be THE Jester!
+	req_text = "Be THE Jester!"
 	allowed_jobs = list(/datum/job/jester)
 	weight = 50
 

--- a/code/_globalvars/special_traits/traits.dm
+++ b/code/_globalvars/special_traits/traits.dm
@@ -636,6 +636,45 @@
 	ADD_TRAIT(character, TRAIT_JESTERPHOBIA, "[type]") // purely for the info text
 	character.gain_trauma(/datum/brain_trauma/mild/phobia/jesters)
 
+
+/datum/attribute_holder/sheet/job/truejester //This is why Jesterphobic exists
+	attribute_variance = list(
+		STAT_SPEED = list(-8, 7),
+		STAT_CONSTITUTION = list(-6, 7),
+		STAT_ENDURANCE = list(-6, 7),
+		STAT_PERCEPTION = list(-7, 7),
+		STAT_INTELLIGENCE = list(-6, 7),
+		STAT_STRENGTH = list(-6, 7),
+		STAT_FORTUNE = list(-4, 4),
+		/datum/attribute/skill/combat/knives = list(-10, 20),
+		/datum/attribute/skill/combat/unarmed = list(-10, 20),
+		/datum/attribute/skill/misc/riding = list(0, 20),
+		/datum/attribute/skill/labor/fishing = list(0, 30),
+		/datum/attribute/skill/combat/wrestling = list(-10, 30),
+		/datum/attribute/skill/misc/reading = list(-10, 30),
+		/datum/attribute/skill/misc/sneaking = list(-20, 20),
+		/datum/attribute/skill/misc/stealing = list(-20, 20),
+		/datum/attribute/skill/misc/lockpicking = list(0, 20),
+		/datum/attribute/skill/misc/music = list(-10, 20),
+		/datum/attribute/skill/craft/cooking = list(-10, 20),
+		/datum/attribute/skill/combat/firearms = list(-10, 40),
+		/datum/attribute/skill/craft/bombs = list(-10, 40),
+		/datum/attribute/skill/misc/climbing = list(-10, 10),
+		/datum/attribute/skill/misc/athletics = list(-20, 10),
+	)
+
+/datum/special_trait/truejester
+	name = "True Jester"
+	greet_text = span_notice("My life has been the real joke, Xylix has influenced my body and mind!")
+	req_text = "Be THE Jester!
+	allowed_jobs = list(/datum/job/jester)
+	weight = 50
+
+/datum/special_trait/truejester/on_apply(mob/living/carbon/human/character)
+	character.attributes?.add_sheet(/datum/attribute_holder/sheet/job/truejester)
+	if(GET_MOB_ATTRIBUTE_VALUE_RAW(character, STAT_STRENGTH) > 16)
+		character.cmode_music = 'sound/music/cmode/nobility/CombatJesterSTR.ogg'
+
 /datum/special_trait/wild_night
 	name = "Wild Night"
 	greet_text = span_boldwarning("I don't remember what I did last night, and now I'm lost!")

--- a/code/modules/jobs/job_types/peasants/jester.dm
+++ b/code/modules/jobs/job_types/peasants/jester.dm
@@ -1,33 +1,32 @@
 /datum/attribute_holder/sheet/job/jester
 	attribute_variance = list(
-		STAT_SPEED = list(-9, 10),
-		STAT_CONSTITUTION = list(-9, 10),
-		STAT_ENDURANCE = list(-9, 10),
-		STAT_PERCEPTION = list(-9, 10),
-		STAT_INTELLIGENCE = list(-9, 10),
-		STAT_STRENGTH = list(-9, 10),
-		STAT_FORTUNE = list(-9, 10),
-		/datum/attribute/skill/combat/knives = list(-20, 50),
-		/datum/attribute/skill/combat/unarmed = list(-20, 50),
-		/datum/attribute/skill/misc/riding = list(-20, 50),
-		/datum/attribute/skill/labor/fishing = list(-20, 50),
-		/datum/attribute/skill/combat/wrestling = list(-20, 20),
-		/datum/attribute/skill/misc/reading = list(-20, 50),
-		/datum/attribute/skill/misc/sneaking = list(-20, 50),
-		/datum/attribute/skill/misc/stealing = list(-20, 50),
-		/datum/attribute/skill/misc/lockpicking = list(-20, 50),
-		/datum/attribute/skill/misc/music = list(-20, 50),
-		/datum/attribute/skill/craft/cooking = list(-20, 50),
-		/datum/attribute/skill/combat/firearms = list(-20, 50),
-		/datum/attribute/skill/craft/bombs = list(-20, 50),
-		/datum/attribute/skill/misc/climbing = list(-10, 10),
-		/datum/attribute/skill/misc/athletics = list(-20, 10),
+		STAT_SPEED = list(0, 2),
+		STAT_CONSTITUTION = list(-2, 2),
+		STAT_ENDURANCE = list(-2, 2),
+		STAT_PERCEPTION = list(-1, 2),
+		STAT_INTELLIGENCE = list(-2, 2),
+		STAT_STRENGTH = list(-2, 2),
+		STAT_FORTUNE = list(-5, 5),
+		/datum/attribute/skill/combat/knives = list(10, 30),
+		/datum/attribute/skill/combat/unarmed = list(10, 30),
+		/datum/attribute/skill/misc/riding = list(0, 30),
+		/datum/attribute/skill/labor/fishing = list(0, 20),
+		/datum/attribute/skill/combat/wrestling = list(10, 20),
+		/datum/attribute/skill/misc/reading = list(10, 20),
+		/datum/attribute/skill/misc/sneaking = list(20, 40),
+		/datum/attribute/skill/misc/stealing = list(20, 40),
+		/datum/attribute/skill/misc/lockpicking = list(0, 30),
+		/datum/attribute/skill/misc/music = list(10, 40),
+		/datum/attribute/skill/craft/cooking = list(10, 30),
+		/datum/attribute/skill/combat/firearms = list(0, 10),
+		/datum/attribute/skill/craft/bombs = list(0, 10),
+		/datum/attribute/skill/craft/carpentry = list (10,20),
+		/datum/attribute/skill/craft/crafting = list (10,20)
 	)
 
 	raw_attribute_list = list(
-		/datum/attribute/skill/misc/climbing = 40,
-		/datum/attribute/skill/misc/athletics = 40,
-
+		/datum/attribute/skill/misc/climbing = 50,
+		/datum/attribute/skill/misc/athletics = 40
 	)
 
 /datum/job/jester
@@ -80,10 +79,11 @@
 /datum/outfit/jester
 	name = JOB_JESTER
 	shoes = /obj/item/clothing/shoes/jester
-	pants = /obj/item/clothing/pants/tights
+	pants = /obj/item/clothing/pants/tights/colored/black
 	armor = /obj/item/clothing/shirt/jester
 	belt = /obj/item/storage/belt/leather
-	beltr = /obj/item/storage/keyring/jester
+	wrists =/obj/item/storage/keyring/jester
+	beltr = /obj/item/weapon/knife/villager
 	beltl = /obj/item/storage/belt/pouch
 	head = /obj/item/clothing/head/jester
 	neck = /obj/item/clothing/neck/coif


### PR DESCRIPTION
## About The Pull Request
This PR lessens the upper and lower bounds of the standard jester's stat/skill randomness.

Note, jesters will now always have (without the be special) 40 athletics for the flip jump, and 50 climbing for the graceful landings.

Ranges without the game's random base -1,0, or +1 for every skill

**JESTER BLOCK**
SPEED = list(0, 2),
CONSTITUTION = list(-2, 2),
ENDURANCE = list(-2, 2),
PERCEPTION = list(-1, 2),
INTELLIGENCE = list(-2, 2),
STRENGTH = list(-2, 2),
FORTUNE = list(-5, 5),

Knives = list(10, 30),
Unarmed = list(10, 30),
Riding = list(0, 30),
Fishing = list(0, 20),
Wrestling = list(10, 20),
Reading = list(10, 20),
Sneaking = list(20, 40),
Stealing = list(20, 40),
Lockpicking = list(0, 30),
Music = list(10, 40),
Cooking = list(10, 30),
Firearms = list(0, 10),
Bombs = list(0, 10),
Carpentry = list (10,20), // NEW Carpenty and Crafting. I hope they will use these skills to build or whittle things for their japes.
Crafting = list (10,20)

Climbing = 50,
Athletics = 40

I've also added a be special with 50 weight called true Jester these stats get added to the upper sheet and should put set stats to any value 1-20, and skills between 0-50. 

**TRUE JESTER BLOCK**
SPEED = list(-8, 7),
CONSTITUTION = list(-6, 7),
ENDURANCE = list(-6, 7),
PERCEPTION = list(-7, 7),
INTELLIGENCE = list(-6, 7),
STRENGTH = list(-6, 7),
FORTUNE = list(-4, 4),


knives = list(-10, 20),
unarmed = list(-10, 20),
riding = list(0, 20),
fishing = list(0, 30),
wrestling = list(-10, 30),
reading = list(-10, 30),
sneaking = list(-20, 20),
stealing = list(-20, 20),
lockpicking = list(0, 20),
music = list(-10, 20),
cooking = list(-10, 20),
firearms = list(-10, 40),
bombs = list(-10, 40),
climbing = list(-10, 10),
athletics = list(-20, 10),


I also changed their pants from linen colored tights to black tights.
They also get a village knife, they will hopefully use this to whittle or build things for jokes. (Like toys or wooden crowns or what have you)


## Why It's Good For The Game
The random stats did a good job of attracting players just for the chance of rolling high stats. There is also the chance that you role such low stats that your round feels unplayable (1 perception is worse than -3 because at that point your regain your vision cone).  Players playing Jester should go into the role trying to be creative with the couple tools/abilities provided. Also knowing that you will likely have certain skills lets you plan gimmicks around using those skills, instead of leaving them up to chance.

The be special roll allows people to still play old jester, but less often.


## Changelog

:cl:
add: True Jester Be Special Trait
balance: Adjusted Jester Stat/Skill Block
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
