### PR TITLE
Reduces the firing delay of powder-based weapons

### DIFF
--- a/code/modules/projectiles/guns/ballistic/_powder.dm
+++ b/code/modules/projectiles/guns/ballistic/_powder.dm
@@ -46,7 +46,7 @@
 	/// Ideally a mulitple of 5 so you can actually hit it with containers
 	var/powder_required = 5
 	/// Delay before firing after pulling trigger (Find a way to move this up and not sleep)
-	var/trigger_delay = 0.5 SECONDS
+	var/trigger_delay = 0.2 SECONDS
 	// Currently there is no "matchlock" or similar weapons, change this var if that happens
 	/// If the striker is cocked into the firing position
 	var/cocked = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Roughly halves the firing delay applied to powder-based weapons (puffer, musket, blunderbuss, etc).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current firing delay is very oppressive. The reason this hasn't been complained about more is likely because powder based weaponry are rarely used - despite the constant complaints about how powerful they are and how "necessary" the firing delay is, but fact is it's turned an 800-1000 mammon value gun into something rather worthless, as you will only be able to actually hit someone with it if you no-esc them. I've never been able to shoot someone with the puffer because the firing delay gives them too much time to dodge. 

Truthfully, I personally think there shouldn't be any firing delay at all. The downsides of these weapons are already prominent - expensive/costly to maintain with blastpowder, lead bullets are a pain in the ass to store (unlike arrows or bolts in quivers), they take ages to reload - ontop of this someone wanted them to be nigh impossible to hit anyone with? No, that doesn't quite seem fair. However, a reduction is probably a good compromise for now to stop people screaming.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Lowered the firing delay of powder weapons from 0.5 to 0.2 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
