### PR TITLE
Adds Golden Psycross to Loadout.

### DIFF
--- a/code/datums/loadouts/neck_loadout_items.dm
+++ b/code/datums/loadouts/neck_loadout_items.dm
@@ -103,6 +103,13 @@
 
 	triumph_cost_permanent = 5
 
+/datum/loadout_item/psydon_cross_gold
+	name = "Golden Psycross"
+	item_path = /obj/item/clothing/neck/psycross/gold
+	ui_category = "Neck"
+
+	triumph_cost_permanent = 150
+
 /datum/loadout_item/psydon_cross
 	name = "Silver Psycross"
 	item_path = /obj/item/clothing/neck/psycross/silver


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

For Xander on the DIscord, adds the Golden Psycross to the Loadout for 150 Triumphs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a neat cosmetic item that's used ingame and doesn't have any real mechanical benefit over the other amulets.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Golden Psycrosses can be bought in the Loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
