### PR TITLE
Gatemaster Buff - Always winch instantly

### DIFF
--- a/code/__DEFINES/traits/definitions.dm
+++ b/code/__DEFINES/traits/definitions.dm
@@ -572,6 +572,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FACELESS "Faceless One"
 #define TRAIT_ROYALSERVANT "Household Insight" // Let's you see the royals liked/hated food/drink
 #define TRAIT_COURTAGENT "Agent of the Court"
+#define TRAIT_GATEKEEPER "Gatekeeper"
 
 ///every hearing sensitive atom has this trait
 #define TRAIT_HEARING_SENSITIVE "hearing_sensitive"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -349,8 +349,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_COIN_ILLITERATE = span_info("I care little for the concept of coins and prefer to barter via other means."),
 	TRAIT_LUCKY_COOK = span_info("Xylix smiles upon my cooking, I often end up with impossible amounts of extra goods..."),
 	TRAIT_ABOMINATION = span_info("I am an abomination, others will recognise me for what I am"),
-	TRAIT_COURTAGENT = span_info("I am an Agent of the Court, employed by the Hand. I am able to recognise my colleagues")
-	TRAIT_GATEKEEPER = span_info("I am a Gatekeeper, well practiced in the art of swiftly opening and sealing the gates, alongside levers and switches.")"
+	TRAIT_COURTAGENT = span_info("I am an Agent of the Court, employed by the Hand. I am able to recognise my colleagues"),
+	TRAIT_GATEKEEPER = span_info("I am well practiced in the art of swiftly opening and sealing the gates, alongside levers and switches.")
 ))
 
 /// value -> trait name, generated on use from trait_by_type global

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -209,6 +209,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"Graceless" = TRAIT_UNPARRYING,
 		"Agent of the Court" = TRAIT_COURTAGENT,
 		"Know Gallowband Secrets" = TRAIT_GALLOWBAND_SECRETS,
+		"Gatekeeper" = TRAIT_GATEKEEPER,
 	),
 	/obj/item/bodypart = list(
 		"TRAIT_PARALYSIS" = TRAIT_PARALYSIS
@@ -349,6 +350,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LUCKY_COOK = span_info("Xylix smiles upon my cooking, I often end up with impossible amounts of extra goods..."),
 	TRAIT_ABOMINATION = span_info("I am an abomination, others will recognise me for what I am"),
 	TRAIT_COURTAGENT = span_info("I am an Agent of the Court, employed by the Hand. I am able to recognise my colleagues")
+	TRAIT_GATEKEEPER = span_info("I am a Gatekeeper, well practiced in the art of swiftly opening and sealing the gates, alongside levers and switches.")"
 ))
 
 /// value -> trait name, generated on use from trait_by_type global

--- a/code/game/objects/structures/gate.dm
+++ b/code/game/objects/structures/gate.dm
@@ -197,8 +197,9 @@ GLOBAL_LIST_EMPTY(biggates)
 	var/mob/living/L = user
 	L.changeNext_move(CLICK_CD_MELEE)
 	var/used_time = 10.5 SECONDS - (GET_MOB_ATTRIBUTE_VALUE(L, STAT_STRENGTH) * 10)
-	if(!HAS_TRAIT, TRAIT_GATEKEEPER	(!do_after(user, used_time))
-		return
+	if (!HAS_TRAIT(user, TRAIT_GATEKEEPER))
+		if(!do_after(user, used_time))
+			return
 
 	COOLDOWN_START(src, winch_cooldown, 1.5 SECONDS)
 	for(var/obj/structure/structure in redstone_attached)

--- a/code/game/objects/structures/gate.dm
+++ b/code/game/objects/structures/gate.dm
@@ -197,7 +197,7 @@ GLOBAL_LIST_EMPTY(biggates)
 	var/mob/living/L = user
 	L.changeNext_move(CLICK_CD_MELEE)
 	var/used_time = 10.5 SECONDS - (GET_MOB_ATTRIBUTE_VALUE(L, STAT_STRENGTH) * 10)
-	if(!do_after(user, used_time))
+	if(!HAS_TRAIT, TRAIT_GATEKEEPER	(!do_after(user, used_time))
 		return
 
 	COOLDOWN_START(src, winch_cooldown, 1.5 SECONDS)

--- a/code/game/objects/structures/redstone.dm
+++ b/code/game/objects/structures/redstone.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	if(isliving(user))
 		var/mob/living/L = user
 		L.changeNext_move(CLICK_CD_MELEE)
-		var/used_time = pulltime - (GET_MOB_ATTRIBUTE_VALUE(L, STAT_STRENGTH) * 1 SECONDS)
+		var/used_time = HAS_TRAIT(user, TRAIT_GATEKEEPER) ? 0 : (GET_MOB_ATTRIBUTE_VALUE(L, STAT_STRENGTH) * 1 SECONDS)
 		user.visible_message("<span class='warning'>[user] pulls the lever.</span>")
 		user.log_message("pulled the lever with redstone id \"[redstone_id]\"", LOG_GAME)
 		if(do_after(user, used_time))

--- a/code/modules/jobs/job_types/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/garrison/gatemaster.dm
@@ -31,6 +31,7 @@
 
 	traits = list(
 		TRAIT_STEELHEARTED,
+		TRAIT_GATEKEEPER,
 	)
 	mind_traits = list(TRAIT_KNOWBANDITS)
 	verbs = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR adds a new trait to the gatemaster, simply known as Gatekeeper. It allows them to always instantly throw levers and pull winches

## Why It's Good For The Game

Old gatemasters can now actually open and close gates quickly

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Gatemasters now always instantly pull levers and winches, no matter their STR score
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
