### PR TITLE
add: law and decree preferences via character setup

### DIFF
--- a/code/modules/client/preferences/_preferences.dm
+++ b/code/modules/client/preferences/_preferences.dm
@@ -250,6 +250,8 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 		"parchment",
 	)
 
+	var/list/role_preferences = list()
+
 	// I beg for datumised prefs
 	/// culture datum type
 	var/datum/culture/culture = /datum/culture/universal/ambiguous
@@ -1118,6 +1120,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 		else
 			HTML += "<br>"
 		HTML += "<center><a href='?_src_=prefs;preference=job;task=reset'>Reset</a></center>"
+		HTML += "<br><center><a href='?_src_=prefs;preference=role_settings'>Role Specific Preferences</a></center>"
 
 	HTML += "</center>"
 
@@ -1441,6 +1444,30 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 		return
 	else if(href_list["preference"] == "triumph_buy_menu")
 		SStriumphs.startup_triumphs_menu(user.client)
+
+	else if(href_list["preference"] == "role_settings")
+		var/list/settings = list(
+			"Monarch Law" = "monarch_law",
+			"Monarch Decree" = "monarch_decree"
+		)
+		var/choice = input(user, "Select a role setting to modify:", "Role Settings") as null|anything in settings
+		if(choice)
+			var/setting_key = settings[choice]
+			var/current_val = role_preferences[setting_key]
+
+			var/prompt_msg = "Set value for [choice].\n(You can enter multiple lines. Clearing it will remove the setting.)"
+			if(choice == "Monarch Law")
+				prompt_msg += "\n\nExample:\nThou shalt ...\nThou shalt not ..."
+			else if(choice == "Monarch Decree")
+				prompt_msg += "\n\nExample:\nTaxes are hereby abolished.\nAll peasants must ..."
+
+			var/new_val = input(user, prompt_msg, choice, current_val) as message|null
+			if(!isnull(new_val))
+				if(new_val == "")
+					role_preferences -= setting_key
+				else
+					role_preferences[setting_key] = sanitize_text(new_val)
+		return TRUE
 
 	else if(href_list["preference"] == "keybinds")
 		switch(href_list["task"])

--- a/code/modules/client/preferences/preferences_savefile.dm
+++ b/code/modules/client/preferences/preferences_savefile.dm
@@ -334,6 +334,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["gender_choice"] >> gender_choice
 	S["setspouse"] >> setspouse
 	S["selected_accent"] >> selected_accent
+	S["role_preferences"] >> role_preferences
+	if(!islist(role_preferences))
+		role_preferences = list()
 
 	voice_color = sanitize_hexcolor(voice_color, include_crunch = FALSE)
 
@@ -509,6 +512,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["gender_choice"], gender_choice)
 	WRITE_FILE(S["setspouse"], setspouse)
 	WRITE_FILE(S["selected_accent"], selected_accent)
+	WRITE_FILE(S["role_preferences"], role_preferences)
 
 	WRITE_FILE(S["equipped_loadout"], equipped_loadout)
 	WRITE_FILE(S["equipped_loadout_colors"], equipped_loadout_colors)

--- a/code/modules/jobs/job_types/nobility/lord.dm
+++ b/code/modules/jobs/job_types/nobility/lord.dm
@@ -138,6 +138,21 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	if(spawned.dna?.species?.id == SPEC_ID_HUMEN && spawned.gender == MALE)
 		spawned.dna.species.soundpack_m = new /datum/voicepack/male/evil()
 
+	if(player_client?.prefs)
+		var/datum/preferences/prefs = player_client.prefs
+		
+		var/law_text = prefs.role_preferences["monarch_law"]
+		if(law_text)
+			for(var/line in splittext(law_text, "\n"))
+				if(trim(line))
+					GLOB.laws_of_the_land += trim(line)
+					
+		var/decree_text = prefs.role_preferences["monarch_decree"]
+		if(decree_text)
+			for(var/line in splittext(decree_text, "\n"))
+				if(trim(line))
+					GLOB.lord_decrees += trim(line)
+
 /datum/outfit/lord
 	name = JOB_MONARCH
 	head = /obj/item/clothing/head/crown/serpcrown


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds law and decree enacting to character setup so players can choose their ruling text before the round starts, and save them for future uses.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This avoids forcing players to set laws/decrees only after spawn. It improves role consistency and gives players a better pre-round setup experience.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: show law and decree prefs in character setup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
