### PR TITLE
Makes the improve combat skills ravox quest need 20 skill points instead of 2

### DIFF
--- a/code/game/gamemodes/personal_objectives/ravox/improve_combat.dm
+++ b/code/game/gamemodes/personal_objectives/ravox/improve_combat.dm
@@ -4,7 +4,7 @@
 	triumph_count = 2
 	rewards = list("2 Triumphs", "Ravox grows stronger", "Ravox blesses you (+1 Strength)")
 	var/levels_gained = 0
-	var/required_levels = 2
+	var/required_levels = 20
 
 /datum/objective/personal/improve_combat/on_creation()
 	. = ..()
@@ -37,7 +37,7 @@
 		complete_objective()
 	else
 		var/remaining = required_levels - levels_gained
-		to_chat(owner.current, span_notice("Combat skill improved! [remaining] more level[remaining == 1 ? "" : "s"] needed to fulfill Ravox's task!"))
+		to_chat(owner.current, span_notice("Combat skill improved! [remaining] more point[remaining == 1 ? "" : "s"] needed to fulfill Ravox's task!"))
 
 /datum/objective/personal/improve_combat/complete_objective()
 	. = ..()
@@ -50,4 +50,4 @@
 	owner.current.adjust_stat_modifier(STATMOD_RAVOX_BLESSING, list(STAT_STRENGTH = 1))
 
 /datum/objective/personal/improve_combat/update_explanation_text()
-	explanation_text = "Improve your combat skills by gaining [required_levels] new skill levels through practice or dreams. For Ravox!"
+	explanation_text = "Improve your combat skills by gaining [required_levels] new skill points through practice or dreams. For Ravox!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The Ravox quest used to need 2 _levels_ of skill gain (so from novice to journeyman, for example). After the skill system got reworked, it required 2 _points_ of skill gain (so from 10 to 12 points of a combat skill), because apparently someone forgot to adjust it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Surely Ravox isnt so depressed that hitting a dummy twice is enough to impress him?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
fix: Fixes Ravox "Improve combat skills" quest not requiring enough skill points to complete.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
