### PR TITLE
Fix TGUI asset cache confirmation timeout

### DIFF
--- a/code/modules/asset_cache/asset_client.dm
+++ b/code/modules/asset_cache/asset_client.dm
@@ -36,7 +36,7 @@
 	var/t = 0
 	var/timeout_time = timeout
 
-	src << browse({"<script>var xhr = new XMLHttpRequest(); xhr.open('GET', 'byond://?asset_cache_confirm_arrival=[job]', true); xhr.send(null);</script>"}, "window=asset_cache_browser&file=asset_cache_send_verify.htm")
+	src << browse({"<script>window.location.href='byond://?asset_cache_confirm_arrival=[job]'</script>"}, "window=asset_cache_browser&file=asset_cache_send_verify.htm")
 
 	while(!completed_asset_jobs["[job]"] && t < timeout_time) // Reception is handled in Topic()
 		stoplag(1) // Lock up the requester until this is received.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_EMPTY(respawncounts)
 	// asset_cache
 	var/asset_cache_job
 	if(href_list["asset_cache_confirm_arrival"])
-		asset_cache_job = round(text2num(href_list["asset_cache_confirm_arrival"]))
+		asset_cache_job = asset_cache_confirm_arrival(href_list["asset_cache_confirm_arrival"])
 		if(!asset_cache_job)
 			return
 


### PR DESCRIPTION
## About The Pull Request

Fixes the TGUI asset-cache confirmation path.

The asset flush confirmation is now sent through `byond://` navigation, matching upstream behavior, and `/client/Topic()` now calls `asset_cache_confirm_arrival()` instead of only parsing the job id.

## Why It's Good For The Game

Trust me, it's a good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Fixed an unnecessary delay when opening the first TGUI window after joining.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

Before fix:
https://github.com/user-attachments/assets/1fa952db-9ad6-44e3-b16d-fd8662e6eb7d

After fix:
https://github.com/user-attachments/assets/ea353292-1b11-4b23-af74-71350ba3a1db

