### PR TITLE
Heir & Garrison Issues

### DIFF
--- a/code/modules/jobs/job_types/apprentices/prince.dm
+++ b/code/modules/jobs/job_types/apprentices/prince.dm
@@ -47,6 +47,10 @@
 		TRAIT_NOBLE_POWER
 	)
 
+/datum/outfit/heir
+	name = "Prince Base"
+	neck = /obj/item/key/heir
+
 /datum/job/prince/after_spawn(mob/living/carbon/human/spawned, client/player_client)
 	. = ..()
 	addtimer(CALLBACK(SSfamilytree, TYPE_PROC_REF(/datum/controller/subsystem/familytree, AddRoyal), spawned, FAMILY_PROGENY), 10 SECONDS)
@@ -102,8 +106,7 @@
 	shoes = /obj/item/clothing/shoes/nobleboot
 	belt = /obj/item/storage/belt/leather
 	beltl = /obj/item/weapon/sword
-	beltr = /obj/item/key/heir
-	neck = /obj/item/storage/belt/pouch/coins/rich
+	beltr = /obj/item/storage/belt/pouch/coins/rich
 	backr = /obj/item/storage/backpack/satchel
 
 /datum/attribute_holder/sheet/job/heir/aristocrat
@@ -148,7 +151,6 @@
 /datum/outfit/heir/aristocrat
 	name = "Sheltered Aristocrat (Prince)"
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/key/heir
 	beltr = /obj/item/storage/belt/pouch/coins/rich
 
 /datum/outfit/heir/aristocrat/pre_equip(mob/living/carbon/human/equipped_human, visuals_only)
@@ -208,7 +210,6 @@
 /datum/outfit/heir/inbred
 	name = "Inbred Wastrel (Prince)"
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/key/heir
 	beltr = /obj/item/storage/belt/pouch/coins/rich
 
 /datum/outfit/heir/inbred/pre_equip(mob/living/carbon/human/equipped_human, visuals_only)

--- a/code/modules/jobs/job_types/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/apprentices/squire.dm
@@ -42,12 +42,6 @@
 	shoes = /obj/item/clothing/shoes/boots/darkboots
 	belt = /obj/item/storage/belt/leather
 	beltl = /obj/item/storage/keyring/manorguard
-	backr = /obj/item/storage/backpack/satchel
-	backpack_contents = list(
-		/obj/item/storage/belt/pouch/coins/poor = 1,
-		/obj/item/clothing/neck/chaincoif = 1,
-		/obj/item/weapon/hammer/iron = 1
-	)
 
 /datum/job/advclass/squire
 	allowed_ages = list(AGE_CHILD, AGE_ADULT)
@@ -119,6 +113,12 @@
 	name = "Pikeman Squire"
 	r_hand = /obj/item/weapon/polearm/spear
 	cloak = /obj/item/clothing/cloak/stabard/guard
+	backr = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/storage/belt/pouch/coins/poor = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/weapon/hammer/iron = 1
+	)
 
 /datum/attribute_holder/sheet/job/squire/footman
 	raw_attribute_list = list(
@@ -180,6 +180,12 @@
 	name = "Footman Squire"
 	beltr = /obj/item/weapon/sword
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard
+	backr = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/storage/belt/pouch/coins/poor = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/weapon/hammer/iron = 1
+	)
 
 /datum/attribute_holder/sheet/job/squire/skirmisher
 	raw_attribute_list = list(
@@ -243,8 +249,14 @@
 /datum/outfit/squire/skirmisher
 	name = "Bowman Squire"
 	beltr = /obj/item/ammo_holder/quiver/arrows
-	backl = /obj/item/gun/ballistic/bow/short
 	cloak = /obj/item/clothing/cloak/stabard/jupon/guard
+	backl = /obj/item/gun/ballistic/bow/short
+	backr = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/storage/belt/pouch/coins/poor = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/weapon/hammer/iron = 1
+	)
 
 /datum/outfit/squire/skirmisher/pre_equip(mob/living/carbon/human/equipped_human, visuals_only)
 	. = ..()

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -42,7 +42,6 @@
 /datum/outfit/watchman
 	name = "Men-at-arms Base"
 	cloak = /obj/item/clothing/cloak/stabard/guard
-	shirt = /obj/item/clothing/shirt/tunic/colored/tunicprimary
 	neck = /obj/item/clothing/neck/bevor
 	gloves = /obj/item/clothing/gloves/leather/advanced
 	wrists = /obj/item/clothing/wrists/bracers/leather
@@ -50,9 +49,7 @@
 	shoes = /obj/item/clothing/shoes/boots/leather/advanced/watch
 	belt = /obj/item/storage/belt/leather
 	beltl = /obj/item/storage/keyring/manorguard
-	backpack_contents = list(
-		/obj/item/weapon/knife/dagger/steel/special = 1
-	)
+
 /datum/job/men_at_arms/on_roundstart(mob/living/spawned, client/player_client)
 	. = ..()
 
@@ -115,9 +112,13 @@
 /datum/outfit/watchman/pikeman
 	name = "Pikeman Men-At-Arms"
 	armor = /obj/item/clothing/armor/chainmail/hauberk
+	shirt = /obj/item/clothing/shirt/tunic/colored/tunicprimary
 	beltr = /obj/item/weapon/sword/arming
 	backr = /obj/item/weapon/polearm/spear/billhook
 	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/knife/dagger/steel/special = 1
+	)
 	scabbards = list(/obj/item/weapon/scabbard/sword)
 
 /datum/attribute_holder/sheet/job/menatarms/axeman
@@ -162,6 +163,9 @@
 	shirt = /obj/item/clothing/armor/gambeson/heavy
 	gloves = /obj/item/clothing/gloves/chain
 	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/knife/dagger/steel/special = 1
+	)
 	backr = /obj/item/weapon/greataxe/steel
 
 /datum/attribute_holder/sheet/job/menatarms/ranger
@@ -200,7 +204,12 @@
 /datum/outfit/watchman/ranger
 	name = "Archer Men-At-Arms"
 	armor = /obj/item/clothing/armor/leather/splint
+	shirt = /obj/item/clothing/shirt/tunic/colored/tunicprimary
 	beltr = /obj/item/weapon/mace/cudgel
+	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/knife/dagger/steel/special = 1
+	)
 
 /datum/job/advclass/menatarms/watchman_ranger/on_roundstart(mob/living/carbon/human/equipped_human, client/player_client)
 	. = ..()
@@ -251,7 +260,11 @@
 /datum/outfit/watchman/swordsman
 	name = "Swordsman Men-At-Arms"
 	armor = /obj/item/clothing/armor/chainmail/hauberk
+	shirt = /obj/item/clothing/shirt/tunic/colored/tunicprimary
 	beltr = /obj/item/weapon/sword/arming
 	backr = /obj/item/weapon/shield/heater
 	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/knife/dagger/steel/special = 1
+	)
 	scabbards = list(/obj/item/weapon/scabbard/sword)

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -142,9 +142,12 @@
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard
 	shirt = /obj/item/clothing/armor/gambeson/arming
 	wrists = /obj/item/storage/keyring/manorguard
+	backl = /obj/item/storage/backpack/satchel
+	backpack_contents = list(
+		/obj/item/weapon/knife/dagger/steel/special = 1
+	)
 	belt = /obj/item/storage/belt/leather/steel
 	beltr = /obj/item/weapon/sword/arming
-	backl = /obj/item/storage/backpack/satchel
 	scabbards = list(/obj/item/weapon/scabbard/sword/noble)
 
 /datum/outfit/royalknight/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)


### PR DESCRIPTION
## About The Pull Request

With this PR I attempted to do the following:

- Adds the Heir key to the Prince base outfit to let Triumph classes still have access.
- Attempts to fix Squire equipment duplication in the bag.
- Removes the second MAA dagger and adds Axeman gambeson back which is absent due to a bug.
- Gives Royal Knight a dagger as they were lacking a short backup weapon.

Will it work? No idea. I didn't actually test anything. Did I just make files longer? Yup. Is it safe to test merge? Probably.

## Why It's Good For The Game

Should fix bugs and eliminate an annoying mechanic, see above.

## Changelog

:cl:
qol: Keys for Triumph-class Heirs
balance: Gave the Royal Knight a dagger
fix: Duplicate equipment from MAA & Squire gone
fix: Axeman-At-Arms has their gambeson
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
