### PR TITLE
Fixes bullets not appearing in the GOLDFACE

### DIFF
--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -373,7 +373,7 @@
 	cost = 100
 	contains = /obj/item/storage/belt/pouch/bullets
 
-/datum/supply_pack/weapons/ammo/bullets
+/datum/supply_pack/weapons/ammo/bulletflask
 	name = "Gunpowder Flask"
 	cost = 150
 	contains = /obj/item/reagent_containers/glass/bottle/aflask


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Changes the name of the gunpowder flask supply pack from bullets to bulletflask. The lead ball pouch doesn't appear because it shares the "bullets" datum.

## Why It's Good For The Game

Bugfix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: bullets should properly appear in the GOLDFACE like they're coded to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
