### PR TITLE
Inquisition Music Box can be Destroyed by Burial Rites

### DIFF
--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -803,7 +803,6 @@
 	stress_change = 10
 	desc = span_red("The horrid wails of the dead call for relief!")
 
-
 /datum/stress_event/soulchurnerpsydon
 	timer = 1 MINUTES
 	stress_change = 1

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -446,3 +446,8 @@
 	timer = 10 MINUTES
 	stress_change = -5
 	desc = SPAN_GOD_XYLIX("Oh frabjous dae, calooh callay! The Silver-Tongue's guffaw keeps my troubles at bay!")
+
+/datum/stress_event/soulchurnerdestroyed
+	timer = 10 MINUTES
+	stress_change = -5
+	desc = span_green("That barbaric machine has been destroyed, I have done a great service todae!")

--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -134,6 +134,39 @@
 			if("gen")
 				return list("shrink" = 0.6,"sx" = -1,"sy" = 0,"nx" = 11,"ny" = 1,"wx" = 0,"wy" = 1,"ex" = 4,"ey" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 15,"sturn" = 0,"wturn" = 0,"eturn" = 39,"nflip" = 8,"sflip" = 0,"wflip" = 0,"eflip" = 8)
 
+/// Called by burial_rites, gives some fluff messages before deleting the box.
+/obj/item/psydonmusicbox/proc/free_souls(mob/living/savior)
+	var/list/soul_lines = list(
+		SPAN_GOD_ASTRATA("Her light once more... thank you..."),
+		SPAN_GOD_ASTRATA("Warmth at last..."),
+		SPAN_GOD_NOC("I can see them... the stars..."),
+		SPAN_GOD_NECRA("Finally... peace..."),
+		SPAN_GOD_NECRA("You have done a noble service kin..."),
+		SPAN_GOD_NECRA("I will make sure to inform the Undermaiden of your service..."),
+		SPAN_GOD_ABYSSOR("May the sea treat you well..."),
+		SPAN_GOD_RAVOX("Freedom at last! May justice be done for what I have suffered..."),
+		SPAN_GOD_PESTRA("The suffering has ended..."),
+		SPAN_GOD_EORA("Peace at last! May you find love stranger..."),
+		SPAN_GOD_DENDOR("THOSE GRENZEL SCUM SHALL PAY FOR WHAT THEY HAVE DONE!"),
+		SPAN_GOD_XYLIX("Finally! That audience was getting boring anyways..."),
+		SPAN_GOD_MALUM("I have been freed! I must find my apprentice..."),
+		SPAN_GOD_MALUM("May Malum curse the creator of that cursed craft... thank you..."),
+		SPAN_GOD_MATTHIOS("Thanks pal, I owe you one..."),
+		SPAN_GOD_ZIZO("Thanks IDIOT! Time to cause some chaos~"),
+		SPAN_GOD_GRAGGAR("I WILL TEAR THOSE GRENZELS LIMB FROM LIMB!"),
+		SPAN_GOD_BAOTHA("What a horrid experience... I need a drink..."),
+		SPAN_GOD_PSYDON("Don't expect thanks from me, servant of the betrayer...")
+	)
+
+	to_chat(savior, span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One seems to face you and begins to speak..."))
+
+	sleep(2 SECONDS)
+	to_chat(savior, pick(soul_lines))
+
+	savior.add_stress(/datum/stress_event/soulchurnerdestroyed)
+	qdel(src)
+
+
 /atom/movable/screen/alert/status_effect/buff/cranking_soulchurner
 	name = "Cranking Soulchurner"
 	desc = "I am bringing the twisted device to life..."

--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -158,7 +158,7 @@
 		SPAN_GOD_PSYDON("Don't expect thanks from me, servant of the betrayer...")
 	)
 
-	to_chat(savior, span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One seems to face you and begins to speak..."))
+	savior.visible_message(span_info("As \the [src] crumbles to dust, you can see a few faint lights float away and fade out."), span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One seems to face you and begins to speak..."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	sleep(1 SECONDS)
 	to_chat(savior, pick(soul_lines))

--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -160,7 +160,7 @@
 
 	to_chat(savior, span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One seems to face you and begins to speak..."))
 
-	sleep(2 SECONDS)
+	sleep(1 SECONDS)
 	to_chat(savior, pick(soul_lines))
 
 	savior.add_stress(/datum/stress_event/soulchurnerdestroyed)

--- a/code/game/objects/items/inquisition_relics.dm
+++ b/code/game/objects/items/inquisition_relics.dm
@@ -158,7 +158,7 @@
 		SPAN_GOD_PSYDON("Don't expect thanks from me, servant of the betrayer...")
 	)
 
-	savior.visible_message(span_info("As \the [src] crumbles to dust, you can see a few faint lights float away and fade out."), span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One seems to face you and begins to speak..."), vision_distance = COMBAT_MESSAGE_RANGE)
+	savior.visible_message(span_info("As \the [src] crumbles to dust, you can see a few faint lights float away and fade out."), span_info("As \the [src] crumbles, you can faintly see fourteen souls slowly drift out and fade into the air. One of them utters a few words before joining the rest..."), vision_distance = COMBAT_MESSAGE_RANGE)
 
 	sleep(1 SECONDS)
 	to_chat(savior, pick(soul_lines))

--- a/code/modules/spells/spell_types/pointed/burial_rites.dm
+++ b/code/modules/spells/spell_types/pointed/burial_rites.dm
@@ -19,7 +19,7 @@
 	spell_cost = 15
 
 /datum/action/cooldown/spell/burial_rites/is_valid_target(atom/cast_on)
-	if(istype(cast_on, /obj/item/weapon/knife/dagger/steel/profane))
+	if(istype(cast_on, /obj/item/weapon/knife/dagger/steel/profane) || istype(cast_on, /obj/item/psydonmusicbox))
 		return TRUE
 	else if(!istype(cast_on, /obj/structure/closet/dirthole))
 		return FALSE
@@ -47,6 +47,10 @@
 	if(istype(cast_on, /obj/item/weapon/knife/dagger/steel/profane))
 		var/obj/item/weapon/knife/dagger/steel/profane/profane = cast_on
 		owner.adjust_triumphs(profane.release_profane_souls(owner)) // Every soul saved earns you a big fat triumph.
+		return
+	else if(istype(cast_on, /obj/item/psydonmusicbox))
+		var/obj/item/psydonmusicbox/musicbox = cast_on
+		musicbox.free_souls(owner)
 		return
 	if(pacify_coffin(cast_on, owner))
 		if(istype(cast_on, /obj/structure/closet/dirthole))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The inquisition's cranking music box can now be destroyed through burial rites, like the assassin's dagger

## Why It's Good For The Game

Approved here https://discord.com/channels/1511469905700978729/1519595804136833116

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Inquisition music box can now be destroyed by casting Burial Rites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
