### PR TITLE
Restore Beggar stats to their previous state, add Crafting

### DIFF
--- a/code/modules/jobs/job_types/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/peasants/beggar.dm
@@ -1,13 +1,14 @@
 /datum/attribute_holder/sheet/job/vagrant
 	attribute_variance = list(
 		STAT_FORTUNE = list(-9, 9),
-		/datum/attribute/skill/misc/sneaking = list(10, 40),
-		/datum/attribute/skill/misc/stealing = list(10, 40),
-		/datum/attribute/skill/misc/lockpicking = list(10, 40),
-		/datum/attribute/skill/misc/climbing = list(10, 30),
-		/datum/attribute/skill/combat/wrestling = list(-10, 10),
-		/datum/attribute/skill/combat/unarmed = list(10, 20),
-		/datum/attribute/skill/craft/alchemy = list(10, 20),
+		/datum/attribute/skill/misc/sneaking = list(20, 50),
+		/datum/attribute/skill/misc/stealing = list(20, 50),
+		/datum/attribute/skill/misc/lockpicking = list(20, 50),
+		/datum/attribute/skill/misc/climbing = list(30, 50),
+		/datum/attribute/skill/combat/wrestling = list(-10, 20),
+		/datum/attribute/skill/combat/unarmed = list(20, 30),
+		/datum/attribute/skill/craft/alchemy = list(20, 30),
+		/datum/attribute/skill/craft/crafting = list(10, 20),
 	)
 	raw_attribute_list = list(
 		STAT_INTELLIGENCE = -3,
@@ -61,10 +62,6 @@
 	. = ..()
 	if(prob(20))
 		head = /obj/item/clothing/head/knitcap
-	if(prob(5))
-		beltr = /obj/item/reagent_containers/powder/moondust
-	if(prob(10))
-		beltl = /obj/item/clothing/face/cigarette/rollie/cannabis
 	if(prob(10))
 		cloak = /obj/item/clothing/cloak/raincloak/colored/brown
 	if(prob(10))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When the skill rebalance came around, the Beggar skills were erroneously greatly reduced since the refactor didn't include the existing stats Beggars got (on the top of the image):
<img width="586" height="690" alt="image" src="https://github.com/user-attachments/assets/4d10fdce-e80f-4869-bcda-852db55b4928" />
This rectifies that and restores the skills to their original values, and gives Beggars 10 to 20 points of Crafting skill on top of that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The original nerf to skills was almost certainly done in error, and that should probably be corrected. The Crafting skill buff is mostly so Beggars can whittle their own woodworks like pipes, toys, and the upcoming holy wooden symbols and hawk them like trinket sellers.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Beggars now have 10 to 20 Crafting skill.
fix: Beggar stats restored to their previous (higher) values from pre skill-change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
