### PR TITLE
Grass layering & fiber chance change

### DIFF
--- a/code/game/objects/structures/rogueflora.dm
+++ b/code/game/objects/structures/rogueflora.dm
@@ -307,6 +307,7 @@
 	icon = 'icons/roguetown/misc/foliage.dmi'
 	icon_state = "grass1"
 	base_icon_state = "grass"
+	layer = BELOW_OBJ_LAYER
 	num_random_icons = 6
 	attacked_sound = "plantcross"
 	destroy_sound = "plantcross"

--- a/code/game/objects/structures/rogueflora.dm
+++ b/code/game/objects/structures/rogueflora.dm
@@ -311,7 +311,7 @@
 	attacked_sound = "plantcross"
 	destroy_sound = "plantcross"
 	max_integrity = 5
-	debris = list(/obj/item/natural/fibers = 1)
+	debris = list(/obj/item/natural/fibers = 2)
 	/// base % to find any useful thing in the bush, gets modded by perception
 	var/prob2findstuff
 	/// for harvestable


### PR DESCRIPTION
## About The Pull Request
Grass drops between 0-2 fiber. This change makes them drop 1-3 fiber.
If you dropped an item on a tile with grass you would have to open the tile menu or break the grass to pick it up. Now items layer above grass so you can pick them up normally.


## Why It's Good For The Game
Gathering fiber is a pain especially when you have a chance to get 0 fiber from grass, this makes gathering fibers easier for jobs like Tailor.

Grass layering above items is bad because the sprite doesn't look like it would cover them, but it does.

## Changelog

:cl:
balance: Grass Fiber Drops changed from 0-2 to 1-3
fix: Grass no longer covers dropped items
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
