### PR TITLE
Cup inventory grid change (You can use cloth on cups now)

### DIFF
--- a/code/datums/components/storage/storage_grid_types.dm
+++ b/code/datums/components/storage/storage_grid_types.dm
@@ -284,7 +284,6 @@
 		/obj/item/coin,
 		/obj/item/paper,
 		/obj/item/clothing/ring,
-		/obj/item/reagent_containers/glass/bottle/vial,
 		/obj/item/reagent_containers/powder,
 		/obj/item/key,
 		/obj/item/collar_detonator

--- a/code/datums/components/storage/storage_grid_types.dm
+++ b/code/datums/components/storage/storage_grid_types.dm
@@ -273,7 +273,22 @@
 /datum/component/storage/concrete/grid/cup
 	screen_max_rows = 2
 	screen_max_columns = 1
-	max_w_class = WEIGHT_CLASS_TINY
+	max_w_class = WEIGHT_CLASS_SMALL
+
+/datum/component/storage/concrete/grid/cup/New(datum/P, ...)
+	. = ..()
+	//Going off the idea that giving cups storage grids was to smuggle things in them. Limiting what a cup can hold makes cloth work on them.
+	set_holdable(list(
+		/obj/item/weapon/knife,
+		/obj/item/gem,
+		/obj/item/coin,
+		/obj/item/paper,
+		/obj/item/clothing/ring,
+		/obj/item/reagent_containers/glass/bottle/vial,
+		/obj/item/reagent_containers/powder,
+		/obj/item/key,
+		/obj/item/collar_detonator
+		))
 
 /datum/component/storage/concrete/grid/bucket
 	screen_max_rows = 4


### PR DESCRIPTION
## About The Pull Request
Limits storage on cup items to the following.
knifes
gems
coins
paper
rings
powders (They do not dissolve, this is just a way to smuggle them)
keys (including collar detonator)


Some items that the cup can conceal. (Vials were for testing, can't conceal).
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/0f51c701-eaf8-457d-88df-42dd41cc0463" />

## Why It's Good For The Game
Limiting what can go in the cup makes it so you can use cloth on them. Sadly it still throws up "cloth can't fit in mug" text, but at least you can clean/soak/wring with mugs again.

## Changelog

:cl:
fix: Limits cup inventory so cloth soak/wring/clean works on them again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
