### PR TITLE
Makes quarterstaves not suck

### DIFF
--- a/code/game/objects/items/weapons/melee/polearms.dm
+++ b/code/game/objects/items/weapons/melee/polearms.dm
@@ -46,7 +46,7 @@
 	desc = "The ultimate tool of travel for weary wanderers, support your weight or crack the heads that don't support you."
 	icon_state = "woodstaff"
 	force =  DAMAGE_STAFF
-	force_wielded =  DAMAGE_STAFF_WIELD - 1
+	force_wielded =  DAMAGE_STAFF_WIELD
 	wdefense = GREAT_PARRY
 	wlength = WLENGTH_LONG
 	possible_item_intents = list(POLEARM_BASH)
@@ -75,7 +75,7 @@
 	name = "wooden quarterstaff"
 	desc = "A staff that makes any journey easier. Durable and swift, capable of bludgeoning stray volves and ruffians alike."
 	icon_state = "quarterstaff"
-	force_wielded =  DAMAGE_STAFF_WIELD
+	force_wielded =  DAMAGE_STAFF_WIELD + 3
 	max_integrity = INTEGRITY_STRONG * 0.8
 	sellprice = 10
 	item_weight = 1.2 KILOGRAMS
@@ -85,6 +85,8 @@
 	name = "iron quarterstaff"
 	desc = "A perfect tool for bounty hunters who prefer their prisoners broken and bruised but not slain. This reinforced staff is capable of clubbing even an armed opponent into submission with some carefully placed strikes."
 	icon_state = "quarterstaff_iron"
+	force = DAMAGE_STAFF + 4
+	force_wielded = DAMAGE_STAFF_WIELD + 5
 	gripped_intents = list(POLEARM_BASH, MACE_SMASH)
 	max_integrity = INTEGRITY_STRONG
 	minstr = 7
@@ -97,7 +99,8 @@
 	name = "steel quarterstaff"
 	desc = "An unusual sight, a knightly combat staff made out of worked steel and reinforced wood. It is a heavy and powerful weapon, more than capable of beating the living daylights out of any brigand."
 	icon_state = "quarterstaff_steel"
-	force_wielded =  DAMAGE_STAFF_WIELD + 1
+	force = DAMAGE_STAFF + 6
+	force_wielded =  DAMAGE_STAFF_WIELD + 7
 	gripped_intents = list(POLEARM_BASH, MACE_SMASH)
 	max_integrity = INTEGRITY_STRONGEST
 	minstr = 7
@@ -110,7 +113,8 @@
 	name = "silver quarterstaff"
 	desc = "A quarterstaff with silver reinforcements, more effective against supernatural foes than a steel quarterstaff."
 	icon_state = "quarterstaff_silver"
-	force_wielded =  DAMAGE_STAFF_WIELD + 1
+	force = DAMAGE_STAFF + 6
+	force_wielded =  DAMAGE_STAFF_WIELD + 7
 	gripped_intents = list(POLEARM_BASH, MACE_SMASH)
 	max_integrity = INTEGRITY_STRONGEST * 0.8
 	minstr = 7
@@ -127,7 +131,7 @@
 	name = "staff of the rous seer"
 	desc = "A staff used by the rousman seers, mainly to protect themselves."
 	icon_state = "seerstaff"
-	force_wielded =  DAMAGE_STAFF_WIELD + 1
+	force_wielded =  DAMAGE_STAFF_WIELD + 3
 	sellprice = 100
 	item_weight = 1.2 KILOGRAMS
 
@@ -344,7 +348,7 @@
 
 /obj/item/weapon/polearm/spear/javelin
 	name = "copper javelin"
-	desc = "Made for throwing, long out of favor and using inferior metals, it still can kill when the aim is true."
+	desc = "Made for throwing, long out of favor and using inferior metals, it can still kill when your aim is true."
 	icon_state = "cspear"
 	force = DAMAGE_SPEAR - 2
 	force_wielded = DAMAGE_SPEAR + 2
@@ -390,7 +394,7 @@
 
 /obj/item/weapon/polearm/spear/javelin/steel
 	name = "steel javelin"
-	desc = "A sturdy javelin made from steel, suitable to hunt knightly foes."
+	desc = "A sturdy javelin made from steel, suitable for hunting knightly foes."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "javelin"
 	melting_material = /datum/material/steel
@@ -406,7 +410,7 @@
 
 /obj/item/weapon/polearm/spear/javelin/silver
 	name = "silver javelin"
-	desc = "A sturdy javelin made from silver, suitable to hunt supernatural foes."
+	desc = "A sturdy javelin made from silver, suitable for hunting supernatural foes."
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "sjavelin"
 	gripsprite = FALSE
@@ -426,7 +430,7 @@
 
 /obj/item/weapon/polearm/spear/bone
 	name = "bone javelin"
-	desc = "Made by the tribes of the wilds for hunting, this spear has will eventually kill your prey, if aim remains true."
+	desc = "Made by the tribes of the wilds for hunting, this spear will eventually kill your prey, if your aim remains true."
 	icon_state = "bspear"
 	throwforce = DAMAGE_SPEAR_WIELD
 	max_blade_int = 60
@@ -453,7 +457,7 @@
 
 /obj/item/weapon/polearm/spear/trollbone
 	name = "troll-horn bone javelin"
-	desc = "Made by the tribes of the wilds for hunting, and strengthed with a troll's horn, this spear has will outlast your prey, if aim remains true."
+	desc = "Made by the tribes of the wilds for hunting, and strengthened with a troll's horn, this spear will outlast your prey, if your aim remains true."
 	icon_state = "bspear"
 	throwforce = DAMAGE_SPEAR_WIELD
 	max_blade_int = 60


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR increases the damage modifiers of the different quarterstaves (NOT the base DAMAGE_STAFF values). 
## Why It's Good For The Game
Currently there's little reason to use a quarterstaff in place of a more popular weapon due to their piss poor damage (These things barely do more damage than a knife!). 
This PR seeks to give staves a fighting chance without elevating them to the level of a longsword or mace.

Have you ever seen what even a wooden quarterstaff can do?
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Made quarterstaves usable
balance: Buffed quarterstaves
spellcheck: fixed grammar in a few javelin descs.
/:cl:


## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
