### PR TITLE
Jump fixes / clean up

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -649,35 +649,18 @@
 		animate(pixel_z = prev_pixel_z, transform = turn(transform, pick(-12, 0, 12)), time = 0.2 SECONDS)
 		animate(transform = prev_transform, time = 0)
 
-	if(extra_tile)
-		throw_at(target, range, 1, spin = FALSE)
-		RegisterSignal(src, COMSIG_MOVABLE_THROW_LANDED, PROC_REF(jump_extra_ended))
-	else
-		throw_at(target, range, 1, spin = FALSE)
-		RegisterSignal(src, COMSIG_MOVABLE_THROW_LANDED, PROC_REF(jump_ended))
+	throw_at(target, range, 1, spin = FALSE, callback = CALLBACK(src, PROC_REF(jump_ended), extra_tile))
 
-// Depression
-/// Callback for ending a sprint jump (probably) makes you go an extra tile so you fall off platforms
-/mob/living/proc/jump_extra_ended()
-	SIGNAL_HANDLER
-
-	jump_ended()
-
-	// This is unsafe but w/e
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), get_step(src, dir), 1, 1, null, FALSE), 0.1 SECONDS)
-
-/// Callback for ending jump plays a specific "landing" sound, probably not the best way to do this
-/mob/living/proc/jump_ended()
-	SIGNAL_HANDLER
-
-	UnregisterSignal(src, COMSIG_MOVABLE_THROW_LANDED)
-
-	if(!isopenturf(loc))
+/mob/living/proc/jump_ended(extra_tile)
+	if(QDELETED(src) || !isopenturf(loc))
 		return
 
 	var/turf/open/open_turf = loc
 	if(open_turf.landsound)
 		playsound(open_turf, open_turf.landsound, 100, FALSE)
+
+	if(extra_tile)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), get_step(src, dir), 1, 1, null, FALSE), 0.1 SECONDS)
 
 #undef FLIP_DIRECTION_CLOCKWISE
 #undef FLIP_DIRECTION_ANTICLOCKWISE

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -612,52 +612,72 @@
 #define FLIP_DIRECTION_CLOCKWISE 1
 #define FLIP_DIRECTION_ANTICLOCKWISE 0
 
-/mob/living/proc/jump_action_resolve(atom/A, jadded, jrange, jextra)
-	var/do_a_flip
+/**
+ * Jump resolve
+ * Args
+ * * target - target atom we are jumping towards
+ * * stamina_cost - amount of stamina we need / we take when we jump
+ * * range - amount of tiles to throw
+ * * extra_tile - when the jump has ended, throw another tile
+ */
+/mob/living/proc/jump_action_resolve(atom/target, stamina_cost, range, extra_tile)
+	var/do_a_flip = FALSE
 	var/flip_direction = FLIP_DIRECTION_CLOCKWISE
 	var/prev_pixel_z = pixel_z
 	var/prev_transform = transform
-	if(GET_MOB_SKILL_VALUE_OLD(src, /datum/attribute/skill/misc/athletics) > 4 || HAS_TRAIT(src, TRAIT_FLIP_JUMP))
+
+	if(HAS_TRAIT(src, TRAIT_FLIP_JUMP) || GET_MOB_SKILL_VALUE_OLD(src, /datum/attribute/skill/misc/athletics) > 4)
 		do_a_flip = TRUE
 		if((dir & SOUTH) || (dir & WEST))
 			flip_direction = FLIP_DIRECTION_ANTICLOCKWISE
 
-	// ensures the floating animation doesn't mess with our animation
-	if(movement_type & (MOVETYPES_FLOATING_ANIMATION))
-		ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, UPDATE_TRANSFORM_TRAIT)
-		addtimer(TRAIT_CALLBACK_REMOVE(src, TRAIT_NO_FLOATING_ANIM, UPDATE_TRANSFORM_TRAIT), 0.3 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
-
-	if(adjust_stamina(min(jadded,100)))
-		if(do_a_flip)
-			var/flip_angle = flip_direction ? 120 : -120
-			animate(src, pixel_z = pixel_z + 6, transform = turn(transform, flip_angle), time = 1)
-			animate(transform = turn(transform, flip_angle), time=1)
-			animate(pixel_z = prev_pixel_z, transform = turn(transform, flip_angle), time=1)
-			animate(transform = prev_transform, time = 0)
-		else
-			animate(src, pixel_z = pixel_z + 6, time = 1)
-			animate(pixel_z = prev_pixel_z, transform = turn(transform, pick(-12, 0, 12)), time=2)
-			animate(transform = prev_transform, time = 0)
-
-		if(jextra)
-			throw_at(A, jrange, 1, src, spin = FALSE)
-			while(src.throwing)
-				sleep(1)
-			throw_at(get_step(src, src.dir), 1, 1, src, spin = FALSE)
-		else
-			throw_at(A, jrange, 1, src, spin = FALSE)
-			while(src.throwing)
-				sleep(1)
-		if(isopenturf(src.loc))
-			var/turf/open/T = src.loc
-			if(T.landsound)
-				playsound(T, T.landsound, 100, FALSE)
-			T.Entered(src)
-	else
-		animate(src, pixel_z = pixel_z + 6, time = 1)
-		animate(pixel_z = prev_pixel_z, transform = turn(transform, pick(-12, 0, 12)), time=2)
+	if(!adjust_stamina(min(stamina_cost, 100)))
+		animate(src, pixel_z = pixel_z + 6, time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
+		animate(pixel_z = prev_pixel_z, transform = turn(transform, pick(-12, 0, 12)), time = 0.2 SECONDS)
 		animate(transform = prev_transform, time = 0)
-		throw_at(A, 1, 1, src, spin = FALSE)
+		throw_at(target, 1, 1, spin = FALSE)
+		return
+
+	if(do_a_flip)
+		var/flip_angle = flip_direction ? 120 : -120
+		animate(src, pixel_z = pixel_z + 6, transform = turn(transform, flip_angle), time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
+		animate(transform = turn(transform, flip_angle), time = 0.1 SECONDS)
+		animate(pixel_z = prev_pixel_z, transform = turn(transform, flip_angle), time = 0.1 SECONDS)
+		animate(transform = prev_transform, time = 0)
+	else
+		animate(src, pixel_z = pixel_z + 6, time = 0.1 SECONDS, flags = ANIMATION_PARALLEL)
+		animate(pixel_z = prev_pixel_z, transform = turn(transform, pick(-12, 0, 12)), time = 0.2 SECONDS)
+		animate(transform = prev_transform, time = 0)
+
+	if(extra_tile)
+		throw_at(target, range, 1, spin = FALSE)
+		RegisterSignal(src, COMSIG_MOVABLE_THROW_LANDED, PROC_REF(jump_extra_ended))
+	else
+		throw_at(target, range, 1, spin = FALSE)
+		RegisterSignal(src, COMSIG_MOVABLE_THROW_LANDED, PROC_REF(jump_ended))
+
+// Depression
+/// Callback for ending a sprint jump (probably) makes you go an extra tile so you fall off platforms
+/mob/living/proc/jump_extra_ended()
+	SIGNAL_HANDLER
+
+	jump_ended()
+
+	// This is unsafe but w/e
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), get_step(src, dir), 1, 1, null, FALSE), 0.1 SECONDS)
+
+/// Callback for ending jump plays a specific "landing" sound, probably not the best way to do this
+/mob/living/proc/jump_ended()
+	SIGNAL_HANDLER
+
+	UnregisterSignal(src, COMSIG_MOVABLE_THROW_LANDED)
+
+	if(!isopenturf(loc))
+		return
+
+	var/turf/open/open_turf = loc
+	if(open_turf.landsound)
+		playsound(open_turf, open_turf.landsound, 100, FALSE)
 
 #undef FLIP_DIRECTION_CLOCKWISE
 #undef FLIP_DIRECTION_ANTICLOCKWISE

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -652,12 +652,13 @@
 	throw_at(target, range, 1, spin = FALSE, callback = CALLBACK(src, PROC_REF(jump_ended), extra_tile))
 
 /mob/living/proc/jump_ended(extra_tile)
-	if(QDELETED(src) || !isopenturf(loc))
+	if(QDELETED(src) || isopenspace(loc))
 		return
 
-	var/turf/open/open_turf = loc
-	if(open_turf.landsound)
-		playsound(open_turf, open_turf.landsound, 100, FALSE)
+	if(isopenturf(loc))
+		var/turf/open/open_turf = loc
+		if(open_turf.landsound)
+			playsound(open_turf, open_turf.landsound, 100, FALSE)
 
 	if(extra_tile)
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, throw_at), get_step(src, dir), 1, 1, null, FALSE), 0.1 SECONDS)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -231,8 +231,11 @@ SUBSYSTEM_DEF(throwing)
 		if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
 			return //deletion should already be handled by on_thrownthing_qdel()
 
-	if (callback)
+	if(callback)
 		callback.Invoke()
+		// Same can happen in the callback
+		if(QDELETED(thrownthing))
+			return
 
 	if(!thrownthing?.currently_z_moving) // I don't think you can zfall while thrown but hey, just in case.
 		var/turf/T = get_turf(thrownthing)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -58,7 +58,7 @@ SUBSYSTEM_DEF(throwing)
 	///The speed of the projectile thrownthing being thrown.
 	var/speed
 	///If a mob is the one who has thrown the object, then it's moved here. This can be null and must be null checked before trying to use it.
-	var/mob/thrower
+	var/datum/weakref/thrower
 	///A variable that helps in describing objects thrown at an angle, if it should be moved diagonally first or last.
 	var/diagonals_first
 	///Set to TRUE if the throw is exclusively diagonal (45 Degree angle throws for example)
@@ -101,7 +101,8 @@ SUBSYSTEM_DEF(throwing)
 	src.init_dir = init_dir
 	src.maxrange = maxrange
 	src.speed = speed
-	src.thrower = thrower
+	if(thrower)
+		src.thrower = WEAKREF(thrower)
 	src.diagonals_first = diagonals_first
 	src.force = force
 	src.gentle = gentle
@@ -124,9 +125,15 @@ SUBSYSTEM_DEF(throwing)
 
 	qdel(src)
 
+/// Returns the thrower, or null
+/datum/thrownthing/proc/get_thrower()
+	. = thrower?.resolve()
+	if(isnull(.))
+		thrower = null
+
 /datum/thrownthing/proc/tick()
 	var/atom/movable/AM = thrownthing
-	if (!isturf(AM.loc) || !AM.throwing)
+	if(!isturf(AM.loc) || !AM.throwing)
 		finalize()
 		return
 
@@ -135,17 +142,18 @@ SUBSYSTEM_DEF(throwing)
 		return
 
 	var/atom/movable/actual_target = initial_target?.resolve()
+	var/atom/thrower = get_thrower()
 
 	if(dist_travelled) //to catch sneaky things moving on our tile while we slept
 		for(var/atom/movable/obstacle as anything in get_turf(thrownthing))
-			if (obstacle == thrownthing || (obstacle == thrower && !ismob(thrownthing)))
+			if(obstacle == thrownthing || (obstacle == thrower && !ismob(thrownthing)))
 				continue
 			if(ismob(obstacle) && thrownthing.pass_flags & PASSMOB && (obstacle != actual_target))
 				continue
 			if(obstacle.pass_flags_self & LETPASSTHROW)
 				if(!(ismob(thrownthing) || ismobholder(thrownthing)) || !(obstacle.pass_flags_self & NOTLETPASSTHROWNMOB))
 					continue
-			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1) && !(obstacle in AM.buckled_mobs)))
+			if(obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1) && !(obstacle in AM.buckled_mobs) && !(AM in obstacle.buckled_mobs)))
 				finalize(TRUE, obstacle)
 				return
 
@@ -155,22 +163,22 @@ SUBSYSTEM_DEF(throwing)
 
 	//calculate how many tiles to move, making up for any missed ticks.
 	var/tilestomove = CEILING(min(((((world.time+world.tick_lag) - start_time + delayed_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed*MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait), 1)
-	while (tilestomove-- > 0)
-		if ((dist_travelled >= maxrange || AM.loc == target_turf))
+	while(tilestomove-- > 0)
+		if((dist_travelled >= maxrange || AM.loc == target_turf))
 			finalize()
 			return
 
-		if (dist_travelled <= max(dist_x, dist_y)) //if we haven't reached the target yet we home in on it, otherwise we use the initial direction
+		if(dist_travelled <= max(dist_x, dist_y)) //if we haven't reached the target yet we home in on it, otherwise we use the initial direction
 			step = get_step(AM, get_dir(AM, target_turf))
 		else
 			step = get_step(AM, init_dir)
 
-		if (!pure_diagonal && !diagonals_first) // not a purely diagonal trajectory and we don't want all diagonal moves to be done first
-			if (diagonal_error >= 0 && max(dist_x,dist_y) - dist_travelled != 1) //we do a step forward unless we're right before the target
+		if(!pure_diagonal && !diagonals_first) // not a purely diagonal trajectory and we don't want all diagonal moves to be done first
+			if(diagonal_error >= 0 && max(dist_x,dist_y) - dist_travelled != 1) //we do a step forward unless we're right before the target
 				step = get_step(AM, dx)
 			diagonal_error += (diagonal_error < 0) ? dist_x/2 : -dist_y
 
-		if (!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
+		if(!step) // going off the edge of the map makes get_step return null, don't let things go off the edge
 			finalize()
 			return
 
@@ -185,16 +193,19 @@ SUBSYSTEM_DEF(throwing)
 			finalize(TRUE, actual_target)
 			return
 
-		if (dist_travelled > MAX_THROWING_DIST)
+		if(dist_travelled > MAX_THROWING_DIST)
 			finalize()
 			return
 
 /datum/thrownthing/proc/finalize(hit = FALSE, target=null)
 	set waitfor = FALSE
+
 	//done throwing, either because it hit something or it finished moving
 	if(!thrownthing)
 		return
+
 	thrownthing.throwing = null
+
 	if(!hit)
 		for(var/atom/movable/obstacle as anything in get_turf(thrownthing)) //looking for our target on the turf we land on.
 			if(obstacle == target)
@@ -208,6 +219,7 @@ SUBSYSTEM_DEF(throwing)
 			var/turf/T = get_turf(thrownthing)
 			if(T?.zFall(thrownthing)) // throwing has been nulled so this works
 				var/atom/movable/actual_target = initial_target?.resolve()
+				var/atom/thrower = get_thrower()
 				for(var/atom/movable/obstacle as anything in get_turf(thrownthing))
 					if (obstacle == thrownthing || (obstacle == thrower && !ismob(thrownthing)))
 						continue

--- a/code/game/atom/atoms_movable.dm
+++ b/code/game/atom/atoms_movable.dm
@@ -1098,57 +1098,56 @@
 	if(QDELETED(src))
 		CRASH("Qdeleted thing being thrown around.")
 
-	if (!target || speed <= 0)
+	if(!target || speed <= 0)
 		return
 
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_THROW, args) & COMPONENT_CANCEL_THROW)
 		return
 
-	if (pulledby)
+	if(pulledby)
 		pulledby.stop_pulling()
 
 	//They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if (thrower && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag*2)
-		var/user_momentum = thrower.cached_multiplicative_slowdown
-		if (!user_momentum) //no movement_delay, this means they move once per byond tick, lets calculate from that instead.
-			user_momentum = world.tick_lag
+	if(ismob(thrower))
+		var/mob/thrower_mob = thrower
+		if(thrower_mob.last_move && thrower_mob.client && thrower_mob.client.move_delay >= world.time)
+			var/user_momentum = thrower_mob.cached_multiplicative_slowdown
+			if(!user_momentum) //no movement_delay, this means they move once per byond tick, lets calculate from that instead.
+				user_momentum = world.tick_lag
 
-		user_momentum = 1 / user_momentum // convert from ds to the tiles per ds that throw_at uses.
+			user_momentum = 1 / user_momentum // convert from ds to the tiles per ds that throw_at uses.
 
-		if (get_dir(thrower, target) & last_move)
-			user_momentum = user_momentum //basically a noop, but needed
-		else if (get_dir(target, thrower) & last_move)
-			user_momentum = -user_momentum //we are moving away from the target, lets slowdown the throw accordingly
-		else
-			user_momentum = 0
+			if(get_dir(thrower_mob, target) & last_move)
+				user_momentum = user_momentum //basically a noop, but needed
+			else if (get_dir(target, thrower_mob) & last_move)
+				user_momentum = -user_momentum //we are moving away from the target, lets slowdown the throw accordingly
+			else
+				user_momentum = 0
 
-
-		if (user_momentum)
-			//first lets add that momentum to range.
-			range *= (user_momentum / speed) + 1
-			//then lets add it to speed
-			speed += user_momentum
-			if (speed <= 0)
-				return//no throw speed, the user was moving too fast.
-
-	. = TRUE // No failure conditions past this point.
+			if(user_momentum)
+				//first lets add that momentum to range.
+				range *= (user_momentum / speed) + 1
+				//then lets add it to speed
+				speed += user_momentum
+				if(speed <= 0)
+					return//no throw speed, the user was moving too fast.
 
 	var/target_zone
 	if(QDELETED(thrower))
 		thrower = null //Let's not pass a qdeleting reference if any.
-	else
-		target_zone = thrower.zone_selected
+	else if(ismob(thrower))
+		var/mob/thrower_mob = thrower
+		target_zone = thrower_mob.zone_selected
 
-	var/datum/thrownthing/TT = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
+	var/datum/thrownthing/thrown_thing = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 	var/dx = (target.x > src.x) ? EAST : WEST
 	var/dy = (target.y > src.y) ? NORTH : SOUTH
 
-	if (dist_x == dist_y)
-		TT.pure_diagonal = 1
-
+	if(dist_x == dist_y)
+		thrown_thing.pure_diagonal = 1
 	else if(dist_x <= dist_y)
 		var/olddist_x = dist_x
 		var/olddx = dx
@@ -1156,31 +1155,39 @@
 		dist_y = olddist_x
 		dx = dy
 		dy = olddx
-	TT.dist_x = dist_x
-	TT.dist_y = dist_y
-	TT.dx = dx
-	TT.dy = dy
-	TT.diagonal_error = dist_x/2 - dist_y
-	TT.start_time = world.time
+
+	thrown_thing.dist_x = dist_x
+	thrown_thing.dist_y = dist_y
+	thrown_thing.dx = dx
+	thrown_thing.dy = dy
+	thrown_thing.diagonal_error = dist_x / 2 - dist_y
+	thrown_thing.start_time = world.time
 
 	if(pulledby)
 		pulledby.stop_pulling()
 
-	throwing = TT
+	throwing = thrown_thing
+
+	// Upwards throw
 	var/turf/curloc = get_turf(src)
-	if(TT.target_turf && curloc)
-		if(TT.target_turf.z > curloc.z)
+	if(thrown_thing.target_turf && curloc)
+		if(thrown_thing.target_turf.z > curloc.z)
 			var/turf/above = GET_TURF_ABOVE(curloc)
 			if(istype(above, /turf/open/openspace))
 				forceMove(above)
+
 	if(spin)
 		do_spin_animation(5, 1)
 
-	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW, TT, spin)
-	SSthrowing.processing[src] = TT
-	if (SSthrowing.state == SS_PAUSED && length(SSthrowing.currentrun))
-		SSthrowing.currentrun[src] = TT
-	TT.tick()
+	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW, thrown_thing, spin)
+
+	SSthrowing.processing[src] = thrown_thing
+	if(SSthrowing.state == SS_PAUSED && length(SSthrowing.currentrun))
+		SSthrowing.currentrun[src] = thrown_thing
+
+	thrown_thing.tick()
+
+	return TRUE
 
 /atom/movable/proc/handle_buckled_mob_movement(newloc, direction, glide_size_override)
 	for(var/mob/living/buckled_mob as anything in buckled_mobs)

--- a/code/game/objects/items/ropechainbola.dm
+++ b/code/game/objects/items/ropechainbola.dm
@@ -182,7 +182,8 @@
 /obj/item/rope/net/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
-	if(prob(100 * (throwingdatum?.GET_MOB_SKILL_VALUE_OLD(thrower, /datum/attribute/skill/craft/traps) || 1) / 3))
+	var/mob/thrower = throwingdatum.get_thrower()
+	if(prob(100 * (GET_MOB_SKILL_VALUE_OLD(thrower, /datum/attribute/skill/craft/traps) || 1) / 3))
 		ensnare(hit_atom)
 
 /obj/item/rope/net/proc/ensnare(mob/living/carbon/C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Jumping no longer sleeps on a while loop, much more responsive in general.
Jumping no longer messes with other animations.

General cleanup of throw_at and jumping code

Looking into #7214 seems like negative movement delay can break throwing datums.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
