### PR TITLE
Two new orphan classes

### DIFF
--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -356,9 +356,7 @@
 		if(prob(20))
 			mouth = /obj/item/natural/stone
 
-
-// WEIRD WARD - The Kid with Possibly Bad Vibes
-
+/// WEIRD WARD - The Kid with Possibly Bad Vibes
 /datum/attribute_holder/sheet/job/orphanadv/wward
 	raw_attribute_list = list(
 		STAT_INTELLIGENCE = 2,

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -467,10 +467,7 @@
 
 /datum/job/orphanadv/ccastoff/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
-	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
-		orphanage_renovated = TRUE
-	if(orphanage_renovated)
 		spawned.adjust_stat_modifier(STATMOD_ORPHANAGE, list(
 			STAT_INTELLIGENCE = 1,
 			STAT_SPEED = 1,

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -478,10 +478,7 @@
 
 /datum/outfit/orphanadv/ccastoff/pre_equip(mob/living/carbon/human/equipped_human)
 	. = ..()
-	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
-		orphanage_renovated = TRUE
-	if(orphanage_renovated)
 		head = pick(
 			/obj/item/clothing/head/bardhat,
 			/obj/item/clothing/head/courtierhat,
@@ -493,14 +490,15 @@
 		belt = /obj/item/storage/belt/leather/rope
 		beltl = /obj/item/instrument/flute
 		shoes = /obj/item/clothing/shoes/simpleshoes
-	else
-		head = pick(
-			/obj/item/clothing/head/bardhat,
-			/obj/item/clothing/head/courtierhat,
-			/obj/item/clothing/head/fancyhat,
-		)
-		shirt = /obj/item/clothing/shirt/undershirt/colored/random
-		pants = /obj/item/clothing/pants/tights/colored/random
-		belt = /obj/item/storage/belt/leather/rope
-		beltl = /obj/item/instrument/flute
-		shoes = /obj/item/clothing/shoes/simpleshoes
+		return
+
+	head = pick(
+		/obj/item/clothing/head/bardhat,
+		/obj/item/clothing/head/courtierhat,
+		/obj/item/clothing/head/fancyhat,
+	)
+	shirt = /obj/item/clothing/shirt/undershirt/colored/random
+	pants = /obj/item/clothing/pants/tights/colored/random
+	belt = /obj/item/storage/belt/leather/rope
+	beltl = /obj/item/instrument/flute
+	shoes = /obj/item/clothing/shoes/simpleshoes

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -432,9 +432,7 @@
 			/obj/item/needle/thorn,
 		)
 
-
-// Creative Castoff - The Artistic One
-
+/// Creative Castoff - The Artistic One
 /datum/attribute_holder/sheet/job/orphanadv/ccastoff
 	raw_attribute_list = list(
 		STAT_FORTUNE = 1,

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -184,8 +184,7 @@
 		belt = /obj/item/storage/belt/leather/rope
 		beltr = /obj/item/weapon/mace/woodclub
 
-// SKILLED SCAMP - THE RESPONSIBLE CHILD
-
+/// SKILLED SCAMP - THE RESPONSIBLE CHILD
 /datum/attribute_holder/sheet/job/orphanadv/sscamp
 	raw_attribute_list = list(
 		STAT_ENDURANCE = 1,

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -396,10 +396,7 @@
 
 /datum/outfit/orphanadv/wward/pre_equip(mob/living/carbon/human/equipped_human)
 	. = ..()
-	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
-		orphanage_renovated = TRUE
-	if(orphanage_renovated)
 		if(equipped_human.gender == MALE)
 			shirt = /obj/item/clothing/shirt/undershirt/colored/black
 			pants = /obj/item/clothing/pants/tights/colored/black
@@ -416,21 +413,22 @@
 			/obj/item/weapon/surgery/scalpel,
 			/obj/item/needle,
 		)
+		return
+
+	if(equipped_human.gender == MALE)
+		shirt = /obj/item/clothing/shirt/undershirt/colored/black
+		pants = /obj/item/clothing/pants/tights/colored/black
 	else
-		if(equipped_human.gender == MALE)
-			shirt = /obj/item/clothing/shirt/undershirt/colored/black
-			pants = /obj/item/clothing/pants/tights/colored/black
-		else
-			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
-		mask = /obj/item/clothing/face/shepherd
-		belt = /obj/item/storage/belt/leather/rope
-		backr = /obj/item/storage/backpack/satchel
-		backpack_contents = list(
-			/obj/item/weapon/surgery/retractor/improv,
-			/obj/item/weapon/surgery/hemostat/improv,
-			/obj/item/weapon/surgery/scalpel,
-			/obj/item/needle/thorn,
-		)
+		shirt = /obj/item/clothing/shirt/dress/gen/colored/black
+	mask = /obj/item/clothing/face/shepherd
+	belt = /obj/item/storage/belt/leather/rope
+	backr = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/surgery/retractor/improv,
+		/obj/item/weapon/surgery/hemostat/improv,
+		/obj/item/weapon/surgery/scalpel,
+		/obj/item/needle/thorn,
+	)
 
 /// Creative Castoff - The Artistic One
 /datum/attribute_holder/sheet/job/orphanadv/ccastoff

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -388,10 +388,7 @@
 
 /datum/job/orphanadv/wward/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
-	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
-		orphanage_renovated = TRUE
-	if(orphanage_renovated)
 		spawned.adjust_stat_modifier(STATMOD_ORPHANAGE, list(
 			STAT_INTELLIGENCE = 1,
 			STAT_ENDURANCE = 1,

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -332,7 +332,7 @@
 	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
 		orphanage_renovated = TRUE
-	if(orphanage_renovated)
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
 		spawned.adjust_stat_modifier(STATMOD_ORPHANAGE, list(
 			STAT_INTELLIGENCE = 1,
 		))

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -342,7 +342,7 @@
 	var/orphanage_renovated = FALSE
 	if(has_world_trait(/datum/world_trait/orphanage_renovated))
 		orphanage_renovated = TRUE
-	if(orphanage_renovated)
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
 		shirt = /obj/item/clothing/shirt/undershirt
 		pants = /obj/item/clothing/pants/tights
 		belt = /obj/item/storage/belt/leather/rope

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -185,7 +185,7 @@
 		belt = /obj/item/storage/belt/leather/rope
 		beltr = /obj/item/weapon/mace/woodclub
 
-// SKILLED STRAY - THE RESPONSIBLE CHILD
+// SKILLED SCAMP - THE RESPONSIBLE CHILD
 
 /datum/attribute_holder/sheet/job/orphanadv/sscamp
 	raw_attribute_list = list(
@@ -194,6 +194,9 @@
 		/datum/attribute/skill/misc/climbing = 20,
 		/datum/attribute/skill/craft/crafting = 20,
 		/datum/attribute/skill/misc/reading = 10,
+		/datum/attribute/skill/craft/masonry = 10,
+		/datum/attribute/skill/craft/carpentry = 10,
+		/datum/attribute/skill/craft/cooking = 10,
 	)
 
 /datum/job/advclass/orphanadv/sscamp
@@ -345,9 +348,15 @@
 		shirt = /obj/item/clothing/shirt/undershirt
 		pants = /obj/item/clothing/pants/tights
 		belt = /obj/item/storage/belt/leather/rope
+		if(prob(1))
+			mouth = /obj/item/gem/diamond
+		else
+			mouth = /obj/item/natural/stone
 	else
 		pants = /obj/item/clothing/pants/tights/colored/vagrant
 		shirt = /obj/item/clothing/shirt/undershirt/colored/vagrant
+		if(prob(20))
+			mouth = /obj/item/natural/stone
 
 
 // WEIRD WARD - The Kid with Possibly Bad Vibes
@@ -361,7 +370,8 @@
 		/datum/attribute/skill/misc/sewing = 10,
 		/datum/attribute/skill/misc/medicine = 15,
 		/datum/attribute/skill/craft/alchemy = 5,
-		/datum/attribute/skill/craft/tanning = 10,
+		/datum/attribute/skill/labor/butchering = 10,
+		/datum/attribute/skill/craft/tanning = 5,
 	)
 
 /datum/job/advclass/orphanadv/wward
@@ -402,7 +412,7 @@
 			pants = /obj/item/clothing/pants/tights/colored/black
 		else
 			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
-		pants = /obj/item/clothing/pants/tights
+			pants = /obj/item/clothing/pants/tights
 		gloves = /obj/item/clothing/gloves/leather/phys
 		mask = /obj/item/clothing/face/shepherd
 		belt = /obj/item/storage/belt/leather/rope
@@ -437,17 +447,15 @@
 		STAT_FORTUNE = 1,
 		/datum/attribute/skill/misc/climbing = 20,
 		/datum/attribute/skill/misc/athletics = 10,
-		/datum/attribute/skill/misc/sewing = 10,
-		/datum/attribute/skill/misc/medicine = 15,
-		/datum/attribute/skill/craft/alchemy = 5,
-		/datum/attribute/skill/craft/tanning = 10,
+		/datum/attribute/skill/misc/music = 20,
+		/datum/attribute/skill/craft/crafting = 10,
 	)
 
 /datum/job/advclass/orphanadv/ccastoff
 	title= "Creative Castoff"
-	tutorial = "In sun-blessed Vanderlin \
-	an orphan unraveled the day \
-	practicing their merry songs \
+	tutorial = "In sun-blessed Vanderlin \n\
+	an orphan unraveled the day\n\
+	practicing their merry songs\n\
 	bringing bright color to the grey!"
 	outfit = /datum/outfit/orphanadv/ccastoff
 	category_tags = list(CTAG_ORPHAN)

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -366,8 +366,11 @@
 
 /datum/job/advclass/orphanadv/wward
 	title= "Weird Ward"
-	tutorial = "Write something \
-	here about this kid."
+	tutorial = "While the other children busy themselves with silly activities \
+	like baking bread or throwing rocks into the river, you have your sights set \
+	much higher.  You have seen what goes on in the clinic.  You know that you can \
+	figure it out, too.  You don't need someone to teach you.  You're the Matron's \
+	best and brightest.  You WILL do amazing things."
 	outfit = /datum/outfit/orphanadv/wward
 	category_tags = list(CTAG_ORPHAN)
 	attribute_sheet = /datum/attribute_holder/sheet/job/orphanadv/wward
@@ -396,7 +399,7 @@
 	if(orphanage_renovated)
 		if(equipped_human.gender == MALE)
 			shirt = /obj/item/clothing/shirt/undershirt/colored/black
-			pants = /obj/item/clothing/pants/tights/colored/random
+			pants = /obj/item/clothing/pants/tights/colored/black
 		else
 			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
 		pants = /obj/item/clothing/pants/tights
@@ -413,7 +416,7 @@
 	else
 		if(equipped_human.gender == MALE)
 			shirt = /obj/item/clothing/shirt/undershirt/colored/black
-			pants = /obj/item/clothing/pants/tights/colored/random
+			pants = /obj/item/clothing/pants/tights/colored/black
 		else
 			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
 		mask = /obj/item/clothing/face/shepherd
@@ -442,13 +445,18 @@
 
 /datum/job/advclass/orphanadv/ccastoff
 	title= "Creative Castoff"
-	tutorial = "Write something here about \
-	this kid being artistic and creative."
+	tutorial = "In sun-blessed Vanderlin \
+	an orphan unraveled the day \
+	practicing their merry songs \
+	bringing bright color to the grey!"
 	outfit = /datum/outfit/orphanadv/ccastoff
 	category_tags = list(CTAG_ORPHAN)
 	attribute_sheet = /datum/attribute_holder/sheet/job/orphanadv/ccastoff
 	allowed_ages = list(AGE_CHILD)
 	inherit_parent_title = TRUE
+	traits = list(
+		TRAIT_BARDIC_TRAINING,
+	)
 
 /datum/job/orphanadv/ccastoff/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -14,7 +14,7 @@
 	can_have_apprentices = FALSE
 	can_be_apprentice = TRUE
 	cmode_music = 'sound/music/cmode/towner/CombatTowner.ogg'
-	advclass_cat_rolls = list(CTAG_ORPHAN = 5)
+	advclass_cat_rolls = list(CTAG_ORPHAN = 7
 	outfit = /datum/outfit/orphan
 
 	spells = list(
@@ -348,3 +348,144 @@
 	else
 		pants = /obj/item/clothing/pants/tights/colored/vagrant
 		shirt = /obj/item/clothing/shirt/undershirt/colored/vagrant
+
+
+// WEIRD WARD - The Kid with Possibly Bad Vibes
+
+/datum/attribute_holder/sheet/job/orphanadv/wward
+	raw_attribute_list = list(
+		STAT_INTELLIGENCE = 2,
+		STAT_FORTUNE = -1,
+		/datum/attribute/skill/misc/climbing = 20,
+		/datum/attribute/skill/misc/athletics = 10,
+		/datum/attribute/skill/misc/sewing = 10,
+		/datum/attribute/skill/misc/medicine = 15,
+		/datum/attribute/skill/craft/alchemy = 5,
+		/datum/attribute/skill/craft/tanning = 10,
+	)
+
+/datum/job/advclass/orphanadv/wward
+	title= "Weird Ward"
+	tutorial = "Write something \
+	here about this kid."
+	outfit = /datum/outfit/orphanadv/wward
+	category_tags = list(CTAG_ORPHAN)
+	attribute_sheet = /datum/attribute_holder/sheet/job/orphanadv/wward
+	allowed_ages = list(AGE_CHILD)
+	inherit_parent_title = TRUE
+	traits = list(
+		TRAIT_DEADNOSE,
+	)
+
+/datum/job/orphanadv/wward/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	var/orphanage_renovated = FALSE
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
+		orphanage_renovated = TRUE
+	if(orphanage_renovated)
+		spawned.adjust_stat_modifier(STATMOD_ORPHANAGE, list(
+			STAT_INTELLIGENCE = 1,
+			STAT_ENDURANCE = 1,
+		))
+
+/datum/outfit/orphanadv/wward/pre_equip(mob/living/carbon/human/equipped_human)
+	. = ..()
+	var/orphanage_renovated = FALSE
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
+		orphanage_renovated = TRUE
+	if(orphanage_renovated)
+		if(equipped_human.gender == MALE)
+			shirt = /obj/item/clothing/shirt/undershirt/colored/black
+			pants = /obj/item/clothing/pants/tights/colored/random
+		else
+			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
+		pants = /obj/item/clothing/pants/tights
+		gloves = /obj/item/clothing/gloves/leather/phys
+		mask = /obj/item/clothing/face/shepherd
+		belt = /obj/item/storage/belt/leather/rope
+		backr = /obj/item/storage/backpack/satchel
+		backpack_contents = list(
+			/obj/item/weapon/surgery/retractor/improv,
+			/obj/item/weapon/surgery/hemostat/improv,
+			/obj/item/weapon/surgery/scalpel,
+			/obj/item/needle,
+		)
+	else
+		if(equipped_human.gender == MALE)
+			shirt = /obj/item/clothing/shirt/undershirt/colored/black
+			pants = /obj/item/clothing/pants/tights/colored/random
+		else
+			shirt = /obj/item/clothing/shirt/dress/gen/colored/black
+		mask = /obj/item/clothing/face/shepherd
+		belt = /obj/item/storage/belt/leather/rope
+		backr = /obj/item/storage/backpack/satchel
+		backpack_contents = list(
+			/obj/item/weapon/surgery/retractor/improv,
+			/obj/item/weapon/surgery/hemostat/improv,
+			/obj/item/weapon/surgery/scalpel,
+			/obj/item/needle/thorn,
+		)
+
+
+// Creative Castoff - The Artistic One
+
+/datum/attribute_holder/sheet/job/orphanadv/ccastoff
+	raw_attribute_list = list(
+		STAT_FORTUNE = 1,
+		/datum/attribute/skill/misc/climbing = 20,
+		/datum/attribute/skill/misc/athletics = 10,
+		/datum/attribute/skill/misc/sewing = 10,
+		/datum/attribute/skill/misc/medicine = 15,
+		/datum/attribute/skill/craft/alchemy = 5,
+		/datum/attribute/skill/craft/tanning = 10,
+	)
+
+/datum/job/advclass/orphanadv/ccastoff
+	title= "Creative Castoff"
+	tutorial = "Write something here about \
+	this kid being artistic and creative."
+	outfit = /datum/outfit/orphanadv/ccastoff
+	category_tags = list(CTAG_ORPHAN)
+	attribute_sheet = /datum/attribute_holder/sheet/job/orphanadv/ccastoff
+	allowed_ages = list(AGE_CHILD)
+	inherit_parent_title = TRUE
+
+/datum/job/orphanadv/ccastoff/after_spawn(mob/living/carbon/human/spawned, client/player_client)
+	. = ..()
+	var/orphanage_renovated = FALSE
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
+		orphanage_renovated = TRUE
+	if(orphanage_renovated)
+		spawned.adjust_stat_modifier(STATMOD_ORPHANAGE, list(
+			STAT_INTELLIGENCE = 1,
+			STAT_SPEED = 1,
+		))
+
+/datum/outfit/orphanadv/ccastoff/pre_equip(mob/living/carbon/human/equipped_human)
+	. = ..()
+	var/orphanage_renovated = FALSE
+	if(has_world_trait(/datum/world_trait/orphanage_renovated))
+		orphanage_renovated = TRUE
+	if(orphanage_renovated)
+		head = pick(
+			/obj/item/clothing/head/bardhat,
+			/obj/item/clothing/head/courtierhat,
+			/obj/item/clothing/head/fancyhat,
+		)
+		neck = /obj/item/storage/belt/pouch/coins/poor
+		shirt = /obj/item/clothing/shirt/undershirt/colored/random
+		pants = /obj/item/clothing/pants/tights/colored/random
+		belt = /obj/item/storage/belt/leather/rope
+		beltl = /obj/item/instrument/flute
+		shoes = /obj/item/clothing/shoes/simpleshoes
+	else
+		head = pick(
+			/obj/item/clothing/head/bardhat,
+			/obj/item/clothing/head/courtierhat,
+			/obj/item/clothing/head/fancyhat,
+		)
+		shirt = /obj/item/clothing/shirt/undershirt/colored/random
+		pants = /obj/item/clothing/pants/tights/colored/random
+		belt = /obj/item/storage/belt/leather/rope
+		beltl = /obj/item/instrument/flute
+		shoes = /obj/item/clothing/shoes/simpleshoes

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -14,7 +14,7 @@
 	can_have_apprentices = FALSE
 	can_be_apprentice = TRUE
 	cmode_music = 'sound/music/cmode/towner/CombatTowner.ogg'
-	advclass_cat_rolls = list(CTAG_ORPHAN = 7
+	advclass_cat_rolls = list(CTAG_ORPHAN = 7)
 	outfit = /datum/outfit/orphan
 
 	spells = list(

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -41,8 +41,7 @@
 		/datum/attribute/skill/combat/bows = 10,
 		/datum/attribute/skill/misc/riding = 10,
 		/datum/attribute/skill/misc/reading = 20,
-		/datum/attribute/skill/labor/mathematics = 10
-
+		/datum/attribute/skill/labor/mathematics = 10,
 	)
 
 /datum/job/advclass/orphanadv/bbrat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds two exciting new orphan subclasses.  One is focused on self-taught medical nonsense, the other focusing on bardic performance (with limited bardic abilities).

Additionally, some existing orphans were changed slightly:  Skilled Scamp received minor masonry, carpentry, and cooking training.  Weary Wastrel can now spawn with a stone in their mouth sometimes.  There is a 1% chance if the orphanage is upgraded for the stone to be a dorpel, for humor's sake.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More options is always better for the orphanage.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Weird Ward Subclass
add: Creative Castoff Subclass
add: Weary Wastrel eating rocks again
balance: Expaned Skilled Scamps skillset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
