### PR TITLE
Replaces Gorefeast from Malum's Anvil with a Vicious Axe

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin_mountain.dmm
+++ b/_maps/map_files/vanderlin/vanderlin_mountain.dmm
@@ -2120,12 +2120,6 @@
 	},
 /turf/open/floor/concrete,
 /area/under/mountains/anvil/lower)
-"aki" = (
-/obj/item/weapon/polearm/halberd/bardiche/woodcutter/gorefeast{
-	pixel_y = 0
-	},
-/turf/open/floor/naturalstone,
-/area/under/mountains/anvil/lower)
 "akk" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "vanderlin-forest_mountain-forest";
@@ -14235,6 +14229,7 @@
 /obj/effect/decal/cleanable/ritual_rune/arcyne/empowerment{
 	pixel_y = -47
 	},
+/obj/item/weapon/greataxe/steel/doublehead/graggar,
 /turf/open/floor/naturalstone,
 /area/under/mountains/anvil/lower)
 "uuP" = (
@@ -36955,7 +36950,7 @@ aEY
 aJv
 aJv
 uum
-aki
+aJv
 aJv
 aJv
 aEY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gorefeast is no longer on Malum's Anvil. Long live. The Vicious Axe will take its place.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This has been requested enough times, and Gorefeast itself is stronger than the other two weapons represented in the Anvil. This should turn down the temperature a bit.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: Replaces the Gorefeast spawn in Malum's Anvil with a Vicious Axe instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
