### PR TITLE
Jacksberry Identification Change

### DIFF
--- a/code/modules/farming/items/produce/_produce.dm
+++ b/code/modules/farming/items/produce/_produce.dm
@@ -236,6 +236,7 @@
 	tastes = list("berry" = 1)
 	faretype = FARE_POOR
 	bitesize = 5
+	list_reagents = list(/datum/reagent/water = 4)
 	dropshrink = 0.75
 	var/color_index = "good"
 	rotprocess = SHELFLIFE_SHORT
@@ -290,7 +291,7 @@
 	. = ..()
 	var/can_tell = HAS_TRAIT(user, TRAIT_FORAGER) || isobserver(user)
 	if(!can_tell)
-		can_tell = user.attributes ? GET_MOB_SKILL_VALUE_OLD(user, /datum/attribute/skill/labor/farming) : FALSE
+		can_tell = user.attributes ? (GET_MOB_SKILL_VALUE(user, /datum/attribute/skill/labor/farming) >= 20) : FALSE
 	if(can_tell)
 		if(poisonous)
 			. += span_warning("This berry looks suspicious. I sense it might be poisoned.")


### PR DESCRIPTION
## About The Pull Request
Jacksberries now require a trait or 20 or more farming skill to properly identify.

Jacksberries now take five bites to eat like the poisonous ones and have some water in them along with their nutrients.

## Why It's Good For The Game
Jacksberries don't give much nutrition, but it doesn't make sense everyone would know which are or aren't poisonous at a glance. Adding water to the normal jacksberries gives them bites equal to the poisonous varient, and has the added benefit of quenching a small amount of thirst in places without clean water.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Jacksberries now require 20 farming skill or the Expert Forager trait to identify.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
