### PR TITLE
Fix skeletons going deaf

### DIFF
--- a/code/modules/antagonists/villain/lich/spells/raise_undead.dm
+++ b/code/modules/antagonists/villain/lich/spells/raise_undead.dm
@@ -100,18 +100,6 @@
 	mob_biotypes = MOB_UNDEAD
 	faction = list(FACTION_UNDEAD)
 
-	skeletonize(FALSE)
-	fully_heal(HEAL_TRAUMAS)
-
-	skele_look()
-	grant_undead_eyes()
-
-	for(var/obj/item/organ/organ as anything in internal_organs)
-		organ.regenerate_organ()
-
-	if(length(quirks))
-		clear_quirks()
-
 	add_traits(list(TRAIT_NOMOOD, \
 		TRAIT_NOHUNGER, \
 		TRAIT_NOBREATH, \
@@ -129,6 +117,18 @@
 		TRAIT_NOAMBUSH, \
 		TRAIT_UNDODGING)
 		, SPECIES_TRAIT)
+
+	skeletonize(FALSE)
+	fully_heal(HEAL_TRAUMAS)
+
+	skele_look()
+	grant_undead_eyes()
+
+	for(var/obj/item/organ/organ as anything in internal_organs)
+		organ.regenerate_organ()
+
+	if(length(quirks))
+		clear_quirks()
 
 	update_body()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1418,6 +1418,7 @@
 	for(var/obj/item/bodypart/B in bodyparts)
 		B.skeletonize(lethal)
 	update_body_parts()
+	REMOVE_TRAIT(src, TRAIT_DEAF, NO_EARS)
 
 /// grant undead eyes to a carbon mob.
 /mob/living/carbon/proc/grant_undead_eyes()

--- a/code/modules/mob/living/carbon/human/npc/skeleton/_skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/_skeleton.dm
@@ -57,8 +57,6 @@
 		if(headdy)
 			headdy.icon = 'icons/roguetown/mob/monster/skeletons.dmi'
 			headdy.icon_state = "skull"
-	for(var/obj/item/bodypart/B as anything in bodyparts)
-		B.skeletonize(FALSE)
 	grant_undead_eyes()
 	update_body()
 	add_traits(list(TRAIT_NOMOOD, \
@@ -74,6 +72,7 @@
 		TRAIT_NO_ORGAN_PROCESS, \
 		TRAIT_NOBLOOD)
 		, SPECIES_TRAIT)
+	skeletonize(FALSE)
 	if(skel_outfit)
 		var/datum/outfit/OU = new skel_outfit
 		if(OU)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Skeletons don't have organ processing and can't fix deafness through processing. We'll just put the trait removal in skeletonize() instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A little snowflakey but should work hopefully.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
