### PR TITLE
Hopefully re-adds stubble.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -120,7 +120,7 @@
 	if(stat < 3) //not dead
 		if(dna?.species)
 			if(STUBBLE in dna.species.species_traits)
-				if(gender == MALE)
+				if(gender == MALE && (age != AGE_CHILD))
 					if(prob(50))
 						has_stubble = TRUE
 						update_body()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -886,6 +886,7 @@
 /datum/species/proc/handle_body(mob/living/carbon/human/H)
 	H.remove_overlay(BODY_LAYER)
 	H.remove_overlay(ABOVE_BODY_FRONT_LAYER)
+	H.remove_overlay(HAIREXTRA_LAYER)
 
 	var/datum/species/species = H.dna?.species
 	var/use_female_sprites = FALSE
@@ -923,6 +924,16 @@
 			var/mutable_appearance/bodyhair_overlay = mutable_appearance(limb_icon, "[species?.hairyness]", -FRONT_MUTATIONS_LAYER)
 			bodyhair_overlay.color = H.get_hair_color()
 			standing += bodyhair_overlay
+
+		//stubble
+		S = GLOB.facial_hairstyles_list[H.facial_hairstyle]
+		var/fhair_state = S.icon_state
+		var/fhair_file = S.icon
+		var/mutable_appearance/facial_overlay = mutable_appearance(fhair_file, fhair_state, -HAIREXTRA_LAYER)
+		if((H.gender == MALE) && H.has_stubble && (STUBBLE in species_traits) && (age != AGE_CHILD))
+			var/mutable_appearance/stubble_underlay = mutable_appearance('icons/roguetown/mob/facial.dmi', "facial_stubble")
+			facial_overlay.underlays += stubble_underlay
+
 
 	//Underwear
 	if(!(NO_UNDERWEAR in species_traits))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

For ABYSSOR/beelzebug, updates and re-adds some missing code that would control the stubble overlay on characters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The functionality is still in the code, it's just that the sprite isn't updated with the stubble. This is a bugfix!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Stubble is visible once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
