### PR TITLE
Fluted Hauberk Recipe Change Silver Flail Recipe No Longer Gives Iron…

### DIFF
--- a/code/game/objects/items/weapons/melee/flail.dm
+++ b/code/game/objects/items/weapons/melee/flail.dm
@@ -102,7 +102,7 @@
 	sellprice = 90
 	item_weight = 1 KILOGRAMS
 
-/obj/item/weapon/flail/silflail/Initialize(mapload)
+/obj/item/weapon/flail/silver/Initialize(mapload)
 	. = ..()
 	enchant(/datum/enchantment/silver)
 

--- a/code/modules/crafting/anvil_recipes/armor.dm
+++ b/code/modules/crafting/anvil_recipes/armor.dm
@@ -1324,8 +1324,9 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/hauberk
-	name = "fluted hauberk"
+	name = "fluted hauberk (+ Bar)"
 	required_material = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/armor/chainmail/hauberk/fluted
 	craftdiff = 3
 

--- a/code/modules/crafting/anvil_recipes/weapons.dm
+++ b/code/modules/crafting/anvil_recipes/weapons.dm
@@ -901,7 +901,7 @@
 	name = "Silver Flail (+Chain, +Stick)"
 	appro_skill = /datum/attribute/skill/craft/weaponsmithing
 	additional_items = list(/obj/item/rope/chain, /obj/item/grown/log/tree/stick)
-	created_item = /obj/item/weapon/flail/silflail
+	created_item = /obj/item/weapon/flail/silver
 
 /datum/anvil_recipe/weapons/silver/sword_silver
 	name = "Silver Sword"


### PR DESCRIPTION
## About The Pull Request
Fluted Hauberk now costs 2 steel bars instead of 1
Silver Flail smithing gives silver flail instead of iron flail
## Why It's Good For The Game
Fluted Hauberk is the same as a hauberk stat wise, and should be the same cost wise, maybe even more since it is supposed to be fancy.
<img width="2560" height="1440" alt="smithing bugfix" src="https://github.com/user-attachments/assets/2c11a4a8-ba3a-4d35-b36f-1aad4ddfc4a3" />

## Changelog


<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Some smithing recipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
