### PR TITLE
New Religion - Quaker Psydonism

### DIFF
--- a/code/datums/gods/patrons/forgotten.dm
+++ b/code/datums/gods/patrons/forgotten.dm
@@ -38,4 +38,18 @@
 		"PSYDON LIVES!",
 	)
 
+/datum/patron/psydon/quaker
+	display_name = "Quaker Psydonite"
+	desc = "The Ten are false prophets and my God is dead, but he lives on through his Spirit. And only through the inner light granted to us of contemplation through his word, may we seek to improve this realm."
+	flaws = "Enforcement of the categorical imperative, and true belief in your maxim with no room for error."
+	worshippers = "Richard Nixon for some fucking reason"
+	sins = "Violence, Cruelty, Working on Sunday"
+	boons = "Bitchin' Oatmeal."
+	added_traits = list(TRAIT_PACIFISM)
+	confess_lines = list(
+		"I FORGIVE YOU!",
+		"PSYDON LOVES YOU!",
+		"BLASPHEMY AGAINST THE SPIRIT (OF PSYDON!)",
+	)
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a new variant of Psydonic worship - Quaker. All Quaker Psydonites start with the Pacifism trait, because this is the natural end-result of true belief in your maxim, and they're the only ones truly brave enough to truly practice what they preach. I'll be adding Amish Psydonism soon after this.

<img width="659" height="152" alt="image" src="https://github.com/user-attachments/assets/7160a015-a4a0-4112-bfdc-03dad7b802ce" />


## Why It's Good For The Game

We have no explanation as to where the oatmeal in this realm comes from. This is a huge plothole and it needs to be fixed immediately.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: The best Patron in the entire game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
