### PR TITLE
Confessions can no longer be used on the dead. 

### DIFF
--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -259,8 +259,13 @@
 
 /obj/item/paper/inqslip/confession/attemptsign(mob/user, mob/living/carbon/human/M)
 	// Check if they've confessed via torture
+	to_chat(M, span_say ("You hold the confession paper up to [user]'s bleeding wound."))
 
 	var/forced_signing = HAS_TRAIT(user, TRAIT_HAS_CONFESSED)
+
+	if(user.stat == DEAD)
+		to_chat(M, span_warning("This one has little to confess, other than being dead."))
+		return
 
 	if(paired)
 		if(paired.subject != user)

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -259,7 +259,7 @@
 
 /obj/item/paper/inqslip/confession/attemptsign(mob/user, mob/living/carbon/human/M)
 	// Check if they've confessed via torture
-	to_chat(M, span_say ("You hold the confession paper up to [user]'s bleeding wound."))
+	to_chat(M, span_notice("You hold the confession paper up to [user.p_their()] bleeding wound."))
 
 	var/forced_signing = HAS_TRAIT(user, TRAIT_HAS_CONFESSED)
 


### PR DESCRIPTION
## About The Pull Request

This changes confessions so that you no longer can use them on the deceased. Also gives you a message in chat when you use the confession on someone so that you don't accidentally spam them. 

## Why It's Good For The Game

Fixes unintended behaviour (I will not go into details). Avoids accidental spamming. 

## Changelog

:cl:
qol: You now know when you show someone a confession. 
fix: You no longer can ask the dead to confess. 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
