### PR TITLE
Kneestingers Take Damage When Walked Over

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -34,6 +34,7 @@
 		var/mob/living/L = AM
 		if(L.z == z)
 			if(!HAS_TRAIT(L, TRAIT_KNEESTINGER_IMMUNITY))
+				take_damage(15, BRUTE)
 				if(L.electrocute_act(20, src))
 					L.emote("painscream")
 					L.update_sneak_invis(TRUE)


### PR DESCRIPTION
## About The Pull Request
Kneestingers can be trampled if walked over enough times without the Dendor's Blessing trait (because they love plants and walk over them nicely).

Currently in this PR they take 15 damage per walk over of their 30 integrity. I think each kneestinger being able to stun twice is fine, though three times is probably fine too.

## Why It's Good For The Game
Currently kneestingers can stun an infinite amount of times. There is a small grace period where you won't get the stun from being electrocuted, but you will still take the burn damage if you are pulled back over kneestingers. There is also the problem of some weapons shocking you (swords) if you attack kneestingers with them, and others not being able to damage kneestingers (blunt/stab only weapons).
<img width="678" height="452" alt="image" src="https://github.com/user-attachments/assets/47fe2c84-a384-430b-afa3-995b241a2054" />

## Changelog
:cl:
balance: Kneestingers take damage when walked on by people without immunity.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
