### PR TITLE
TAMEABLE DIREBEARS

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/creacher/bear.dm
@@ -92,8 +92,8 @@
 									/obj/item/natural/head/direbear = 1)
 	faction = list("bears")		//This mf will kill undead - swapped to its own faction, doesn't trigger ambushes
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	melee_damage_lower = 50		// Ey, bo-bo!
-	melee_damage_upper = 60		// We're gonna take his pick-in-ick basket!
+	melee_damage_lower = 50		// Ey, Boo-Boo!
+	melee_damage_upper = 60		// We're gonna take his pic-a-ic basket!
 	vision_range = 6
 	aggro_vision_range = 8
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES // silly furniture won't stop our boy
@@ -106,6 +106,8 @@
 				/obj/item/organ, 		//Woe be upon ye
 				/obj/effect/decal/remains,
 				)
+	tame_chance = 15 // taken from mole
+	bonus_tame_chance = 15 // likewise taken from mole
 	base_constitution = 12
 	base_strength= 13
 	base_speed = 9
@@ -118,9 +120,25 @@
 	dodgetime = 30
 	stat_attack = UNCONSCIOUS	//You falling unconcious won't save you, little one..
 	ai_controller = /datum/ai_controller/direbear
+	var/static/list/pet_commands = list( // list taken from hound, because sounds about right, and also bears fish!
+		/datum/pet_command/fish,
+		/datum/pet_command/idle,
+		/datum/pet_command/free,
+		/datum/pet_command/good_boy,
+		/datum/pet_command/follow,
+		/datum/pet_command/attack,
+		/datum/pet_command/fetch,
+		/datum/pet_command/play_dead,
+		/datum/pet_command/protect_owner,
+		/datum/pet_command/aggressive,
+		/datum/pet_command/calm,
+	)
 	can_buckle = TRUE
 
-/mob/living/simple_animal/hostile/retaliate/direbear/Initialize(mapload)
+
+
+/mob/living/simple_animal/hostile/retaliate/direbear/Initialize()
+	AddComponent(/datum/component/obeys_commands, pet_commands) // here due to signal overridings from pet commands, apparently?
 	. = ..()
 	AddComponent(/datum/component/ai_aggro_system)
 


### PR DESCRIPTION
FINE, I DID IT MYSELF

## About The Pull Request

Changed it such that dire bears can now be tamed if you're brave enough.

## Why It's Good For The Game

We can tame bears in real life, we should be able to tame them in-game! We can tame gators! Why not bears, for the daring?! Plus, riding bears, it's the end of Pride Month, I had no choice but to get this joke in NOW

## Changelog

Added pet commands and a taming chance to dire bears, taking the taming chances from moles (low-ish chance) and commands from the hound (because bears can fish)

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: added ability to tame dire bears
fix: fixed a few typos in the comments of the bear file, but added one more (for balance)
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
