### PR TITLE
Fixes Decompose and Raise Undead Spells

### DIFF
--- a/code/modules/antagonists/villain/lich/spells/raise_undead.dm
+++ b/code/modules/antagonists/villain/lich/spells/raise_undead.dm
@@ -33,10 +33,11 @@
 	conjured_mobs -= summoned
 
 /datum/action/cooldown/spell/raise_undead/proc/register_minion(mob/living/minion, mob/living/user)
-	var/mob/living/last = conjured_mobs[length(conjured_mobs)]
-	if(!QDELETED(last))
-		qdel(last)
-	conjured_mobs.len--
+	if(length(conjured_mobs))
+		var/mob/living/last = conjured_mobs[length(conjured_mobs)]
+		if(!QDELETED(last))
+			qdel(last)
+		conjured_mobs.len--
 
 	conjured_mobs += minion
 	RegisterSignal(minion, COMSIG_QDELETING, PROC_REF(remove_conjure))
@@ -110,8 +111,9 @@
 	clamped_adjust_skill_level(/datum/attribute/skill/combat/unarmed, 10, 30, TRUE)
 	clamped_adjust_skill_level(/datum/attribute/skill/combat/swords, 20, 30, TRUE)
 
-	mind.current.job = null
-	mind.add_antag_datum(/datum/antagonist/skeleton)
+	if(mind)
+		mind.current.job = null
+		mind.add_antag_datum(/datum/antagonist/skeleton)
 
 	dna.species.soundpack_m = new /datum/voicepack/skeleton()
 	dna.species.soundpack_f = new /datum/voicepack/skeleton()

--- a/code/modules/antagonists/villain/zomble.dm
+++ b/code/modules/antagonists/villain/zomble.dm
@@ -183,7 +183,8 @@
 	zombie.mob_biotypes |= MOB_UNDEAD
 	zombie.add_faction(FACTION_UNDEAD)
 	zombie.remove_faction(list(FACTION_TOWN, FACTION_NEUTRAL))
-	zombie.mind.special_role = name
+	if(zombie.mind)
+		zombie.mind.special_role = name
 
 	zombie.base_intents = list(INTENT_DISARM, INTENT_GRAB, INTENT_HARM, /datum/intent/unarmed/claw)
 	zombie.update_a_intents()

--- a/code/modules/spells/spell_types/pointed/decompose.dm
+++ b/code/modules/spells/spell_types/pointed/decompose.dm
@@ -25,7 +25,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	return isitem(cast_on) || isliving(target)
+	return isitem(cast_on) || isliving(cast_on)
 
 /datum/action/cooldown/spell/decompose/cast(atom/cast_on)
 	. = ..()
@@ -50,4 +50,8 @@
 		injury.adjust_germ_level(250)
 
 	if(target.stat == DEAD)
-		target.zombie_check() //why is this called zombie check when it makes you a zombie...
+		var/datum/antagonist/zombie/zombie_datum = target.zombie_check()
+		if(!zombie_datum)
+			zombie_datum = new /datum/antagonist/zombie()
+		zombie_datum.transform_zombie(target)
+		zombie_datum.wake_zombie(target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Decompose and raise undead didn't work on NPCs.
According to the description of decompose, it's supposed to not only decompose objects, but also raise humanoid corpses as deadites. Right now, it doesn't raise corpses due to an incorrect identifer (among some other things), so this PR makes it do that, and turns them into a zombie.
Raise Undead, didn't work due to fault in the follower limit causing the proc to turn the corpse into a minion runtiming (once again, among other things). Restoring normal functionality, the spell now raises a corpse as a skeleton, which can be possessed by a player or just becomes an NPC. Only one can exist per player at a time, and raising a new one instantly destroys the previous one.

## Why It's Good For The Game
This was intended functionality. It's generally a good thing for a school of magic to have its spells work.

## Changelog
:cl: Karl Johansson
fix: Decompose and Raise Undead are functioning spells again.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
