### PR TITLE
Small climbing tweak for harpies

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
@@ -5,7 +5,8 @@
 
 /datum/attribute_holder/sheet/job/species/harpy
 	raw_attribute_list = list(
-		/datum/attribute/skill/misc/music = 10
+		/datum/attribute/skill/misc/music = 10,
+		/datum/attribute/skill/misc/climbing = 5 
 	)
 
 /datum/attribute_holder/sheet/job/species/harpy/stats


### PR DESCRIPTION
## About The Pull Request

Climbing governing stat is STR, so due extremely low STR, on classes with 50 climbing skill, harpies will be unable to jump down if they are a little hungry or have any other STR debuff.

My PR gives them a slight climbing buff (just 5 points), that will compensate their low governing STR stat.

## Why It's Good For The Game

It will make a life of harpies a little easier and will let them play sneaky/cunning roles without suffering.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: harpies now have +5 climbing skill bonus to compensate their low STR that is governing for that skill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
