### PR TITLE
Rolling Pin Changes

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -11,7 +11,7 @@
 
 /obj/item/kitchen/fork
 	name = "fork"
-	desc = ""
+	desc = "A wooden utenisle with pointed tines on the end. Helps you eat without dirtying your hands. "
 	icon_state = "fork"
 	force = 5
 	w_class = WEIGHT_CLASS_TINY
@@ -61,11 +61,15 @@
 
 /obj/item/kitchen/rollingpin
 	name = "rolling pin"
-	desc = ""
+	desc = "A wooden pin primarily used to shape and flatten dough for baking."
 	icon_state = "rolling_pin"
 	item_state = "rolling_pin"
-	force = 11
-	throwforce = 5
+	slot_flags = ITEM_SLOT_HIP
+	force = DAMAGE_CLUB - 1
+	force_wielded = DAMAGE_CLUB_WIELD - 1
+	throwforce = DAMAGE_CLUB / 2
+	max_integrity = INTEGRITY_WORST
+	associated_skill = /datum/attribute/skill/combat/axesmaces
 	throw_speed = 1
 	throw_range = 7
 	w_class = WEIGHT_CLASS_SMALL
@@ -73,9 +77,21 @@
 	custom_price = 5
 	resistance_flags = FLAMMABLE // Weapon made mostly of wood
 	possible_item_intents = list(/datum/intent/use, /datum/intent/mace/strike/wood)
+	gripped_intents = list(/datum/intent/mace/strike/wood)
 	smeltresult = /obj/item/fertilizer/ash
-	experimental_inhand = FALSE
+	experimental_inhand = TRUE
 	item_weight = 500 GRAMS
+	grid_height = 64
+	grid_width = 32
+
+/obj/item/kitchen/rollingpin/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.6,"sx" = -12,"sy" = -10,"nx" = 12,"ny" = -10,"wx" = -8,"wy" = -7,"ex" = 3,"ey" = -9,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 90,"sturn" = -90,"wturn" = -90,"eturn" = 90,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("wielded")
+				return list("shrink" = 0.6,"sx" = -12,"sy" = 3,"nx" = 12,"ny" = 2,"wx" = -8,"wy" = 2,"ex" = 4,"ey" = 2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+	return ..()
 
 /obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
## About The Pull Request
I have balanced the rolling pin to be a slightly worse club. It has a small grid size, and can fit in hip slots now. It can be two handed, and scales off maces.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c32c475a-7770-43ab-86c8-055ade303182" />

## Why It's Good For The Game
Improvised weapons are funny, being able to carry rolling pins are nice.


## Changelog

:cl:
balance: buffs rolling pin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
