### PR TITLE
More Gorgets

### DIFF
--- a/code/modules/jobs/job_types/church/gmtemplar.dm
+++ b/code/modules/jobs/job_types/church/gmtemplar.dm
@@ -102,7 +102,7 @@
 
 /datum/outfit/gmtemplar
 	name = JOB_GRANDMASTER_TEMPLAR
-	neck = /obj/item/clothing/neck/chaincoif
+	neck = /obj/item/clothing/neck/gorget
 	armor = /obj/item/clothing/armor/plate/full/silver
 	shirt = /obj/item/clothing/armor/chainmail
 	pants = /obj/item/clothing/pants/platelegs/silver

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -132,7 +132,7 @@
 
 /datum/outfit/royalknight
 	name = "Royal Knight Base"
-	neck = /obj/item/clothing/neck/chaincoif
+	neck = /obj/item/clothing/neck/gorget
 	pants = /obj/item/clothing/pants/platelegs
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard
 	shirt = /obj/item/clothing/armor/gambeson/arming

--- a/code/modules/jobs/job_types/inquistion/inquisitor_classes/templar.dm
+++ b/code/modules/jobs/job_types/inquistion/inquisitor_classes/templar.dm
@@ -89,7 +89,7 @@
 	cloak = /obj/item/clothing/cloak/psydontabard
 	backr = /obj/item/weapon/shield/tower/metal
 	gloves = /obj/item/clothing/gloves/chain/psydon
-	neck = /obj/item/clothing/neck/chaincoif
+	neck = /obj/item/clothing/neck/gorget
 	pants = /obj/item/clothing/pants/chainlegs
 	backl = /obj/item/storage/backpack/satchel/grenzel
 	shirt = /obj/item/clothing/armor/gambeson/heavy/inq


### PR DESCRIPTION
## About The Pull Request

Replaces the chain coifs of the Grandmaster Templar, Royal Knights, and Sacrestant Templars with gorgets.

## Why It's Good For The Game

Coifs hide a character's hair, essentially axing one of the most visible character features. Characters with gorgets, unlike characters with coifs, can also remove their helmet in appropriate situations (such as sitting down to chat with a friend in a safe area) and not look stupid.

## Changelog

:cl:
del: removed chain coifs from GMT, RK, and Templar Sacrestant
add: added gorgets to GMT, RK, and Templar Sacrestant
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.