### PR TITLE
Embracing Death prevents Zombification

### DIFF
--- a/code/modules/spells/spell_types/undirected/embrace_death.dm
+++ b/code/modules/spells/spell_types/undirected/embrace_death.dm
@@ -32,6 +32,7 @@
 	playsound(owner, 'sound/magic/churn.ogg', 80)
 	ADD_TRAIT(owner, TRAIT_NECRA_CURSE, "necra_ritual")
 	ADD_TRAIT(owner, TRAIT_BURIED_COIN_GIVEN, "necra_ritual")
+	ADD_TRAIT(owner, TRAIT_ZOMBIE_IMMUNE, "necra_ritual")
 	var/mob/living/living_owner = owner
 	living_owner.death()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

From https://discord.com/channels/1511469905700978729/1515147127712649266

Embracing Death adds zombification immunity

## Why It's Good For The Game

Discussed in above ideasguy thread, Necra's influence prevents a disturbed rest.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Embracing Death now prevents you from turning into a deadite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
