### PR TITLE
heavy armor trait also works on medium armor

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -885,7 +885,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 			else
 				. = item_weight
 		if(AC_MEDIUM)
-			if(carrier && !HAS_TRAIT(carrier, TRAIT_MEDIUMARMOR))
+			if(carrier && !HAS_TRAIT(carrier, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(carrier, TRAIT_HEAVYARMOR))
 				. = item_weight * 2
 			else
 				. = item_weight


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
makes it so heavy armor trait reduce medium encumbrance as well
before:
<img width="633" height="378" alt="Capture d&#39;écran 2026-06-28 110637" src="https://github.com/user-attachments/assets/7221f837-d4e2-4da0-a656-e9b8790127d8" />
after:
<img width="618" height="387" alt="Capture d&#39;écran 2026-06-28 105457" src="https://github.com/user-attachments/assets/5d357f3d-43ae-4acc-8525-040f8a7b9b5d" />


## Why It's Good For The Game
fix oversight
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: heavy armor trait now works on medium armor as well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
