### PR TITLE
Raises Dungeoneer's Sword Skill from 10 to 20

### DIFF
--- a/code/modules/jobs/job_types/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/garrison/dungeoneer.dm
@@ -9,7 +9,7 @@
 		/datum/attribute/skill/combat/whipsflails = 30,
 		/datum/attribute/skill/combat/wrestling = 30,
 		/datum/attribute/skill/combat/unarmed = 30,
-		/datum/attribute/skill/combat/swords = 10,
+		/datum/attribute/skill/combat/swords = 20,
 		/datum/attribute/skill/misc/swimming = 10,
 		/datum/attribute/skill/misc/reading = 10,
 		/datum/attribute/skill/misc/climbing = 10,


### PR DESCRIPTION
## About The Pull Request
Raises Dungeoneer's Sword Skill from 10 to 20

## Why It's Good For The Game
Dungeoneer has a sword mapped in for them, but they start with sword skills lower than a beggar who has hit a training dummy for a while. I'm guessing they had such bad skills because they didn't want it to be a combat class, so I'm raising it past, hit training dummy level, but below what every other normal fighting role gets.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Raises Dungeoneer Sword Skill 10->20
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
