### PR TITLE
Averages Physical Stats for Encumberance

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1315,10 +1315,13 @@
 /mob/living/carbon/proc/get_basic_lift()
 	if(!istype(attributes))
 		return 10
-	var/str = GET_MOB_ATTRIBUTE_VALUE(src, STAT_STRENGTH)
-	if(str <= 0)
+
+	var/physavg = (GET_MOB_ATTRIBUTE_VALUE(src, STAT_STRENGTH) + GET_MOB_ATTRIBUTE_VALUE(src, STAT_CONSTITUTION) + GET_MOB_ATTRIBUTE_VALUE(src, STAT_ENDURANCE)) / 3
+
+	if(physavg <= 0)
 		return 3
-	return max(CEILING(sqrt(str) * 3, 1), 3)
+
+	return max(CEILING(sqrt(physavg) * 3, 1), 3)
 
 /mob/living/carbon/proc/update_maximum_carry_weight()
 	maximum_carry_weight = get_basic_lift() * 10


### PR DESCRIPTION
## About The Pull Request
Max encumbrance used to scale off strength only, now it scales off the average of strength, constitution, and endurance as they are physical stats (speed doesn't count it helps you move faster when encumbered anyways).

## Why It's Good For The Game
Using the average of three stats instead of one averages out the randomness of our +1/-1 stat rolls, so you are less likely to be encumbered because of a bad stat roll.
Strength is used for a lot of important combat things, the other stats should get to help.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a0e21f0b-a771-4054-a9d5-2333b88e650e" />
Picture doesn't show much, but if it was just strength it would be 110 for maximum carry.
## Changelog

:cl:
balance: Maximum Encumbrance now scales off Str,Con,&End instead of just Str.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
