### PR TITLE
Adds Decorated Dagger to Smithing

### DIFF
--- a/code/modules/crafting/anvil_recipes/weapons.dm
+++ b/code/modules/crafting/anvil_recipes/weapons.dm
@@ -657,6 +657,14 @@
 	output_amount = 2
 	craftdiff = 1
 
+/datum/anvil_recipe/weapons/steel/royal
+	name = "Decorated Dagger"
+	appro_skill = /datum/attribute/skill/craft/weaponsmithing
+	additional_items = list(/obj/item/ingot/gold)
+	created_item = /obj/item/weapon/knife/dagger/steel/royal
+	output_amount = 2
+	craftdiff = 4
+
 /datum/anvil_recipe/weapons/steel/decsaber
 	name = "Decorated Sabre (+Gold Bar)"
 	appro_skill = /datum/attribute/skill/craft/weaponsmithing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added smithing recipie for decorated dagger that requires one steel bard and one gold bar

## Why It's Good For The Game

more recipies

## Changelog

Added ONE knife recipie

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Added a recipie for decorated dagger that uses one steel bar+iron bar to craft 2 decorated daggers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
