### PR TITLE
Food and Hunger - Cut by half

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -134,7 +134,7 @@
 	var/say_mod = "says"
 
 	/// Multipler for how quickly nutrition decreases
-	var/nutrition_mod = 1
+	var/nutrition_mod = 0.5
 	/// Multiplier for how quickly hygiene decreases
 	var/hygiene_mod = 1
 	/// Multipler for blood loss

--- a/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
@@ -123,7 +123,7 @@
 		ORGAN_SLOT_GUTS = /obj/item/organ/guts,
 	)
 
-	nutrition_mod = 2 // 200% higher hunger rate. Hungry, hungry horcs
+	nutrition_mod = 1 // 200% higher hunger rate. Hungry, hungry horcs
 	hygiene_mod = 1.5
 
 /datum/species/halforc/check_roundstart_eligible()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Cuts hunger by 50% for all species across the board.  Half-orcs now just get the existing hunger rates that humens have now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Changes to the fabric of time and space have caused hunger to tick faster, so this is a quick solution to bring it in-line hopefully.  I could not test it beyond just making sure it didn't runtime, so I can't guarantee this will even work if the nutrition_modifier variable is broken.  It will require a test merge and feedback.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Hunger rates reduced by 50 percent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
