### PR TITLE
Smithing Minigame Tweaks

### DIFF
--- a/code/game/machinery/anvil.dm
+++ b/code/game/machinery/anvil.dm
@@ -207,7 +207,7 @@
 	var/turf/front = get_turf(src)
 	sparks.set_up(1, 1, front)
 	sparks.start()
-	user.adjust_stamina(user.maximum_stamina / 4)
+	user.adjust_stamina(user.maximum_stamina / 20)
 
 	if(recipe.progress >= 100 && !length(recipe.additional_items) && !recipe.needed_item)
 		complete_recipe(user, quality_score)

--- a/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/crafting/anvil_recipes/_anvil_recipe.dm
@@ -59,6 +59,7 @@
 
 	if(needed_item)
 		to_chat(user, span_notice("Now it's time to add \a [needed_item.name]."))
+		user.balloon_alert(user, "Add \a [needed_item.name]!")
 		return FALSE
 
 	return TRUE
@@ -99,6 +100,7 @@
 		if(length(additional_items))
 			needed_item = pick_n_take(additional_items)
 			to_chat(user, span_notice("Now it's time to add \a [needed_item.name]."))
+			user.balloon_alert(user, "Add \a [needed_item.name]!")
 			progress = 0
 		else
 			to_chat(user, span_info("It's ready."))

--- a/code/modules/crafting/anvil_recipes/minigame.dm
+++ b/code/modules/crafting/anvil_recipes/minigame.dm
@@ -63,11 +63,11 @@
 /datum/anvil_challenge/proc/generate_anvil_beats(init = FALSE)
 	var/list/new_notes = list()
 
-	var/last_note_time = REALTIMEOFDAY + 0.5 SECONDS
-	for(var/i = 1 to min(rand(2,5), notes_left))
+	var/last_note_time = REALTIMEOFDAY + 1 SECONDS
+	for(var/i = 1 to notes_left)
 		notes_left--
 		var/atom/movable/screen/hud_note/hud_note = new(null, null, src)
-		var/time = rand(2, 4)
+		var/time = rand(5, 7)
 		if(difficulty >= 6)
 			time /= round((difficulty - 4) * 0.5)
 		hud_note.generate_click_type(difficulty)

--- a/code/modules/crafting/anvil_recipes/minigame.dm
+++ b/code/modules/crafting/anvil_recipes/minigame.dm
@@ -63,11 +63,11 @@
 /datum/anvil_challenge/proc/generate_anvil_beats(init = FALSE)
 	var/list/new_notes = list()
 
-	var/last_note_time = REALTIMEOFDAY + 1 SECONDS
+	var/last_note_time = REALTIMEOFDAY + 0.5 SECONDS
 	for(var/i = 1 to min(rand(2,5), notes_left))
 		notes_left--
 		var/atom/movable/screen/hud_note/hud_note = new(null, null, src)
-		var/time = rand(5, 10)
+		var/time = rand(2, 4)
 		if(difficulty >= 6)
 			time /= round((difficulty - 4) * 0.5)
 		hud_note.generate_click_type(difficulty)
@@ -120,7 +120,6 @@
 	else
 		if((REALTIMEOFDAY > lower_range) && (REALTIMEOFDAY < upper_range))
 			anvil_presses -= anvil_presses[choice]
-			user.balloon_alert(user, "Great Hit!")
 
 			// for(var/mob/player as anything in GLOB.player_list)
 			// 	if(!is_in_zweb(player.z, host_anvil.z))


### PR DESCRIPTION
## About The Pull Request
This PR speeds up the minigame as not only was it a bit too easy, but it required a lot of waiting for new notes to appear.
This PR also removes the "Great hit!" text clouds, and replaces it with a cloud that informs the smith that they need to add (insert itemname here).
This also changes the stamina drain from smithing, it was really annoying to be sitting with an empty energy bar so often. I'm pretty sure this was added so smiths could get the energy spent malum god's chosen event done. With the faster minigame they'll be draining stamina and smithing more.


## Why It's Good For The Game
 It is really annoying to be trapped in a minigame when someone is asking you a question, and they take so long that some players will walk off before you've gotten through it. It is really easy to do these minigames too.
 
 
This is on draft so I can test the values a bit more tomorrow.

## Changelog
:cl:
qol: Made smithing minigame faster, and take less stamina.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
