### PR TITLE
Patron fix for Wretches (Antiquarian, Renegade).

### DIFF
--- a/code/modules/jobs/job_types/adventurer/types/wretch/antiquarian.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/antiquarian.dm
@@ -31,7 +31,6 @@
 
 // The idea is that they're a slippery bastard. Cantrip focused, stealth-focused. They rely on their spells.
 	languages = list(/datum/language/thievescant)
-	//allowed_patrons = list(/datum/patron/godless/defiant) // This one has seen too much. Matthiosans are not compatible with Heartfelt.
 
 	traits = list(
 		TRAIT_DEADNOSE,

--- a/code/modules/jobs/job_types/adventurer/types/wretch/antiquarian.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/antiquarian.dm
@@ -31,7 +31,7 @@
 
 // The idea is that they're a slippery bastard. Cantrip focused, stealth-focused. They rely on their spells.
 	languages = list(/datum/language/thievescant)
-	allowed_patrons = list(/datum/patron/godless/defiant) // This one has seen too much. Matthiosans are not compatible with Heartfelt.
+	//allowed_patrons = list(/datum/patron/godless/defiant) // This one has seen too much. Matthiosans are not compatible with Heartfelt.
 
 	traits = list(
 		TRAIT_DEADNOSE,
@@ -112,3 +112,6 @@
 		/obj/item/reagent_containers/glass/bottle/stronghealthpot = 1,
 	)
 
+/datum/job/advclass/wretch/antiquarian/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	spawned.set_patron(/datum/patron/godless/defiant)

--- a/code/modules/jobs/job_types/adventurer/types/wretch/vigilante.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/vigilante.dm
@@ -28,7 +28,7 @@
 	total_positions = 10
 	roll_chance = 100
 	cmode_music = 'sound/music/cmode/antag/CombatBeest.ogg'
-	allowed_patrons = list(/datum/patron/inhumen/matthios)
+	//allowed_patrons = list(/datum/patron/inhumen/matthios)
 
 	attribute_sheet = /datum/attribute_holder/sheet/job/vigilante
 
@@ -100,3 +100,7 @@
 		/obj/item/flint = 1,
 		/obj/item/reagent_containers/glass/bottle/stronghealthpot = 1,
 	)
+
+/datum/job/advclass/wretch/vigilante/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	spawned.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/adventurer/types/wretch/vigilante.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/vigilante.dm
@@ -28,7 +28,6 @@
 	total_positions = 10
 	roll_chance = 100
 	cmode_music = 'sound/music/cmode/antag/CombatBeest.ogg'
-	//allowed_patrons = list(/datum/patron/inhumen/matthios)
 
 	attribute_sheet = /datum/attribute_holder/sheet/job/vigilante
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes the inability to select Antiquarian / Renegade for characters that do not worship their specific god. Your patron is now forced post-selection and the allowed_patron requirement is marked out, fixing the oversight.

## Why It's Good For The Game

It's a huge oversight that the allowed_patrons selection was functionally changed and everybody believed that it was now intentional to require worship to play these classes - there's no indicators outside of the code for this, and a majority of players do not codedive. Effectively this change nerfed an antagonist, had hidden playstyles, and lowered quality-of-life for anyone who rolls as a Wretch. This puts a bandaid on that booboo and kisses its' forehead.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Fixes Patron selection for Renegade / Antiquarian Wretch subclasses. You can now respectively shoot or throw calling cards at people like gambit again without needing to worship a specific patron on character-creation. Your patronage is still forced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
